### PR TITLE
Bugfix/vector2raster empty

### DIFF
--- a/geometry/eolearn/geometry/transformations.py
+++ b/geometry/eolearn/geometry/transformations.py
@@ -179,7 +179,7 @@ class VectorToRaster(EOTask):
         feature_type, feature_name = self.raster_feature
 
         if self.write_to_existing and feature_name in eopatch[feature_type]:
-            raster = eopatch[feature_type][feature_name].squeeze(axis=-1)
+            raster = eopatch[self.raster_feature].squeeze(axis=-1)
 
             if (height, width) != raster.shape[:2]:
                 warnings.warn('Writing to existing raster with spatial dimensions {}, but dimensions {} were expected'
@@ -200,13 +200,12 @@ class VectorToRaster(EOTask):
         if eopatch.bbox is None:
             raise ValueError('EOPatch has to have a bounding box')
 
-        feature_type, feature_name = self.raster_feature
         height, width = self._get_raster_shape(eopatch)
 
         rasterization_shapes = self._get_rasterization_shapes(eopatch)
         if not rasterization_shapes:
-            eopatch[feature_type][feature_name] = \
-                np.full((height, width), self.no_data_value)[..., np.newaxis].astype(self.raster_dtype)
+            eopatch[self.raster_feature] = \
+                np.full((height, width, 1), self.no_data_value, dtype=self.raster_dtype)
             return eopatch
 
         affine_transform = rasterio.transform.from_bounds(*eopatch.bbox, width=width, height=height)
@@ -216,7 +215,7 @@ class VectorToRaster(EOTask):
         rasterio.features.rasterize(rasterization_shapes, out=raster, transform=affine_transform,
                                     dtype=self.raster_dtype, **self.rasterio_params)
 
-        eopatch[feature_type][feature_name] = raster[..., np.newaxis]
+        eopatch[self.raster_feature] = raster[..., np.newaxis]
         return eopatch
 
 

--- a/geometry/eolearn/tests/test_transformations.py
+++ b/geometry/eolearn/tests/test_transformations.py
@@ -61,14 +61,14 @@ class TestVectorToRaster(unittest.TestCase):
                          img_min=1, img_max=13, img_mean=12.7093, img_median=13, img_dtype=np.uint16,
                          img_shape=(17, 17, 1)),
             cls.TestCase('deprecated parameters, single value, custom resolution',
-                         VectorToRaster(cls.raster_feature, custom_dataframe, values=14,
+                         VectorToRaster(vector_input=custom_dataframe, raster_feature=cls.raster_feature, values=14,
                                         raster_resolution=(32, 15), no_data_value=-1, raster_dtype=np.int32),
                          img_min=-1, img_max=14, img_mean=-0.8411, img_median=-1, img_dtype=np.int32,
                          img_shape=(67, 31, 1)),
             cls.TestCase('empty vector data test',
-                         VectorToRaster(raster_feature=cls.raster_feature,
-                                        vector_input=custom_dataframe[
+                         VectorToRaster(vector_input=custom_dataframe[
                                             (custom_dataframe.LULC_NAME == 'some_none_existent_name')],
+                                        raster_feature=cls.raster_feature,
                                         values_column='LULC_ID',
                                         raster_shape=(FeatureType.DATA, 'BANDS-S2-L1C'), no_data_value=0),
                          img_min=0, img_max=0, img_mean=0, img_median=0, img_dtype=np.uint8,

--- a/geometry/eolearn/tests/test_transformations.py
+++ b/geometry/eolearn/tests/test_transformations.py
@@ -40,7 +40,7 @@ class TestVectorToRaster(unittest.TestCase):
         cls.raster_feature = FeatureType.MASK_TIMELESS, 'RASTERIZED_LULC'
 
         custom_dataframe = EOPatch.load(cls.TestCase.TEST_PATCH_FILENAME).vector_timeless['LULC']
-        custom_dataframe = custom_dataframe[custom_dataframe['AREA'] < 10 ** 3]
+        custom_dataframe = custom_dataframe[(custom_dataframe['AREA'] < 10 ** 3)]
 
         cls.test_cases = [
             cls.TestCase('basic test',
@@ -64,7 +64,15 @@ class TestVectorToRaster(unittest.TestCase):
                          VectorToRaster(cls.raster_feature, custom_dataframe, values=14,
                                         raster_resolution=(32, 15), no_data_value=-1, raster_dtype=np.int32),
                          img_min=-1, img_max=14, img_mean=-0.8411, img_median=-1, img_dtype=np.int32,
-                         img_shape=(67, 31, 1))
+                         img_shape=(67, 31, 1)),
+            cls.TestCase('empty vector data test',
+                         VectorToRaster(raster_feature=cls.raster_feature,
+                                        vector_input=custom_dataframe[
+                                            (custom_dataframe.LULC_NAME == 'some_none_existent_name')],
+                                        values_column='LULC_ID',
+                                        raster_shape=(FeatureType.DATA, 'BANDS-S2-L1C'), no_data_value=0),
+                         img_min=0, img_max=0, img_mean=0, img_median=0, img_dtype=np.uint8,
+                         img_shape=(101, 100, 1)),
         ]
 
         for test_case in cls.test_cases:


### PR DESCRIPTION
Fixed bug in Vector2Raster, added unittest for testing the case of empty vector data (should return an empty mask)