### PR TITLE
added DuplicateFeature to core tasks

### DIFF
--- a/core/eolearn/core/__init__.py
+++ b/core/eolearn/core/__init__.py
@@ -10,7 +10,7 @@ from .eotask import EOTask, CompositeTask
 from .eoworkflow import EOWorkflow, LinearWorkflow, Dependency, WorkflowResults
 from .eoexecution import EOExecutor
 
-from .core_tasks import CopyTask, DeepCopyTask, SaveToDisk, LoadFromDisk, AddFeature, RemoveFeature, RenameFeature
+from .core_tasks import CopyTask, DeepCopyTask, SaveToDisk, LoadFromDisk, AddFeature, RemoveFeature, RenameFeature, DuplicateFeature
 from .utilities import deep_eq, negate_mask, constant_pad, get_common_timestamps, bgr_to_rgb, FeatureParser
 
 

--- a/core/eolearn/core/__init__.py
+++ b/core/eolearn/core/__init__.py
@@ -10,7 +10,8 @@ from .eotask import EOTask, CompositeTask
 from .eoworkflow import EOWorkflow, LinearWorkflow, Dependency, WorkflowResults
 from .eoexecution import EOExecutor
 
-from .core_tasks import CopyTask, DeepCopyTask, SaveToDisk, LoadFromDisk, AddFeature, RemoveFeature, RenameFeature, DuplicateFeature
+from .core_tasks import CopyTask, DeepCopyTask, SaveToDisk, LoadFromDisk, AddFeature, RemoveFeature, RenameFeature,\
+    DuplicateFeature, InitializeFeature
 from .utilities import deep_eq, negate_mask, constant_pad, get_common_timestamps, bgr_to_rgb, FeatureParser
 
 

--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -172,3 +172,32 @@ class RenameFeature(EOTask):
             del eopatch[feature_type][feature_name]
 
         return eopatch
+
+class DuplicateFeature(EOTask):
+    """Duplicates one or multiple features in an EOPatch.
+
+    :param features: A collection of features to be copied.
+    :type features: object supported by eolearn.core.utilities.FeatureParser class
+    """
+
+    def __init__(self, features):
+        self.feature_gen = self._parse_features(features, new_names=True)
+
+    def execute(self, eopatch):
+        """Returns the EOPatch with copied features.
+
+        :param eopatch: Input EOPatch
+        :type eopatch: EOPatch
+        :return: Input EOPatch with the duplicated features.
+        :rtype: EOPatch
+        :raises BaseException: Raises an exception when trying to duplicate a feature with an
+            already existing feature name.
+        """
+
+        for feature_type, feature_name, new_feature_name in self.feature_gen(eopatch):
+            if new_feature_name in eopatch[feature_type].keys():
+                raise BaseException("A feature named '{}' already exists.".format(new_feature_name))
+
+            eopatch[feature_type][new_feature_name] = eopatch[feature_type][feature_name]
+
+        return eopatch

--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -14,10 +14,12 @@ class CopyTask(EOTask):
 
     It copies feature type dictionaries but not the data itself.
 
-    :param features: A collection of features or feature types that will be copied into new EOPatch.
-    :type features: object supported by eolearn.core.utilities.FeatureParser class
     """
     def __init__(self, features=...):
+        """
+        :param features: A collection of features or feature types that will be copied into new EOPatch.
+        :type features: object supported by eolearn.core.utilities.FeatureParser class
+        """
         self.features = features
 
     def execute(self, eopatch):
@@ -26,9 +28,6 @@ class CopyTask(EOTask):
 
 class DeepCopyTask(CopyTask):
     """ Makes a deep copy of the given EOPatch.
-
-    :param features: A collection of features or feature types that will be copied into new EOPatch.
-    :type features: object supported by eolearn.core.utilities.FeatureParser class
     """
     def execute(self, eopatch):
         return eopatch.__deepcopy__(features=self.features)
@@ -36,21 +35,22 @@ class DeepCopyTask(CopyTask):
 
 class SaveToDisk(EOTask):
     """Saves the given EOPatch to disk.
