### PR TITLE
Bugfix/logging multithread

### DIFF
--- a/core/eolearn/core/eoexecution.py
+++ b/core/eolearn/core/eoexecution.py
@@ -171,7 +171,7 @@ class EOExecutor:
         stats[cls.STATS_END_TIME] = dt.datetime.now()
 
         if log_path:
-            logger.info(msg='Pipeline failed.' if cls.STATS_ERROR else 'Pipeline finished.')
+            logger.info(msg='Pipeline failed.' if cls.STATS_ERROR in stats else 'Pipeline finished.')
             handler.close()
             logger.removeHandler(handler)
 

--- a/core/eolearn/core/utilities.py
+++ b/core/eolearn/core/utilities.py
@@ -13,12 +13,27 @@ file in the root directory of this source tree.
 
 import logging
 from collections import OrderedDict
+from logging import Filter
 
 import numpy as np
 
 from .constants import FeatureType
 
 LOGGER = logging.getLogger(__name__)
+
+
+class LogFileFilter(Filter):
+    """ Filters log messages passed to log file
+    """
+
+    def __init__(self, thread_name, name=''):
+        self.thread_name = thread_name
+        super().__init__(name=name)
+
+    def filter(self, record):
+        """ Shows everything from the thread that it was initialized in.
+        """
+        return record.threadName == self.thread_name
 
 
 class FeatureParser:

--- a/core/eolearn/core/utilities.py
+++ b/core/eolearn/core/utilities.py
@@ -26,9 +26,9 @@ class LogFileFilter(Filter):
     """ Filters log messages passed to log file
     """
 
-    def __init__(self, thread_name, name=''):
+    def __init__(self, thread_name, *args, **kwargs):
         self.thread_name = thread_name
-        super().__init__(name=name)
+        super().__init__(*args, **kwargs)
 
     def filter(self, record):
         """ Shows everything from the thread that it was initialized in.

--- a/core/eolearn/tests/test_eoexecutor.py
+++ b/core/eolearn/tests/test_eoexecutor.py
@@ -73,6 +73,44 @@ class TestEOExecutor(unittest.TestCase):
                     for name, log_filename in zip(execution_names, log_filenames):
                         self.assertTrue(log_filename == 'eoexecution-{}.log'.format(name))
 
+    def test_execution_logs_multiprocess(self):
+        for execution_names in [None, [4, 'x', 'y', 'z']]:
+            with tempfile.TemporaryDirectory() as tmp_dir_name:
+                executor = EOExecutor(self.workflow, self.execution_args, save_logs=True,
+                                      logs_folder=tmp_dir_name,
+                                      execution_names=execution_names)
+                executor.run(workers=3, multiprocess=True)
+
+                self.assertEqual(len(executor.execution_logs), 4)
+                for log in executor.execution_logs:
+                    self.assertTrue(len(log.split()) >= 3)
+
+                log_filenames = sorted(os.listdir(executor.report_folder))
+                self.assertEqual(len(log_filenames), 4)
+
+                if execution_names:
+                    for name, log_filename in zip(execution_names, log_filenames):
+                        self.assertTrue(log_filename == 'eoexecution-{}.log'.format(name))
+
+    def test_execution_logs_multithread(self):
+        for execution_names in [None, [4, 'x', 'y', 'z']]:
+            with tempfile.TemporaryDirectory() as tmp_dir_name:
+                executor = EOExecutor(self.workflow, self.execution_args, save_logs=True,
+                                      logs_folder=tmp_dir_name,
+                                      execution_names=execution_names)
+                executor.run(workers=3, multiprocess=False)
+
+                self.assertEqual(len(executor.execution_logs), 4)
+                for log in executor.execution_logs:
+                    self.assertTrue(len(log.split()) >= 3)
+
+                log_filenames = sorted(os.listdir(executor.report_folder))
+                self.assertEqual(len(log_filenames), 4)
+
+                if execution_names:
+                    for name, log_filename in zip(execution_names, log_filenames):
+                        self.assertTrue(log_filename == 'eoexecution-{}.log'.format(name))
+
     def test_execution_stats(self):
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             executor = EOExecutor(self.workflow, self.execution_args, logs_folder=tmp_dir_name)


### PR DESCRIPTION
When running in multithreading mode, the log files for single eopatches
would also log the information for the eopatches running in different
threads. Adding the filter that filters messages based on the
thread name fixes this problem.
In addition, a message 'Pipeline finished.' or 'Pipeline failed.' is written to the end of every log file depending on the successful execution. 