### PR TITLE
Fixes bug when user tried to remove all features of one type.

### DIFF
--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -154,7 +154,7 @@ class RemoveFeature(EOTask):
         :return: input EOPatch without the specified feature
         :rtype: EOPatch
         """
-        for feature_type, feature_name in self.feature_gen(eopatch):
+        for feature_type, feature_name in list(self.feature_gen(eopatch)):
             if feature_name is ...:
                 eopatch.reset_feature_type(feature_type)
             else:

--- a/core/eolearn/tests/test_core_tasks.py
+++ b/core/eolearn/tests/test_core_tasks.py
@@ -87,15 +87,23 @@ class TestCoreTasks(unittest.TestCase):
         feature_name = 'CLOUD MASK'
         new_feature_name = 'CLM'
 
-        patch = AddFeature((FeatureType.MASK, feature_name))(self.patch, cloud_mask)
+        patch = copy.deepcopy(self.patch)
+
+        patch = AddFeature((FeatureType.MASK, feature_name))(patch, cloud_mask)
         self.assertTrue(np.array_equal(patch.mask[feature_name], cloud_mask), 'Feature was not added')
 
-        patch = RenameFeature((FeatureType.MASK, feature_name, new_feature_name))(self.patch)
+        patch = RenameFeature((FeatureType.MASK, feature_name, new_feature_name))(patch)
         self.assertTrue(np.array_equal(patch.mask[new_feature_name], cloud_mask), 'Feature was not renamed')
         self.assertFalse(feature_name in patch[FeatureType.MASK], 'Old feature still exists')
 
         patch = RemoveFeature((FeatureType.MASK, new_feature_name))(patch)
         self.assertFalse(feature_name in patch.mask, 'Feature was not removed')
+
+        patch = RemoveFeature(FeatureType.MASK_TIMELESS)(patch)
+        self.assertEqual(len(patch.mask_timeless), 0, 'mask_timeless features were not removed')
+
+        patch = RemoveFeature((FeatureType.MASK, ...))(patch)
+        self.assertEqual(len(patch.mask), 0, 'mask features were not removed')
 
     def test_duplicate_feature(self):
         mask_data = np.arange(10).reshape(5, 2, 1, 1)


### PR DESCRIPTION
Because iteration over features happened on dictionary, one got `RuntimeError: dictionary changed size during iteration` when trying to run `RemoveFeature((FeatureType.MASK, ...))`