-
-    :param folder: root directory where all EOPatches are saved
-    :type folder: str
-    :param features: A collection of features types specifying features of which type will be saved. By default
-        all features will be saved.
-    :type features: object supported by eolearn.core.utilities.FeatureParser class
-    :param file_format: File format
-    :type file_format: FileFormat or str
-    :param overwrite_permission: A level of permission for overwriting an existing EOPatch
-    :type overwrite_permission: OverwritePermission or int
-    :param compress_level: A level of data compression and can be specified with an integer from 0 (no compression)
-        to 9 (highest compression).
-    :type compress_level: int
     """
     def __init__(self, folder, *args, **kwargs):
+        """
+        :param folder: root directory where all EOPatches are saved
+        :type folder: str
+        :param features: A collection of features types specifying features of which type will be saved. By default
+            all features will be saved.
+        :type features: object supported by eolearn.core.utilities.FeatureParser class
+        :param file_format: File format
+        :type file_format: FileFormat or str
+        :param overwrite_permission: A level of permission for overwriting an existing EOPatch
+        :type overwrite_permission: OverwritePermission or int
+        :param compress_level: A level of data compression and can be specified with an integer from 0 (no compression)
+            to 9 (highest compression).
+        :type compress_level: int
+        """
         self.folder = folder
         self.args = args
         self.kwargs = kwargs
@@ -71,17 +71,18 @@ class SaveToDisk(EOTask):
 
 class LoadFromDisk(EOTask):
     """Loads the given EOPatch from disk.
-
-    :param folder: root directory where all EOPatches are saved
-    :type folder: str
-    :param features: A collection of features to be loaded. By default all features will be loaded.
-    :type features: object supported by eolearn.core.utilities.FeatureParser class
-    :param lazy_loading: If `True` features will be lazy loaded. Default is `False`
-    :type lazy_loading: bool
-    :param mmap: If `True`, then memory-map the file. Works only on uncompressed npy files
-    :type mmap: bool
     """
     def __init__(self, folder, *args, **kwargs):
+        """
+        :param folder: root directory where all EOPatches are saved
+        :type folder: str
+        :param features: A collection of features to be loaded. By default all features will be loaded.
+        :type features: object supported by eolearn.core.utilities.FeatureParser class
+        :param lazy_loading: If `True` features will be lazy loaded. Default is `False`
+        :type lazy_loading: bool
+        :param mmap: If `True`, then memory-map the file. Works only on uncompressed npy files
+        :type mmap: bool
+        """
         self.folder = folder
         self.args = args
         self.kwargs = kwargs
@@ -100,11 +101,12 @@ class LoadFromDisk(EOTask):
 
 class AddFeature(EOTask):
     """Adds a feature to the given EOPatch.
-
-    :param feature: Feature to be added
-    :type feature: (FeatureType, feature_name) or FeatureType
     """
     def __init__(self, feature):
+        """
+        :param feature: Feature to be added
+        :type feature: (FeatureType, feature_name) or FeatureType
+        """
         self.feature_type, self.feature_name = next(self._parse_features(feature)())
 
     def execute(self, eopatch, data):
@@ -127,11 +129,12 @@ class AddFeature(EOTask):
 
 class RemoveFeature(EOTask):
     """Removes one or multiple features from the given EOPatch.
-
-    :param features: A collection of features to be removed.
-    :type features: object supported by eolearn.core.utilities.FeatureParser class
     """
     def __init__(self, features):
+        """
+        :param features: A collection of features to be removed.
+        :type features: object supported by eolearn.core.utilities.FeatureParser class
+        """
         self.feature_gen = self._parse_features(features)
 
     def execute(self, eopatch):
@@ -153,11 +156,12 @@ class RemoveFeature(EOTask):
 
 class RenameFeature(EOTask):
     """Renames one or multiple features from the given EOPatch.
