### PR TITLE
ExportToTiff now logs warning and finishes instead of failing.

### DIFF
--- a/io/eolearn/io/local_io.py
+++ b/io/eolearn/io/local_io.py
@@ -14,6 +14,7 @@ file in the root directory of this source tree.
 
 import os
 import datetime
+import logging
 import warnings
 from abc import abstractmethod
 
@@ -24,6 +25,8 @@ import numpy as np
 from sentinelhub import CRS, BBox
 
 from eolearn.core import EOTask, EOPatch
+
+LOGGER = logging.getLogger(__name__)
 
 
 class BaseLocalIo(EOTask):
@@ -161,7 +164,12 @@ class ExportToTiff(BaseLocalIo):
         :return: Unchanged input EOPatch
         :rtype: EOPatch
         """
-        feature_type, feature_name = next(self.feature(eopatch))
+        try:
+            feature_type, feature_name = next(self.feature(eopatch))
+        except ValueError as e:
+            LOGGER.warning(e)
+            return eopatch
+
         array = eopatch[feature_type][feature_name]
 
         array_sub = self._get_bands_subset(array)

--- a/io/eolearn/io/local_io.py
+++ b/io/eolearn/io/local_io.py
@@ -166,8 +166,8 @@ class ExportToTiff(BaseLocalIo):
         """
         try:
             feature_type, feature_name = next(self.feature(eopatch))
-        except ValueError as e:
-            LOGGER.warning(e)
+        except ValueError as error:
+            LOGGER.warning(error)
             return eopatch
 
         array = eopatch[feature_type][feature_name]

--- a/io/eolearn/tests/test_local_io.py
+++ b/io/eolearn/tests/test_local_io.py
@@ -159,7 +159,7 @@ class TestExportAndImportTiff(unittest.TestCase):
 
             export_task = ExportToTiff(feature, folder=tmp_dir_name)
             export_task.execute(self.eopatch, filename=tmp_file_name)
-            mocked_logger.assert_called_once()
+            assert mocked_logger.call_count == 1
             val_err_tup, _ = mocked_logger.call_args
             val_err, = val_err_tup
             assert str(val_err) == 'Feature feature-not-present of type FeatureType.MASK_TIMELESS ' \

--- a/io/eolearn/tests/test_local_io.py
+++ b/io/eolearn/tests/test_local_io.py
@@ -12,9 +12,9 @@ file in the root directory of this source tree.
 
 import os
 import unittest
+from unittest.mock import patch
 import logging
 import tempfile
-
 import numpy as np
 
 from sentinelhub import read_data
@@ -149,6 +149,21 @@ class TestExportAndImportTiff(unittest.TestCase):
                 task = ExportToTiff((FeatureType.DATA, 'data'), folder=tmp_dir_name,
                                     band_indices=bands, date_indices=times, image_dtype=data.dtype)
                 task.execute(self.eopatch, filename=tmp_file_name)
+
+    @patch('logging.Logger.warning')
+    def test_export2tiff_wrong_feature(self, mocked_logger):
+
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            tmp_file_name = 'temp_file.tiff'
+            feature = FeatureType.MASK_TIMELESS, 'feature-not-present'
+
+            export_task = ExportToTiff(feature, folder=tmp_dir_name)
+            export_task.execute(self.eopatch, filename=tmp_file_name)
+            mocked_logger.assert_called_once()
+            val_err_tup, _ = mocked_logger.call_args
+            val_err, = val_err_tup
+            assert str(val_err) == 'Feature feature-not-present of type FeatureType.MASK_TIMELESS ' \
+                                   'was not found in EOPatch'
 
 
 class TestImportTiff(unittest.TestCase):


### PR DESCRIPTION
If the _ExportToTiff_ task is requested to create a map for a feature
that is not present in the EOPatch it will exit without an error and
log a warning message instead of exiting with an exception.

This is useful for workflows where we want to export multiple features
over a set of EOPatches. In the previous version the workflow would
fail and stop processing other features once it encountered one that
was not present in the EOPatch. This fix changes the behaviour so that
encountering a missing feature does not stop the execution for that
eopatch.