### PR TITLE
Add orbit parameter to S1 input task

### DIFF
--- a/io/eolearn/io/sentinelhub_service.py
+++ b/io/eolearn/io/sentinelhub_service.py
@@ -300,17 +300,31 @@ class S2L2AWCSInput(SentinelHubWCSInput):
 class S1IWWMSInput(SentinelHubWMSInput):
     """
     Task for creating EOPatches and filling them with Sentinel-1 IW GRD data using Sentinel Hub's WMS request.
+
+    :param orbit: String specifying the orbit hte data belongs to. Options are `'both'`, `'ascending'` and
+        `'descending'`. Default is `'both'`
+    :type orbit: str
     """
-    def __init__(self, layer, **kwargs):
-        super().__init__(layer=layer, data_source=DataSource.SENTINEL1_IW, **kwargs)
+    def __init__(self, layer, orbit='both', **kwargs):
+        data_source = {'both': DataSource.SENTINEL1_IW,
+                       'ascending': DataSource.SENTINEL1_IW_ASC,
+                       'descending': DataSource.SENTINEL1_IW_DES}[orbit]
+        super().__init__(layer=layer, data_source=data_source, **kwargs)
 
 
 class S1IWWCSInput(SentinelHubWCSInput):
     """
     Task for creating EOPatches and filling them with Sentinel-1 IW GRD data using Sentinel Hub's WCS request.
+
+    :param orbit: String specifying the orbit hte data belongs to. Options are `'both'`, `'ascending'` and
+        `'descending'`. Default is `'both'`
+    :type orbit: str
     """
-    def __init__(self, layer, **kwargs):
-        super().__init__(layer=layer, data_source=DataSource.SENTINEL1_IW, **kwargs)
+    def __init__(self, layer, orbit='both', **kwargs):
+        data_source = {'both': DataSource.SENTINEL1_IW,
+                       'ascending': DataSource.SENTINEL1_IW_ASC,
+                       'descending': DataSource.SENTINEL1_IW_DES}[orbit]
+        super().__init__(layer=layer, data_source=data_source, **kwargs)
 
 
 class DEMWMSInput(SentinelHubWMSInput):

--- a/io/eolearn/tests/test_io.py
+++ b/io/eolearn/tests/test_io.py
@@ -47,12 +47,11 @@ class TestEOPatch(unittest.TestCase):
                 raise TypeError('Task {}: Argument \'eop\' should be an EOPatch, not {}'.format(
                     name, eop.__class__.__name__))
 
-
     @classmethod
     def setUpClass(cls):
 
         bbox = BBox(bbox=(-5.05, 48.0, -5.00, 48.05), crs=CRS.WGS84)
-        cls.time_interval = ('2017-6-1', '2017-6-14')
+        cls.time_interval = ('2017-7-1', '2017-7-14')
         cls.time_interval_datetime = (datetime.datetime(2017, 6, 1), datetime.datetime(2018, 6, 14))
         img_width = 100
         img_height = 100
@@ -142,7 +141,7 @@ class TestEOPatch(unittest.TestCase):
                 name='L8 L1C WMS',
                 layer='TRUE-COLOR-L8',
                 data_size=3,
-                timestamp_length=1,
+                timestamp_length=3,
                 request=L8L1CWMSInput(
                     layer='TRUE-COLOR-L8',
                     height=img_height,
@@ -158,9 +157,75 @@ class TestEOPatch(unittest.TestCase):
                 name='L8 L1C WCS',
                 layer='TRUE-COLOR-L8',
                 data_size=3,
-                timestamp_length=1,
+                timestamp_length=3,
                 request=L8L1CWCSInput(
                     layer='TRUE-COLOR-L8',
+                    resx=resx,
+                    resy=resy,
+                    instance_id=instance_id
+                ),
+                bbox=bbox,
+                time_interval=cls.time_interval,
+                eop=EOPatch()
+            ),
+
+            cls.TaskTestCase(
+                name='S1 IW WMS',
+                layer='TRUE-COLOR-S1-IW',
+                data_size=3,
+                timestamp_length=10,
+                request=S1IWWMSInput(
+                    layer='TRUE-COLOR-S1-IW',
+                    height=img_height,
+                    width=img_width,
+                    instance_id=instance_id
+                ),
+                bbox=bbox,
+                time_interval=cls.time_interval,
+                eop=EOPatch()
+            ),
+
+            cls.TaskTestCase(
+                name='S1 IW WCS',
+                layer='TRUE-COLOR-S1-IW',
+                data_size=3,
+                timestamp_length=10,
+                request=S1IWWCSInput(
+                    layer='TRUE-COLOR-S1-IW',
+                    resx=resx,
+                    resy=resy,
+                    instance_id=instance_id
+                ),
+                bbox=bbox,
+                time_interval=cls.time_interval,
+                eop=EOPatch()
+            ),
+
+            cls.TaskTestCase(
+                name='S1 IW WCS ascending orbit',
+                layer='TRUE-COLOR-S1-IW',
+                data_size=3,
+                timestamp_length=4,
+                request=S1IWWCSInput(
+                    layer='TRUE-COLOR-S1-IW',
+                    orbit='ascending',
+                    resx=resx,
+                    resy=resy,
+                    instance_id=instance_id
+                ),
+                bbox=bbox,
+                time_interval=cls.time_interval,
+                eop=EOPatch()
+            ),
+
+            cls.TaskTestCase(
+                name='S1 IW WCS descending orbit',
+                layer='TRUE-COLOR-S1-IW',
+                data_size=3,
+                timestamp_length=6,
+                request=S1IWWCSInput(
+                    layer='TRUE-COLOR-S1-IW',
+                    orbit='descending',
                     resx=resx,
                     resy=resy,
                     instance_id=instance_id
@@ -174,7 +239,7 @@ class TestEOPatch(unittest.TestCase):
                 name='S2 L2A WMS',
                 layer='BANDS-S2-L2A',
                 data_size=12,
-                timestamp_length=3,
+                timestamp_length=2,
                 request=S2L2AWMSInput(
                     layer='BANDS-S2-L2A',
                     height=img_height,
@@ -190,7 +255,7 @@ class TestEOPatch(unittest.TestCase):
                 name='S2 L2A WCS',
                 layer='BANDS-S2-L2A',
                 data_size=12,
-                timestamp_length=3,
+                timestamp_length=2,
                 request=S2L2AWCSInput(
                     layer='BANDS-S2-L2A',
                     resx=resx,


### PR DESCRIPTION
PR that adds an `orbit` parameter to the `S1IWWCSInput` and `S1IWWMSInput` tasks.

The parameter can have the following values:
 
 * `'both'`: (_default_) images from both ascending and descending orbit are queried and downloaded;
 * `'ascending'`: only images from ascending orbit direction are downloaded;
 * `'descending'`: only images from descending orbit direction are downloaded.

Unit-tests are added for S1 WMS, WCS requests, as well as for WCS requests with ascending and descending images only.