-
-    :param features: A collection of features to be renamed.
-    :type features: object supported by eolearn.core.utilities.FeatureParser class
     """
     def __init__(self, features):
+        """
+        :param features: A collection of features to be renamed.
+        :type features: object supported by eolearn.core.utilities.FeatureParser class
+        """
         self.feature_gen = self._parse_features(features, new_names=True)
 
     def execute(self, eopatch):

--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -307,7 +307,7 @@ class EOPatch:
                 self[feature_type][new_feature_name] = self[feature_type][feature_name]
                 del self[feature_type][feature_name]
             else:
-                raise BaseException("Feature {} from attribute {} does not exist!".format(
+                raise ValueError("Feature {} from attribute {} does not exist!".format(
                     feature_name, feature_type.value))
         else:
             LOGGER.debug("Feature '%s' was not renamed because new name is identical.", feature_name)

--- a/core/eolearn/tests/test_core_tasks.py
+++ b/core/eolearn/tests/test_core_tasks.py
@@ -3,7 +3,8 @@ import logging
 import datetime
 import numpy as np
 
-from eolearn.core import EOPatch, FeatureType, CopyTask, DeepCopyTask, AddFeature, RemoveFeature, RenameFeature, DuplicateFeature
+from eolearn.core import EOPatch, FeatureType, CopyTask, DeepCopyTask, AddFeature, RemoveFeature, RenameFeature,\
+    DuplicateFeature, InitializeFeature
 
 
 logging.basicConfig(level=logging.DEBUG)
@@ -96,16 +97,15 @@ class TestCoreTasks(unittest.TestCase):
         self.assertTrue(np.array_equal(patch.mask[duplicate_name], mask_data),
                         'Feature was not duplicated correctly. Data does not match.')
 
-        self.assertRaises(BaseException, duplicate_task, patch,
-                          'Expected an exception when duplicating an already exising feature.')
+        with self.assertRaises(ValueError, msg='Expected a ValueError when creating an already exising feature.'):
+            duplicate_task(patch)
 
         duplicate_names = {'D1', 'D2'}
         feature_list = [(FeatureType.MASK, 'MASK1', 'D1'), (FeatureType.MASK, 'MASK2', 'D2')]
         patch = DuplicateFeature(feature_list).execute(patch)
 
-        self.assertTrue(duplicate_names.issubset(patch.mask.keys()),
-                        'Duplicating multiple features failed.')
-        
+        self.assertTrue(duplicate_names.issubset(patch.mask.keys()), 'Duplicating multiple features failed.')
+
         # Duplicating MASK1 three times into D3, D4, D5 doesn't work, because EOTask.feature_gen
         # returns a dict containing only ('MASK1', 'D5') duplication
 
@@ -115,6 +115,50 @@ class TestCoreTasks(unittest.TestCase):
 
         # self.assertTrue(duplicate_names.issubset(patch.mask.keys()),
         #                 'Duplicating single feature multiple times failed.')
+
+    def test_initialize_feature(self):
+        patch = DeepCopyTask()(self.patch)
+
+        init_val = 123
+        shape = (5, 10, 10, 3)
+        compare_data = np.ones(shape) * init_val
+
+        InitializeFeature((FeatureType.MASK, 'test'), shape=shape, init_value=init_val)(patch)
+        self.assertEqual(patch.mask['test'].shape, shape)
+        self.assertTrue(np.array_equal(patch.mask['test'], compare_data))
+
+        failmsg = 'Expected a ValueError when trying to initialize a feature with a wrong shape dmensions.'
+        with self.assertRaises(ValueError, msg=failmsg):
+            InitializeFeature((FeatureType.MASK_TIMELESS, 'wrong'), shape=shape, init_value=init_val)(patch)
+
+        init_val = 123
+        shape = (10, 10, 3)
+        compare_data = np.ones(shape) * init_val
+
+        InitializeFeature((FeatureType.MASK_TIMELESS, 'test'), shape=shape, init_value=init_val)(patch)
+        self.assertEqual(patch.mask_timeless['test'].shape, shape)
+        self.assertTrue(np.array_equal(patch.mask_timeless['test'], compare_data))
+
+        fail_msg = 'Expected a ValueError when trying to initialize a feature with a wrong shape dmensions.'
+        with self.assertRaises(ValueError, msg=fail_msg):
+            InitializeFeature((FeatureType.MASK, 'wrong'), shape=shape, init_value=init_val)(patch)
+
+        init_val = 123
+        shape = (5, 10, 10, 3)
+        compare_data = np.ones(shape) * init_val
+        new_names = {'F1', 'F2', 'F3'}
+
+        InitializeFeature({FeatureType.MASK: new_names}, shape=shape, init_value=init_val)(patch)
+        fail_msg = "Failed to initialize new features from a shape tuple."
+        self.assertTrue(new_names < set(patch.mask.keys()), msg=fail_msg)
+        self.assertTrue(all(patch.mask[key].shape == shape for key in new_names))
+        self.assertTrue(all(np.array_equal(patch.mask[key], compare_data) for key in new_names))
+
+        InitializeFeature({FeatureType.DATA: new_names}, shape=(FeatureType.DATA, 'bands'))(patch)
+        fail_msg = "Failed to initialize new features from an existing feature."
+        self.assertTrue(new_names < set(patch.data.keys()), msg=fail_msg)
+        self.assertTrue(all(patch.data[key].shape == patch.data['bands'].shape for key in new_names))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
There is a usecase that I'm not sure whether it should be supported or not. One can duplicate multiple features as [('f1', 'f11'), ('f2', 'f21')], but not a single feature multiple times: [('f', 'f1'), ('f', 'f2')]. This case is also presented in test_core_tasks.py, but is commented out. As I understand, this is caused by the behavior of EOTask._parse_features, since it returns an ordered dict which would have feature_to_be_copied as a dict key and since dict keys cannot be repeated, the loop in DuplicateFeature doesn't go through the same feature_to_be_copied multiple times.