### PR TITLE
Bug/self abuse and other stuff

### DIFF
--- a/features/eolearn/features/radiometric_normalization.py
+++ b/features/eolearn/features/radiometric_normalization.py
@@ -39,11 +39,11 @@ class ReferenceScenes(EOTask):
         valid_frac = list(eopatch[valid_fraction_feature_type][valid_fraction_feature_name].flatten())
         data = eopatch[feature_type][feature_name]
 
-        self.number = data.shape[0] if self.number is None else self.number
+        number = data.shape[0] if self.number is None else self.number
 
         eopatch[feature_type][new_feature_name] = np.array([data[x] for _, x in
                                                             sorted(zip(valid_frac, range(data.shape[0])), reverse=True)
-                                                            if x <= self.number-1])
+                                                            if x <= number-1])
 
         return eopatch
 

--- a/geometry/eolearn/geometry/utilities.py
+++ b/geometry/eolearn/geometry/utilities.py
@@ -45,12 +45,18 @@ class ErosionTask(EOTask):
             return eopatch
 
         labels = eopatch[self.mask_type][self.mask_name].squeeze().copy()
-        erode_labels = np.unique(labels) if self.erode_labels is None else self.erode_labels
+
+        patch_labels = np.unique(labels)
+        erode_labels = patch_labels if self.erode_labels is None else self.erode_labels
 
         mask_values = np.zeros(labels.shape, dtype=np.bool)
-        for label in erode_labels:
+        for label in patch_labels:
+            if label == self.no_data_label:
+                continue
+
             label_mask = (labels == label)
-            label_mask = skimage.morphology.binary_erosion(label_mask, skimage.morphology.disk(self.disk_radius))
+            if label in erode_labels:
+                label_mask = skimage.morphology.binary_erosion(label_mask, skimage.morphology.disk(self.disk_radius))
             mask_values |= label_mask
 
         labels[~mask_values] = self.no_data_label

--- a/geometry/eolearn/geometry/utilities.py
+++ b/geometry/eolearn/geometry/utilities.py
@@ -45,11 +45,10 @@ class ErosionTask(EOTask):
             return eopatch
 
         labels = eopatch[self.mask_type][self.mask_name].squeeze().copy()
-        if self.erode_labels is None:
-            self.erode_labels = np.unique(labels)
+        erode_labels = np.unique(labels) if self.erode_labels is None else self.erode_labels
 
         mask_values = np.zeros(labels.shape, dtype=np.bool)
-        for label in self.erode_labels:
+        for label in erode_labels:
             label_mask = (labels == label)
             label_mask = skimage.morphology.binary_erosion(label_mask, skimage.morphology.disk(self.disk_radius))
             mask_values |= label_mask

--- a/geometry/eolearn/tests/test_utilities.py
+++ b/geometry/eolearn/tests/test_utilities.py
@@ -1,10 +1,10 @@
 import unittest
 import os
 
+import numpy as np
+
 from eolearn.core import EOPatch, FeatureType
 from eolearn.geometry import ErosionTask
-
-import numpy as np
 
 
 class TestErosion(unittest.TestCase):
@@ -16,8 +16,7 @@ class TestErosion(unittest.TestCase):
     def setUpClass(cls):
         cls.classes = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
-    def test_point_raster_sampler(self):
-        # test erosion on all classes
+    def test_erosion_full(self):
         eopatch = EOPatch.load(self.TEST_PATCH_FILENAME, lazy_loading=True)
         mask_before = eopatch.mask_timeless['LULC'].copy()
 
@@ -35,6 +34,32 @@ class TestErosion(unittest.TestCase):
             else:
                 self.assertLessEqual(np.sum(mask_after == label), np.sum(mask_before == label),
                                      msg="error in the erosion process")
+
+    def test_erosion_partial(self):
+        eopatch = EOPatch.load(self.TEST_PATCH_FILENAME, lazy_loading=True)
+        mask_before = eopatch.mask_timeless['LULC'].copy()
+
+        # skip forest and artificial surface
+        specific_labels = [0, 1, 3, 4]
+        erosion_task = ErosionTask(mask_feature=(FeatureType.MASK_TIMELESS, 'LULC', 'LULC_ERODED'),
+                                   disk_radius=1,
+                                   erode_labels=specific_labels)
+        eopatch = erosion_task.execute(eopatch)
+
+        mask_after = eopatch.mask_timeless['LULC_ERODED'].copy()
+
+        self.assertFalse(np.all(mask_before == mask_after))
+
+        for label in self.classes:
+            if label == 0:
+                self.assertGreaterEqual(np.sum(mask_after == label), np.sum(mask_before == label),
+                                        msg="error in the erosion process")
+            elif label in specific_labels:
+                self.assertLessEqual(np.sum(mask_after == label), np.sum(mask_before == label),
+                                     msg="error in the erosion process")
+            else:
+                self.assertEqual(np.sum(mask_after == label), np.sum(mask_before == label),
+                                 msg="error in the erosion process")
 
 
 if __name__ == '__main__':

--- a/io/eolearn/io/geopedia.py
+++ b/io/eolearn/io/geopedia.py
@@ -117,10 +117,10 @@ class AddGeopediaFeature(EOTask):
                         'cultivated land': (1,[193, 243, 249, 255]),
                         'forest': (2,[73, 119, 20, 255]),
                         'grassland': (3,[95, 208, 169, 255]),
-                        'schrubland': (4,[112, 179, 62, 255]),
+                        'shrubland': (4,[112, 179, 62, 255]),
                         'water': (5,[154, 86, 1, 255]),
                         'wetland': (6,[244, 206, 126, 255]),
-                        'thundra': (7,[50, 100, 100, 255]),
+                        'tundra': (7,[50, 100, 100, 255]),
                         'artificial surface': (8,[20, 47, 147, 255]),
                         'bareland': (9,[202, 202, 202, 255]),
                         'snow and ice': (10,[251, 237, 211, 255])}


### PR DESCRIPTION
Fix cases of self abuse where variable `X` was improperly used in non-init functions of the classes, such as `EOTask`s

```
# bad
if self.X is None:
    self.X = foo

# good
X = foo if self.X is None else self.X
```