### PR TITLE
implemented 'per_value' train splitting

### DIFF
--- a/ml_tools/eolearn/ml_tools/train_test_split.py
+++ b/ml_tools/eolearn/ml_tools/train_test_split.py
@@ -4,7 +4,7 @@ Tasks used for train set preparation.
 from enum import Enum
 import numpy as np
 
-from eolearn.core import EOTask
+from eolearn.core import EOTask, FeatureType
 
 
 class TrainTestSplitType(Enum):
@@ -58,9 +58,10 @@ class TrainTestSplitTask(EOTask):
         :param split_type: Valye split type, either 'per_pixel', 'per_class' or 'per_value'.
         :type split_type: str
         :param ignore_values: A list of values to ignore and not assign them to any subsets.
-        :type ignore_values: a list of any valid numpy.dtype
+        :type ignore_values: a list of integers
         """
-        self.feature = next(self._parse_features(feature, new_names=True)())
+        allowed_types = [FeatureType.MASK_TIMELESS]
+        self.feature = next(self._parse_features(feature, new_names=True, allowed_feature_types=allowed_types)())
 
         if np.isscalar(bins):
             bins = [bins]

--- a/ml_tools/eolearn/ml_tools/train_test_split.py
+++ b/ml_tools/eolearn/ml_tools/train_test_split.py
@@ -1,17 +1,33 @@
 """
 Tasks used for train set preparation.
 """
+from enum import Enum
 import numpy as np
 
 from eolearn.core import EOTask
+
+
+class TrainTestSplitType(Enum):
+    """ An enum defining TrainTestSplitTask's methods of splitting the data into subsets
+    """
+    PER_PIXEL = 'per_pixel'
+    PER_CLASS = 'per_class'
+    PER_VALUE = 'per_value'
 
 
 class TrainTestSplitTask(EOTask):
     """ Randomly assign each or group of pixels to a train, test, and/or validation sets.
 
     The group of pixels is defined by an input feature (i.e. MASK_TIMELESS with polygon ids, or connected component id,
-    or similar that groups pixels with similar properties). By default pixels get assigned to a subset 'per_class'. If
-    split_type is set to 'random', then pixels get randomly assigned to a subset, regardless of their class.
+    or similar that groups pixels with similar properties). By default pixels get assigned to a subset
+    :attr:`PER_CLASS<eolearn.ml_tools.train_test_split.TrainTestSplitType.PER_CLASS>`, where pixels of the same class
+    will be assigned to the same subset. On the other hand if split_type is set to
+    :attr:`PER_PIXEL<eolearn.ml_tools.train_test_split.TrainTestSplitType.PER_PIXEL>`, each pixel gets randomly
+    assigned to a subset regardless of its class. The third option is splitting
+    :attr:`PER_VALUE<eolearn.ml_tools.train_test_split.TrainTestSplitType.PER_VALUE>`, where each class is assigned to
+    a certain subset consistently across eopatches. In other words, if a polyogn lies on multiple eopatches, it will
+    still be assigned to the same subset in all eopatches. In this case, the *seed* argument of the *execute* method
+    gets ignored.
 
     Classes are defined by a list of cumulative probabilities, passed as the *bins* argument, the same way as the *bins*
     argument in `numpy.digitize <https://docs.scipy.org/doc/numpy/reference/generated/numpy.digitize.html>`_. Valid
@@ -28,13 +44,13 @@ class TrainTestSplitTask(EOTask):
     have a value representing the train, test and/or validation set.
     """
 
-    def __init__(self, feature, bins, split_type='per_class', no_data_value=None):
+    def __init__(self, feature, bins, split_type=TrainTestSplitType.PER_CLASS, no_data_value=None):
         """
         :param feature: The input feature out of which to generate the train mask.
         :type feature: (FeatureType, feature_name, new_name)
         :param bins: Cumulative probabilities of all value classes or a single float, representing a fraction.
         :type bins: a float or list of floats
-        :param split_type: Valye split type, either 'per_class' or 'random'.
+        :param split_type: Valye split type, either 'per_class' or 'per_pixel'.
         :type split_type: str
         :param no_data_value: A value to ignore and not assign it to any subsets.
         :type no_data_value: any numpy.dtype
@@ -48,12 +64,9 @@ class TrainTestSplitTask(EOTask):
                 or np.any(np.diff(bins) <= 0) or bins[0] <= 0 or bins[-1] >= 1:
             raise ValueError('bins argument should be a list of ascending floats inside an open interval (0, 1)')
 
-        if split_type not in ['per_class', 'random']:
-            raise ValueError('Invalid split type.')
-
         self.bins = bins
         self.no_data_value = no_data_value
-        self.split_type = split_type
+        self.split_type = TrainTestSplitType(split_type)
 
     def execute(self, eopatch, *, seed=None):
         """
@@ -64,28 +77,25 @@ class TrainTestSplitTask(EOTask):
         :return: Input EOPatch with the train set mask.
         :rtype: EOPatch
         """
-        np.random.seed(seed)
+        if self.split_type in [TrainTestSplitType.PER_CLASS, TrainTestSplitType.PER_PIXEL]:
+            np.random.seed(seed)
 
         ftype, fname, new_name = self.feature
         data = eopatch[(ftype, fname)]
 
-        if self.split_type == 'per_class':
-            classes = set(np.unique(data)) - {self.no_data_value}
-
-            class_masks = (data == class_mask for class_mask in classes)
-            if self.no_data_value:
-                class_masks = (class_mask & (data != self.no_data_value) for class_mask in class_masks)
-
-            rands = np.random.rand(len(classes))
-            split = np.digitize(rands, self.bins) + 1
-            output_mask = np.zeros_like(data)
-
-            for class_mask, split_class in zip(class_masks, split):
-                output_mask[class_mask] = split_class
-
-        elif self.split_type == 'random':
+        if self.split_type == TrainTestSplitType.PER_PIXEL:
             rands = np.random.rand(*data.shape)
             output_mask = np.digitize(rands, self.bins) + 1
+        else:
+            classes = set(np.unique(data)) - {self.no_data_value}
+            output_mask = np.zeros_like(data)
+
+            for class_id in classes:
+                if self.split_type == TrainTestSplitType.PER_VALUE:
+                    np.random.seed(class_id)
+
+                fold = np.digitize(np.random.rand(), self.bins) + 1
+                output_mask[data == class_id] = fold
 
         eopatch[ftype][new_name] = output_mask
 


### PR DESCRIPTION
Implemented 'per_value' splitting, where class ids get assigned to the same subclasses across multiple eopatches.