### PR TITLE
Squeeze first dimension of feature_data if len=1

### DIFF
--- a/features/eolearn/features/interpolation.py
+++ b/features/eolearn/features/interpolation.py
@@ -292,6 +292,8 @@ class InterpolationTask(EOTask):
         # Prepare mask of valid data
         if self.mask_feature:
             mask_type, mask_name = next(self.mask_feature(eopatch))
+            if feature_data.shape[0] == 1:
+                feature_data = np.squeeze(feature_data,axis=0)
             feature_data[~eopatch[mask_type][mask_name].squeeze(), :] = np.nan
 
         # Flatten array


### PR DESCRIPTION
Some eopatches fail the interpolation when their first dimension is of length 1, because they no longer match the dimensions of the mask. This happens when the interpolated eopatch contains masks which do not match the FEATURES or BANDS in first dimension (time) length.

In the following example, this patch could not be interpolated before the script change:

`EOPatch(
  data: {
    FEATURES: <class 'numpy.ndarray'>, shape=(10, 1339, 1368, 9), dtype=float32
  }
  mask: {
    IS_VALID: <class 'numpy.ndarray'>, shape=(1, 1339, 1368, 1), dtype=bool
  }
  scalar: {}
  label: {}
  vector: {}
  data_timeless: {
    PRED: <class 'numpy.ndarray'>, shape=(1339, 1368, 1), dtype=uint8
  }
  mask_timeless: {}
  scalar_timeless: {}
  label_timeless: {}
  vector_timeless: {}
  meta_info: {}
  bbox: BBox(((486812.800062168, 2789900.2618496483), (500487.89285265905, 2803295.097495106)), crs=EPSG:32639)
  timestamp: <class 'list'>, length=10
)
`
