### PR TITLE
Bugfix: eotask execution exceptions

### DIFF
--- a/core/eolearn/core/eotask.py
+++ b/core/eolearn/core/eotask.py
@@ -76,8 +76,10 @@ class EOTask(ABC):
 
         if caught_exception is not None:  # Exception is not raised in except statement to prevent duplicated traceback
             exception, traceback = caught_exception
-            raise type(exception)('During execution of task {}: {}'.format(self.__class__.__name__,
-                                                                           exception)).with_traceback(traceback)
+
+            exception = exception.with_traceback(traceback)
+            exception.errmsg = 'During execution of task {}: {}'.format(self.__class__.__name__, exception)
+            raise exception
 
         self.private_task_config.end_time = datetime.datetime.now()
         return return_value

--- a/core/eolearn/core/eotask.py
+++ b/core/eolearn/core/eotask.py
@@ -75,12 +75,14 @@ class EOTask(ABC):
         except BaseException as exception:
             exception, traceback = exception, sys.exc_info()[2]
 
-            # Some special exceptions don't accept error message as a parameter and a TypeError is raised in such case.
+            # Some special exceptions don't accept an error message as a parameter and raise a TypeError in such case.
             try:
                 errmsg = 'During execution of task {}: {}'.format(self.__class__.__name__, exception)
-                raise type(exception)(errmsg).with_traceback(traceback)
+                extended_exception = type(exception)(errmsg)
             except TypeError:
-                raise exception
+                extended_exception = exception
+
+            raise extended_exception.with_traceback(traceback)
 
     @abstractmethod
     def execute(self, *eopatches, **kwargs):

--- a/core/eolearn/tests/test_eotask.py
+++ b/core/eolearn/tests/test_eotask.py
@@ -76,16 +76,17 @@ class TestCompositeTask(unittest.TestCase):
         task = ExceptionTestingTask('test_exception')
         self.assertRaises(TestException, task, 'test')
 
-        task = ExceptionTestingTask('test_exception_fail')
-        self.assertRaises(TypeError, task, 'test')
-
-        task = ExceptionTestingTask('value_error')
-        self.assertRaises(ValueError, task, 'test')
-
         task = ExceptionTestingTask('success')
-
         self.assertEqual(task('test'), 'success test')
 
+        for parameter, exception_type in [('test_exception_fail', TypeError), ('value_error', ValueError)]:
+            task = ExceptionTestingTask(parameter)
+            self.assertRaises(exception_type, task, 'test')
+            try:
+                task('test')
+            except exception_type as exception:
+                message = str(exception)
+                self.assertTrue(message.startswith('During execution of task ExceptionTestingTask: '))
 
 if __name__ == '__main__':
     unittest.main()

--- a/core/eolearn/tests/test_eotask.py
+++ b/core/eolearn/tests/test_eotask.py
@@ -17,6 +17,34 @@ from eolearn.core import EOTask
 logging.basicConfig(level=logging.DEBUG)
 
 
+class TestException(BaseException):
+    def __init__(self, param1, param2):
+        # accept two parameters as opposed to BaseException, which just accepts one
+        super().__init__()
+        self.param1 = param1
+        self.param2 = param2
+
+
+class ExceptionTestingTask(EOTask):
+    def __init__(self, task_arg):
+        self.task_arg = task_arg
+
+    def execute(self, exec_param):
+        # try raising a subclassed exception
+        if self.task_arg == 'test_exception':
+            raise TestException(1, 2)
+
+        # try raising a failed subclassed exception (wrong exception init parameters)
+        if self.task_arg == 'test_exception_fail':
+            raise TestException
+
+        # raise some standard error
+        if self.task_arg == 'value_error':
+            raise ValueError
+
+        return self.task_arg + exec_param
+
+
 class TestEOTask(unittest.TestCase):
     class PlusOneTask(EOTask):
 
@@ -43,6 +71,21 @@ class TestCompositeTask(unittest.TestCase):
 
         for i in range(5):
             self.assertEqual(composite(i), 6 * i + 9)
+
+    def test_execution_handling(self):
+        task = ExceptionTestingTask('test_exception')
+        self.assertRaises(TestException, task, 'test')
+
+        task = ExceptionTestingTask('test_exception_fail')
+        self.assertRaises(TypeError, task, 'test')
+
+        task = ExceptionTestingTask('value_error')
+        self.assertRaises(ValueError, task, 'test')
+
+        task = ExceptionTestingTask('success')
+
+        self.assertEqual(task('test'), 'successtest')
+
 
 
 if __name__ == '__main__':

--- a/core/eolearn/tests/test_eotask.py
+++ b/core/eolearn/tests/test_eotask.py
@@ -30,19 +30,19 @@ class ExceptionTestingTask(EOTask):
         self.task_arg = task_arg
 
     def execute(self, exec_param):
-        # try raising a subclassed exception
+        # try raising a subclassed exception with an unsupported __init__ arguments signature
         if self.task_arg == 'test_exception':
             raise TestException(1, 2)
 
-        # try raising a failed subclassed exception (wrong exception init parameters)
+        # try raising a subclassed exception with an unsupported __init__ arguments signature without initializing it
         if self.task_arg == 'test_exception_fail':
             raise TestException
 
-        # raise some standard error
+        # raise one of the standard errors
         if self.task_arg == 'value_error':
-            raise ValueError
+            raise ValueError('Testing value error.')
 
-        return self.task_arg + exec_param
+        return self.task_arg + ' ' + exec_param
 
 
 class TestEOTask(unittest.TestCase):
@@ -84,8 +84,7 @@ class TestCompositeTask(unittest.TestCase):
 
         task = ExceptionTestingTask('success')
 
-        self.assertEqual(task('test'), 'successtest')
-
+        self.assertEqual(task('test'), 'success test')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
EOTask execution wasn't working properly for exceptions that didn't have the expected __init__ signature (accepting only errmsg parameter). When such an exception occurred it wasn't clear where exactly it happened, because another exception was raised when trying to instantiate such an exception. I fixed it by avoiding instantiation of a new object through type(exception)(...) and instead I just change the errmsg of the existing exception object.