### PR TITLE
raise error for no good_idx

### DIFF
--- a/features/eolearn/features/feature_manipulation.py
+++ b/features/eolearn/features/feature_manipulation.py
@@ -52,6 +52,8 @@ class SimpleFilterTask(EOTask):
 
         good_idxs = self._get_filtered_indices(eopatch[feature_type][feature_name] if feature_name is not ... else
                                                eopatch[feature_type])
+        if not good_idxs:
+            raise RuntimeError(f'Patch has no good indices after filtering with {self.filter_func}')
 
         for feature_type, feature_name in self.filter_features(eopatch):
             if feature_type.is_time_dependent():


### PR DESCRIPTION
When filtering images in a patch, it can occur that the filter evaluates to `False` for all images (e.g. in all-year cloudy spots where you apply a strict cloud cover threshold).

This situation should be caught nicely, not raise an error deeper down.

This PR adds a simple test for empty `good_idx`.

What do you think?

(with @buwuyou)