### PR TITLE
bug-fix: loop over a list of Dependecy objects instead of tuples.

### DIFF
--- a/core/eolearn/core/eoworkflow.py
+++ b/core/eolearn/core/eoworkflow.py
@@ -62,7 +62,7 @@ class EOWorkflow:
         :rtype: list(Dependency)
         """
         parsed_dependencies = [dep if isinstance(dep, Dependency) else Dependency(*dep) for dep in dependencies]
-        for dep in dependencies:
+        for dep in parsed_dependencies:
             if task_names and dep.task in task_names:
                 dep.set_name(task_names[dep.task])
         return parsed_dependencies


### PR DESCRIPTION
Naming EOTasks in EOWorkflow fails due to a bug in `_parse_dependencies` method. The loop has to be over parsed dependencies (`Dependency` objects and not tuples).