### PR TITLE
Enable VectorToRaster tranform crs on the fly with a warning

### DIFF
--- a/geometry/eolearn/geometry/transformations.py
+++ b/geometry/eolearn/geometry/transformations.py
@@ -146,8 +146,9 @@ class VectorToRaster(EOTask):
             raise ValueError('Cannot recognize CRS of vector data')
         vector_data_crs = CRS(vector_data.crs['init'])
         if eopatch.bbox.crs is not vector_data_crs:
-            raise ValueError("Vector data and EOPatch should be in the same CRS, found '{}' and '{}'"
-                             "".format(eopatch.bbox.crs, vector_data_crs))
+            warnings.warn('Vector data is not in the same CRS as EOPatch, this task will re-project vector data for '
+                          'each execution', RuntimeWarning)
+            vector_data = vector_data.to_crs(epsg=eopatch.bbox.crs.epsg)
 
         bbox_poly = eopatch.bbox.geometry
         vector_data = vector_data[vector_data.geometry.intersects(bbox_poly)].copy(deep=True)

--- a/geometry/eolearn/tests/test_transformations.py
+++ b/geometry/eolearn/tests/test_transformations.py
@@ -53,6 +53,8 @@ class TestVectorToRaster(unittest.TestCase):
         custom_dataframe = EOPatch.load(cls.TestCase.TEST_PATCH_FILENAME).vector_timeless['LULC']
         custom_dataframe = custom_dataframe[(custom_dataframe['AREA'] < 10 ** 3)]
 
+        reprojected_dataframe = custom_dataframe.to_crs(epsg=3857)
+
         cls.test_cases = [
             cls.TestCase('basic test',
                          VectorToRaster(cls.vector_feature, cls.raster_feature, values_column='LULC_ID',
@@ -99,6 +101,13 @@ class TestVectorToRaster(unittest.TestCase):
                                         buffer=2,
                                         raster_shape=(FeatureType.DATA, 'BANDS-S2-L1C'), no_data_value=0),
                          img_min=0, img_max=8, img_mean=0.0664, img_median=0, img_dtype=np.uint8,
+                         img_shape=(101, 100, 1)),
+            cls.TestCase('different crs',
+                         VectorToRaster(vector_input=reprojected_dataframe,
+                                        raster_feature=cls.raster_feature,
+                                        values_column='LULC_ID',
+                                        raster_shape=(FeatureType.DATA, 'BANDS-S2-L1C'), no_data_value=0),
+                         img_min=0, img_max=8, img_mean=0.042079, img_median=0, img_dtype=np.uint8,
                          img_shape=(101, 100, 1)),
         ]
 


### PR DESCRIPTION
This fix can be merged now. 

Later I intend to add `ImportFromVector` and `ExportToVector` tasks which will implement a better way of transforming imported dataframe to different CRS.
