### PR TITLE
Bugfix/fs eopatch dir

### DIFF
--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -499,7 +499,7 @@ class EOPatch:
         :type filesystem: fs.FS or None
         """
         if filesystem is None:
-            filesystem = get_filesystem(path)
+            filesystem = get_filesystem(path, create=True)
             path = '/'
 
         save_eopatch(self, filesystem, path, features=features, compress_level=compress_level,
@@ -522,7 +522,7 @@ class EOPatch:
         :rtype: EOPatch
         """
         if filesystem is None:
-            filesystem = get_filesystem(path)
+            filesystem = get_filesystem(path, create=False)
             path = '/'
 
         return load_eopatch(EOPatch(), filesystem, path, features=features, lazy_loading=lazy_loading)

--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -60,7 +60,8 @@ def save_eopatch(eopatch, filesystem, patch_location, features=..., overwrite_pe
                          compress_level) for ftype, fname, path in eopatch_features)
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        executor.map(lambda params: params[0].save(*params[1:]), features_to_save)
+        # Note: The following is intentionally wrapped in a list in order to get back potential exceptions
+        list(executor.map(lambda params: params[0].save(*params[1:]), features_to_save))
 
 
 def load_eopatch(eopatch, filesystem, patch_location, features=..., lazy_loading=False):

--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -60,7 +60,7 @@ def save_eopatch(eopatch, filesystem, patch_location, features=..., overwrite_pe
                          compress_level) for ftype, fname, path in eopatch_features)
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        # Note: The following is intentionally wrapped in a list in order to get back potential exceptions
+        # The following is intentionally wrapped in a list in order to get back potential exceptions
         list(executor.map(lambda params: params[0].save(*params[1:]), features_to_save))
 
 

--- a/core/eolearn/core/fs_utils.py
+++ b/core/eolearn/core/fs_utils.py
@@ -14,7 +14,7 @@ from fs_s3fs import S3FS
 from sentinelhub import SHConfig
 
 
-def get_filesystem(path, create=True, **kwargs):
+def get_filesystem(path, create=False, **kwargs):
     """ A utility function for initializing any type of filesystem object with PyFilesystem2 package
 
     :param path: A filesystem path


### PR DESCRIPTION
The following fixes 2 bugs:
- Loading from a non-existing location doesn't create empty folders anymore.
- If the saving of EOPatch features fails an error gets passed forward from `fs`.
