### PR TITLE
Added development environment guide to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,38 +74,47 @@ The following guidelines should be observed when creating a PR.
 
 ### General guidelines
 
- * Where applicable, create your contribution in a new branch of your fork based on the
-   `develop` branch, as the `master` branch is aligned to the released package on [PyPI][pypi]. Upon
-   completion of the code review, the branch will be merged into `develop` and, at
-   the next package release, into `master`.
+* Where applicable, create your contribution in a new branch of your fork based on the `develop` branch, as the `master` branch is aligned to the released package on [PyPI][pypi]. Upon completion of the code review, the branch will be merged into `develop` and, at the next package release, into `master`.
 
- * Document your PR to help maintainers understand and review your contribution. The PR
-   should include:
+* Document your PR to help maintainers understand and review your contribution. The PR should include:
 
-   * Description of contribution;
-   * Required testing;
-   * Link to issue/feature request.
+  * Description of contribution;
+  * Required testing;
+  * Link to issue/feature request.
 
- * Your contribution should include unit tests, to test correct behaviour of the new feature
-   and to lower the maintenance effort. Bug fixes as well as new features should include unit tests.
-   When submitting the PR, check whether the Travis CI testing returns any errors, and if it does,
-   please try to fix the issues causing failure. A test `EOPatch` is made available [here][test-eo-patch]
-   with data for each `FeatureType`. Unit tests evaluating the correctness of new tasks should use data
-   available in this `EOPatch`. New fields useful for testing purposes can be added, but should
-   be consistent with the `bbox` and `timestamp` of the `EOPatch`.
+* Your contribution should include unit tests, to test correct behaviour of the new feature and to lower the maintenance effort. Bug fixes as well as new features should include unit tests. When submitting the PR, check whether the Travis CI testing returns any errors, and if it does, please try to fix the issues causing failure. A test `EOPatch` is made available [here][test-eo-patch] with data for each `FeatureType`. Unit tests evaluating the correctness of new tasks should use data available in this `EOPatch`. New fields useful for testing purposes can be added, but should be consistent with the `bbox` and `timestamp` of the `EOPatch`.
 
- * Try to keep contributions small, as this speeds up the reviewing process. In the case of large
-   contributions, e.g. a new complex `EOTask`, it's best to contact us first to review the scope
-   of the contribution.
+* Try to keep contributions small, as this speeds up the reviewing process. In the case of large contributions, e.g. a new complex `EOTask`, it's best to contact us first to review the scope of the contribution.
 
- * Keep API compatibility in mind, in particular when contributing a new `EOTask`. In general,
-   all new tasks should adhere to the modularity of **eo-learn**.
-   Check the Section below for more information on how to contribute an `EOTask`.
+* Keep API compatibility in mind, in particular when contributing a new `EOTask`. In general,all new tasks should adhere to the modularity of **eo-learn**. Check the Section below for more information on how to contribute an `EOTask`.
 
- * New features or tasks should be appropriately commented using Sphinx style docstrings. The documentation uses
-   the [PEP-8][pep-8] formatting guidelines. [Pylint][pylint] is used to check the coding standard.
-   Therefore please run `pylint` from the the main folder, which contains the `pylintrc` file, to make sure your
-   contribution is scored `10.0/10.0`.
+* New features or tasks should be appropriately commented using Sphinx style docstrings. The documentation uses the [PEP-8][pep-8] formatting guidelines. [Pylint][pylint] is used to check the coding standard. Therefore please run `pylint` from the the main folder, which contains the `pylintrc` file, to make sure your contribution is scored `10.0/10.0`.
+
+### Development environment
+
+* Get the latest development version. Fork and clone the repo:
+```bash
+git clone git@github.com:<username>/eo-learn.git
+```
+
+* Make sure that you have python 3 installed, i.e. version 3.5 or higher.
+
+* Install **eo-learn** and all subpackages in editable mode with `pip install -e <package_folder>`. We strongly recommend initializing a virtual environment before installing the required libraries. For example:
+
+```bash
+cd eo-learn
+virtualenv --python python3 .env
+source .env/bin/activate
+pip install -e ./core
+pip install -e ./coregistration
+pip install -e ./features
+pip install -e ./geometry
+pip install -e ./io
+pip install -e ./mask
+pip install -e ./ml_tools
+pip install -e ./visualization
+pip install -e .
+```
 
 ### Contribute an `EOTask`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,9 @@ to the library is very much appreciated.
 
 Here is how you can contribute:
 
