### PR TITLE
Interpolation copy fields

### DIFF
--- a/features/eolearn/features/interpolation.py
+++ b/features/eolearn/features/interpolation.py
@@ -103,7 +103,8 @@ class InterpolationTask(EOTask):
         :rtype: numpy.array
         """
         seen = set()
-        duplicated_indices = np.array([idx for idx, item in enumerate(times) if item in seen or seen.add(item)])
+        duplicated_indices = np.array([idx for idx, item in enumerate(times) if item in seen or seen.add(item)],
+                                      dtype=int)
         duplicated_times = np.unique(times[duplicated_indices])
 
         for time in duplicated_times:

--- a/features/eolearn/tests/test_interpolation.py
+++ b/features/eolearn/tests/test_interpolation.py
@@ -50,6 +50,12 @@ class TestInterpolation(unittest.TestCase):
                                       result_len=68, img_min=0.0, img_max=10.0, img_mean=0.720405,
                                       img_median=0.59765935),
 
+            cls.InterpolationTestCase('linear_change_timescale', LinearInterpolation('NDVI', result_interval=(0.0, 1.0),
+                                                                    mask_feature=(FeatureType.MASK, 'IS_VALID'),
+                                                                    unknown_value=10, scale_time=1),
+                                      result_len=68, img_min=0.0, img_max=10.0, img_mean=0.720405,
+                                      img_median=0.59765935),
+
             cls.InterpolationTestCase('cubic', CubicInterpolation('NDVI', result_interval=(0.0, 1.0),
                                                                   mask_feature=(FeatureType.MASK, 'IS_VALID'),
                                                                   resample_range=('2015-01-01', '2018-01-01', 16),

--- a/features/eolearn/tests/test_interpolation.py
+++ b/features/eolearn/tests/test_interpolation.py
@@ -50,9 +50,10 @@ class TestInterpolation(unittest.TestCase):
                                       result_len=68, img_min=0.0, img_max=10.0, img_mean=0.720405,
                                       img_median=0.59765935),
 
-            cls.InterpolationTestCase('linear_change_timescale', LinearInterpolation('NDVI', result_interval=(0.0, 1.0),
-                                                                    mask_feature=(FeatureType.MASK, 'IS_VALID'),
-                                                                    unknown_value=10, scale_time=1),
+            cls.InterpolationTestCase('linear_change_timescale',
+                                      LinearInterpolation('NDVI', result_interval=(0.0, 1.0),
+                                                          mask_feature=(FeatureType.MASK, 'IS_VALID'),
+                                                          unknown_value=10, scale_time=1),
                                       result_len=68, img_min=0.0, img_max=10.0, img_mean=0.720405,
                                       img_median=0.59765935),
 

--- a/features/eolearn/tests/test_interpolation.py
+++ b/features/eolearn/tests/test_interpolation.py
@@ -111,8 +111,45 @@ class TestInterpolation(unittest.TestCase):
 
         ]
 
+        cls.copy_feature_cases = [
+            cls.InterpolationTestCase('cubic_copy_success',
+                                      CubicInterpolation('NDVI', result_interval=(0.0, 1.0),
+                                                         mask_feature=(
+                                                             FeatureType.MASK, 'IS_VALID'),
+                                                         resample_range=(
+                                                             '2015-01-01', '2018-01-01', 16),
+                                                         unknown_value=5, bounds_error=False,
+                                                         copy_features=[
+                                                             (FeatureType.MASK, 'IS_VALID'),
+                                                             (FeatureType.DATA, 'NDVI', 'NDVI_OLD'),
+                                                             (FeatureType.MASK_TIMELESS, 'LULC'),
+                                                         ]),
+                                      result_len=69, img_min=0.0, img_max=5.0, img_mean=1.3592644,
+                                      img_median=0.6174331),
+
+            cls.InterpolationTestCase('cubic_copy_fail',
+                                      CubicInterpolation('NDVI', result_interval=(0.0, 1.0),
+                                                         mask_feature=(FeatureType.MASK, 'IS_VALID'),
+                                                         resample_range=(
+                                                             '2015-01-01', '2018-01-01', 16),
+                                                         unknown_value=5, bounds_error=False,
+                                                         copy_features=[
+                                                             (FeatureType.MASK, 'IS_VALID'),
+                                                             (FeatureType.DATA, 'NDVI'),
+                                                             (FeatureType.MASK_TIMELESS, 'LULC'),
+                                                         ]),
+                                      result_len=69, img_min=0.0, img_max=5.0, img_mean=1.3592644,
+                                      img_median=0.6174331),
+        ]
+
         for test_case in cls.test_cases:
             test_case.execute()
+
+        for test_case in cls.copy_feature_cases:
+            try:
+                test_case.execute()
+            except ValueError:
+                pass
 
     def test_output_type(self):
         for test_case in self.test_cases:
@@ -153,6 +190,21 @@ class TestInterpolation(unittest.TestCase):
                     self.assertAlmostEqual(test_case.img_median, median_val, delta=delta,
                                            msg="Expected median {}, got {}".format(test_case.img_median,
                                                                                    median_val))
+
+    def test2(self):
+        for test_case in self.copy_feature_cases:
+            with self.subTest(msg='Test case {}'.format(test_case.name)):
+                if test_case.result is not None:
+                    copied_features = [
+                        (FeatureType.MASK, 'IS_VALID'),
+                        (FeatureType.DATA, 'NDVI_OLD'),
+                        (FeatureType.MASK_TIMELESS, 'LULC')
+                    ]
+                    for feature in copied_features:
+                        self.assertTrue(feature in test_case.result.get_feature_list(),
+                                        msg="Expected feature {} is not present in EOPatch".format(feature))
+
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added extension of the interpolation task. 

If resampling is used in temporal interpolation, a new `EOPatch` is created with only the interpolated feature provided. One then had to create an additional task for copying features from the old patch to the new one. This also makes the dependency graph non-linear. 

In this PR, a new option is added to the interpolation task, where one can provide a list of features to be copied over from the version of the `EOPatch` before the interpolation was performed. This then also makes it possible to be used with the `LinearWorkflow` in `eolearn`.