### PR TITLE
fix in case multiprocessing lock cannot be initialized

### DIFF
--- a/core/eolearn/core/eoexecution.py
+++ b/core/eolearn/core/eoexecution.py
@@ -30,7 +30,10 @@ from .utilities import LogFileFilter
 
 LOGGER = logging.getLogger(__name__)
 
-MULTIPROCESSING_LOCK = multiprocessing.Manager().Lock()
+try:
+    MULTIPROCESSING_LOCK = multiprocessing.Manager().Lock()
+except BaseException:
+    MULTIPROCESSING_LOCK = None
 
 
 class EOExecutor:
@@ -283,7 +286,7 @@ def execute_with_mp_lock(execution_function, *args, **kwargs):
     :param kwargs: Function's keyword arguments
     :return: Function's results
     """
-    if multiprocessing.current_process().name == 'MainProcess':
+    if multiprocessing.current_process().name == 'MainProcess' or MULTIPROCESSING_LOCK is None:
         return execution_function(*args, **kwargs)
 
     with MULTIPROCESSING_LOCK:


### PR DESCRIPTION
A minor fix on multiprocessing lock. The previous version of the code prevented running eo-learn with `dask.distributed`.