- * [Bug Reports](#bug-reports)
- * [Feature Requests](#feature-requests)
- * [Pull Requests](#pull-requests)
+* [Bug Reports](#bug-reports)
+* [Feature Requests](#feature-requests)
+* [Pull Requests](#pull-requests)
 
 All contributors agree to follow our [Code of Conduct][code-of-conduct].
 
@@ -30,11 +30,11 @@ When reporting a bug, please check [here][open-bug-list] whether
 the bug was already reported. If not, open an issue with the **bug** label and
 report the following information:
 
- * Issue description
- * How to reproduce the issue
- * Expected outcome
- * Actual outcome
- * OS and package versions
+* Issue description
+* How to reproduce the issue
+* Expected outcome
+* Actual outcome
+* OS and package versions
 
 This information helps us to reproduce, pinpoint, and fix the reported issue.
 
@@ -82,38 +82,51 @@ The following guidelines should be observed when creating a PR.
   * Required testing;
   * Link to issue/feature request.
 
-* Your contribution should include unit tests, to test correct behaviour of the new feature and to lower the maintenance effort. Bug fixes as well as new features should include unit tests. When submitting the PR, check whether the Travis CI testing returns any errors, and if it does, please try to fix the issues causing failure. A test `EOPatch` is made available [here][test-eo-patch] with data for each `FeatureType`. Unit tests evaluating the correctness of new tasks should use data available in this `EOPatch`. New fields useful for testing purposes can be added, but should be consistent with the `bbox` and `timestamp` of the `EOPatch`.
+* Your contribution should include unit tests, to test correct behaviour of the new feature and to lower the maintenance effort. Bug fixes as well as new features should include unit tests. When submitting the PR, check whether the Travis CI testing returns any errors, and if it does, please try to fix the issues causing failure. A test `EOPatch` is made available [here][test-eo-patch] with data for each `FeatureType`. Unit tests evaluating the correctness of new tasks should use data available in this `EOPatch`. New fields useful for testing purposes can be added, but should be consistent with the `bbox` and `timestamp` of the `EOPatch`. To execute all unit tests locally on you machine, use the command: `pytest` from the main folder. See also the [examples/README.md](examples/README.md) for how to setup you SentinelHub account and local config for testing.
 
 * Try to keep contributions small, as this speeds up the reviewing process. In the case of large contributions, e.g. a new complex `EOTask`, it's best to contact us first to review the scope of the contribution.
 
 * Keep API compatibility in mind, in particular when contributing a new `EOTask`. In general,all new tasks should adhere to the modularity of **eo-learn**. Check the Section below for more information on how to contribute an `EOTask`.
 
-* New features or tasks should be appropriately commented using Sphinx style docstrings. The documentation uses the [PEP-8][pep-8] formatting guidelines. [Pylint][pylint] is used to check the coding standard. Therefore please run `pylint` from the the main folder, which contains the `pylintrc` file, to make sure your contribution is scored `10.0/10.0`.
+* New features or tasks should be appropriately commented using Sphinx style docstrings. The documentation uses the [PEP-8][pep-8] formatting guidelines. [Pylint][pylint] is used to check the coding standard. Therefore please run `pylint */ *.py` from the the main folder, which contains the `pylintrc` file, to make sure your contribution is scored `10.0/10.0`.
 
 ### Development environment
 
-* Get the latest development version. Fork and clone the repo:
+* Get the latest development version by creating a fork and clone the repo:
+
 ```bash
 git clone git@github.com:<username>/eo-learn.git
 ```
 
 * Make sure that you have python 3 installed, i.e. version 3.5 or higher.
 
-* Install **eo-learn** and all subpackages in editable mode with `pip install -e <package_folder>`. We strongly recommend initializing a virtual environment before installing the required libraries. For example:
+* Install **eo-learn** and all subpackages in (editable) development mode with `pip install -e <package_folder>`. We strongly recommend initializing a virtual environment before installing the required libraries. For example by using Python Package Index (PyPI) and virtualenv:
 
 ```bash
 cd eo-learn
+# The following creates the virtual environment in the ".env" folder.
 virtualenv --python python3 .env
 source .env/bin/activate
-pip install -e ./core
-pip install -e ./coregistration
-pip install -e ./features
-pip install -e ./geometry
-pip install -e ./io
-pip install -e ./mask
-pip install -e ./ml_tools
-pip install -e ./visualization
-pip install -e .
+
+#The following installs all eo-learn subpackages and development packages
+#using PyPI in the inside the activated virtualenv environment.
+pip install -e ./core -e ./coregistration -e ./features -e ./geometry -e ./io -e ./mask -e ./ml_tools -e ./visualization -e .
+pip install -r requirements-dev.txt -r requirements-docs.txt
+```
+
+Or alternatively by using Conda:
+
+```bash
+cd eo-learn
+# The following creates the virtual environment named "dev_eolearn" where the Conda installation in located.
+# ipykernel: Enables Jupyter (using nb_conda_kernels) to select the environment as a kernel.
+# ipywidgets: Enables Jupyter to show progress bar of EOExecutor without raising an error.
+conda create -n dev_eolearn python=3.7 ipykernel ipywidgets
+conda activate dev_eolearn
+
+# The following installs all eo-learn subpackages and development packages using PyPI inside the activated Conda environment.
+pip install -e ./core -e ./coregistration -e ./features -e ./geometry -e ./io -e ./mask -e ./ml_tools -e ./visualization -e .
+pip install -r requirements-dev.txt -r requirements-docs.txt
 ```
 
 ### Contribute an `EOTask`
@@ -135,23 +148,15 @@ class FooTask(EOTask):
         # do what foo does on input eopatch and return it
         return eopatch
 ```
+
 When creating a new task, bear in mind the following:
 
- * Tasks should be as modular as possible, facilitating task re-use and sharing.
- * An `EOTask` should perform a well-defined operation on the input eopatch(es). If the operation
-   could be split into atomic sub-operations that could be used separately, then consider splitting
-   the task into multiple tasks. Similarly, if tasks share the bulk of the implementation but differ
-   in a minority of implementation, consider using Base classes and inheritance. The interpolation
-   tasks represent a good example of this.  
- * Tasks should be as generalizable as possible, therefore hard-coding of task parameters or `EOPatch`
-   feature types should be avoided. Use the `EOTask._parse_features` method to parse input features in a task,
-   and pass task parameters as arguments, either in the constructor, or at run-time.
- * If in doubt on whether a task is general enough to be of interest to the community, or you are not
-   sure to which sub-package to contribute your task to, send us an email or open a
-   [feature request](#feature-requests).
+* Tasks should be as modular as possible, facilitating task re-use and sharing.
+* An `EOTask` should perform a well-defined operation on the input eopatch(es). If the operation could be split into atomic sub-operations that could be used separately, then consider splitting the task into multiple tasks. Similarly, if tasks share the bulk of the implementation but differ in a minority of implementation, consider using Base classes and inheritance. The interpolation tasks represent a good example of this.  
+* Tasks should be as generalizable as possible, therefore hard-coding of task parameters or `EOPatch` feature types should be avoided. Use the `EOTask._parse_features` method to parse input features in a task, and pass task parameters as arguments, either in the constructor, or at run-time.
+* If in doubt on whether a task is general enough to be of interest to the community, or you are not sure to which sub-package to contribute your task to, send us an email or open a [feature request](#feature-requests).
 
 Looking forward to include your contributions into **eo-learn**.
-
 
 [pypi]: https://pypi.org/project/eo-learn/
 [pep-8]: https://www.python.org/dev/peps/pep-0008/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,9 +76,9 @@ The following guidelines should be observed when creating a PR.
 
 * Try to keep contributions small, as this speeds up the reviewing process. In the case of large contributions, e.g. a new complex `EOTask`, it's best to contact us first to review the scope of the contribution.
 
-* Keep API compatibility in mind, in particular when contributing a new `EOTask`. In general,all new tasks should adhere to the modularity of **eo-learn**. Check the Section below for more information on how to contribute an `EOTask`.
+* Keep API compatibility in mind, in particular when contributing a new `EOTask`. In general, all new tasks should adhere to the modularity of **eo-learn**. Check the Section below for more information on how to contribute an `EOTask`.
 
-* New features or tasks should be appropriately commented using Sphinx style docstrings. The documentation uses the [PEP-8][pep-8] formatting guidelines. [Pylint][pylint] is used to check the coding standard. Therefore please run `pylint */ *.py` from the the main folder, which contains the `pylintrc` file, to make sure your contribution is scored `10.0/10.0`.
+* New features or tasks should be appropriately commented using Sphinx style docstrings. The documentation uses the [PEP-8][pep-8] formatting guidelines. [Pylint][pylint] is used to check the coding standard. Therefore, please run `pylint */ *.py` from the the main folder, which contains the `pylintrc` file, to make sure your contribution is scored `10.0/10.0`.
 
 ### Development environment
 
@@ -88,9 +88,9 @@ The following guidelines should be observed when creating a PR.
 git clone git@github.com:<username>/eo-learn.git
 ```
 
-* Make sure that you have python 3 installed, i.e. version 3.5 or higher.
+* Make sure that you have python 3 installed, i.e. version 3.5 or higher. See https://www.python.org/downloads/ for general Python versions or https://www.anaconda.com/distribution/ for using Conda.
 
-* Install **eo-learn** and all subpackages in (editable) development mode with `pip install -e <package_folder>`. We strongly recommend initializing a virtual environment before installing the required libraries. For example by using Python Package Index (PyPI) and virtualenv:
+* Install **eo-learn** and all subpackages in (editable) development mode with `pip install -e <package_folder>`. We strongly recommend initializing a virtual environment before installing the required packages. For example by using Python Package Index (PyPI) and virtualenv:
 
 ```bash
 cd eo-learn
@@ -110,9 +110,9 @@ Or alternatively by using Conda:
 ```bash
 cd eo-learn
 # The following creates the virtual environment named "dev_eolearn" where the
-# Conda installation in located. ipykernel: Enables Jupyter (using
-# nb_conda_kernels) to select the environment as a kernel. ipywidgets: Enables
-# Jupyter to show progress bar of EOExecutor without raising an error.
+# Conda installation in located. ipykernel enables Jupyter (using
+# nb_conda_kernels) to select the environment as a kernel. ipywidgets enables
+# Jupyter to show the progress bar of EOExecutor without raising an error.
 conda create -n dev_eolearn python=3.7 ipykernel ipywidgets
 conda activate dev_eolearn
 
@@ -123,7 +123,7 @@ pip install -e ./core -e ./coregistration -e ./features -e ./geometry -e ./io \
 pip install -r requirements-dev.txt -r requirements-docs.txt
 ```
 
-**Note:** to reduce later merge conflict, always pull the latest version of the `develop` branch of the upstream eo-learn repository ([located here](https://github.com/sentinel-hub/eo-learn/tree/develop)) to your fork before starting the work on your PR.
+**Note:** to reduce later merge conflicts, always pull the latest version of the `develop` branch from the upstream eo-learn repository ([located here](https://github.com/sentinel-hub/eo-learn/tree/develop)) to your fork before starting the work on your PR.
 
 ### Contribute an `EOTask`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,9 +88,9 @@ The following guidelines should be observed when creating a PR.
 git clone git@github.com:<username>/eo-learn.git
 ```
 
-* Make sure that you have python 3 installed, i.e. version 3.5 or higher. See https://www.python.org/downloads/ for general Python versions or https://www.anaconda.com/distribution/ for using Conda.
+* Make sure that you have python 3 installed, i.e. version 3.5 or higher. See [Python downloads][python] for general Python versions or [Anaconda distributions][conda] for using Conda.
 
-* Install **eo-learn** and all subpackages in (editable) development mode with `pip install -e <package_folder>`. We strongly recommend initializing a virtual environment before installing the required packages. For example by using Python Package Index (PyPI) and virtualenv:
+* All **eo-learn** packages can be installed at once using `python install_all.py -e`. To install each package separately, run `pip install -e <package_folder>`. We strongly recommend initializing a virtual environment before installing the required packages. For example by using Python Package Index (PyPI) and virtualenv:
 
 ```bash
 cd eo-learn
@@ -100,8 +100,7 @@ source .env/bin/activate
 
 # The following installs all eo-learn subpackages and development packages
 # using PyPI in the activated virtualenv environment.
-pip install -e ./core -e ./coregistration -e ./features -e ./geometry -e ./io \
--e ./mask -e ./ml_tools -e ./visualization -e .
+python install_all.py -e
 pip install -r requirements-dev.txt -r requirements-docs.txt
 ```
 
@@ -118,12 +117,11 @@ conda activate dev_eolearn
 
 # The following installs all eo-learn subpackages and development packages
 # using PyPI in the activated Conda environment.
-pip install -e ./core -e ./coregistration -e ./features -e ./geometry -e ./io \
- -e ./mask -e ./ml_tools -e ./visualization -e .
+python install_all.py -e
 pip install -r requirements-dev.txt -r requirements-docs.txt
 ```
 
-**Note:** to reduce later merge conflicts, always pull the latest version of the `develop` branch from the upstream eo-learn repository ([located here](https://github.com/sentinel-hub/eo-learn/tree/develop)) to your fork before starting the work on your PR.
+**Note:** to reduce later merge conflicts, always pull the latest version of the `develop` branch from the upstream eo-learn repository ([located here][dev-branch]) to your fork before starting the work on your PR.
 
 ### Contribute an `EOTask`
 
@@ -159,3 +157,6 @@ Looking forward to include your contributions into **eo-learn**.
 [pylint]: https://www.pylint.org/
 [existing-eo-tasks]: https://eo-learn.readthedocs.io/en/latest/eotasks.html
 [test-eo-patch]: https://github.com/sentinel-hub/eo-learn/tree/master/example_data/TestEOPatch
+[python]: https://www.python.org/downloads/
+[conda]: https://www.anaconda.com/distribution/
+[dev-branch]: https://github.com/sentinel-hub/eo-learn/tree/develop/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,7 @@ report the following information:
 
 This information helps us to reproduce, pinpoint, and fix the reported issue.
 
-If you are not sure whether the odd behaviour is a bug or a _feature_, best to open
-an issue and clarify.
+If you are not sure whether the odd behaviour is a bug or a _feature_, best to open an issue and clarify.
 
 [open-bug-list]: https://github.com/sentinel-hub/eo-learn/issues?q=state:open+type:issue+label:"bug"
 
@@ -47,24 +46,15 @@ an issue and clarify.
 
 Existing feature requests can be found [here][existing-feature-requests].
 
-A new feature request can be created by opening a new issue with the **enhancement** label,
-and describing how the feature would benefit the **eo-learn** community.
-Providing an example use-case would help assessing the scope of the
-feature request.
+A new feature request can be created by opening a new issue with the **enhancement** label, and describing how the feature would benefit the **eo-learn** community. Providing an example use-case would help assessing the scope of the feature request.
 
 [existing-feature-requests]: https://github.com/sentinel-hub/eo-learn/issues?q=state:open+type:issue+label:"enhancement"
 
 ## Pull Requests
 
-The GitHub Pull Request (PR) mechanism is the best option to contribute code
-to the library. Users can fork the repository, make their contribution to their
-local fork and create a PR to add those changes to the codebase. GitHub provides excellent
-tutorials on how the [fork and pull][fork-and-pull] mechanism work, and on
-how to best [create a PR][create-pr].
+The GitHub Pull Request (PR) mechanism is the best option to contribute code to the library. Users can fork the repository, make their contribution to their local fork and create a PR to add those changes to the codebase. GitHub provides excellent tutorials on how the [fork and pull][fork-and-pull] mechanism work, and on how to best [create a PR][create-pr].
 
-Existing PRs can be found [here][existing-prs]. Before creating new PRs, you should check
-whether someone else has contributed a similar feature, and if so, you can add your
-input to the existing code review.
+Existing PRs can be found [here][existing-prs]. Before creating new PRs, you should check whether someone else has contributed a similar feature, and if so, you can add your input to the existing code review.
 
 The following guidelines should be observed when creating a PR.
 
@@ -108,9 +98,10 @@ cd eo-learn
 virtualenv --python python3 .env
 source .env/bin/activate
 
-#The following installs all eo-learn subpackages and development packages
-#using PyPI in the inside the activated virtualenv environment.
-pip install -e ./core -e ./coregistration -e ./features -e ./geometry -e ./io -e ./mask -e ./ml_tools -e ./visualization -e .
+# The following installs all eo-learn subpackages and development packages
+# using PyPI in the activated virtualenv environment.
+pip install -e ./core -e ./coregistration -e ./features -e ./geometry -e ./io \
+-e ./mask -e ./ml_tools -e ./visualization -e .
 pip install -r requirements-dev.txt -r requirements-docs.txt
 ```
 
@@ -118,16 +109,21 @@ Or alternatively by using Conda:
 
 ```bash
 cd eo-learn
-# The following creates the virtual environment named "dev_eolearn" where the Conda installation in located.
-# ipykernel: Enables Jupyter (using nb_conda_kernels) to select the environment as a kernel.
-# ipywidgets: Enables Jupyter to show progress bar of EOExecutor without raising an error.
+# The following creates the virtual environment named "dev_eolearn" where the
+# Conda installation in located. ipykernel: Enables Jupyter (using
+# nb_conda_kernels) to select the environment as a kernel. ipywidgets: Enables
+# Jupyter to show progress bar of EOExecutor without raising an error.
 conda create -n dev_eolearn python=3.7 ipykernel ipywidgets
 conda activate dev_eolearn
 
-# The following installs all eo-learn subpackages and development packages using PyPI inside the activated Conda environment.
-pip install -e ./core -e ./coregistration -e ./features -e ./geometry -e ./io -e ./mask -e ./ml_tools -e ./visualization -e .
+# The following installs all eo-learn subpackages and development packages
+# using PyPI in the activated Conda environment.
+pip install -e ./core -e ./coregistration -e ./features -e ./geometry -e ./io \
+ -e ./mask -e ./ml_tools -e ./visualization -e .
 pip install -r requirements-dev.txt -r requirements-docs.txt
 ```
+
+**Note:** to reduce later merge conflict, always pull the latest version of the `develop` branch of the upstream eo-learn repository ([located here](https://github.com/sentinel-hub/eo-learn/tree/develop)) to your fork before starting the work on your PR.
 
 ### Contribute an `EOTask`
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ If you would like to contribute to `eo-learn`, check out our [contribution guide
  * [Innovations in satellite measurements for development](https://blogs.worldbank.org/opendata/innovations-satellite-measurements-development)
  * [Use eo-learn with AWS SageMaker](https://medium.com/@drewbo19/use-eo-learn-with-aws-sagemaker-9420856aafb5) (by Drew Bollinger)
  * [Spatio-Temporal Deep Learning: An Application to Land Cover Classification](https://www.researchgate.net/publication/333262625_Spatio-Temporal_Deep_Learning_An_Application_to_Land_Cover_Classification)(by Anze Zupanc) 
+ * [Tree Cover Prediction with Deep Learning](https://medium.com/dataseries/tree-cover-prediction-with-deep-learning-afeb0b663966)(by Daniel Moraite)
 
 ## Questions and Issues
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -11,4 +11,4 @@ m2r>=0.2.0
 -e ./io
 -e ./mask
 -e ./ml_tools
-./visualization
+-e ./visualization

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -4,11 +4,11 @@ nbsphinx
 ipython
 m2r>=0.2.0
 
-./core
-./coregistration
-./features
-./geometry
-./io
-./mask
-./ml_tools
+-e ./core
+-e ./coregistration
+-e ./features
+-e ./geometry
+-e ./io
+-e ./mask
+-e ./ml_tools
 ./visualization


### PR DESCRIPTION
Hi, it's my first time contributing to eo-learn, thus I think it was fitting to improve the contribution guide.
I have contributed to other open-source before, e.g. DVC and think their contribution guide (https://dvc.org/doc/user-guide/contributing) has some details the eo-learn guide is missing, for example, the guide of setting up a virtual Python environment for development which I have documented in this pull request.

A guide for executing the unittests could also be useful. However, I'm not familiar enough with your test setup to document such a guide. Are somebody else up for that?