### PR TITLE
Windows interpolation fix

### DIFF
--- a/features/eolearn/features/interpolation.py
+++ b/features/eolearn/features/interpolation.py
@@ -244,9 +244,9 @@ class InterpolationTask(EOTask):
         # define time values as linear monotonically increasing over the observations
         const = int(self.filling_factor * (np.max(times) - np.min(times)))
         temp_values = (times[:, np.newaxis] +
-                       const * np.arange(nobs)[np.newaxis, :]).astype(np.float64)
+                       const * np.arange(nobs)[np.newaxis, :].astype(np.float64))
         res_temp_values = (resampled_times[:, np.newaxis] +
-                           const * np.arange(nobs)[np.newaxis, :]).astype(np.float64)
+                           const * np.arange(nobs)[np.newaxis, :].astype(np.float64))
 
         # initialise array of interpolated values
         new_data = np.full((len(resampled_times), nobs), np.nan, dtype=data.dtype)


### PR DESCRIPTION
Fixing the casting problem which results in interpolation problems on Windows machines. Rather simple fix. The problem was that the casting to float64 happened after the problem occurs on Windows, where the array overflows as int32, while on Linux/Unix it gets upcast automatically.

Perhaps some checks could be added to prevent if this occurs again in the future?