### PR TITLE
Fix bug that occurs when checking/creating folders with multiple workers

### DIFF
--- a/io/eolearn/io/local_io.py
+++ b/io/eolearn/io/local_io.py
@@ -62,7 +62,7 @@ class BaseLocalIo(EOTask):
         if create_dir:
             path_dir = os.path.dirname(path)
             if path_dir != '' and not os.path.exists(path_dir):
-                os.makedirs(path_dir)
+                os.makedirs(path_dir, exist_ok=True)
 
         return path
 


### PR DESCRIPTION
When running with multiple workers enabled, it can happen that
the folder is created by  another worker between checking for
folder existence and creating new folder. **If **exists_ok** is set to **False**
the application will return an error.**


This fix changes the __get_file_path_ function so that it does not throw
and error if a folder that we are creating already exists.