### PR TITLE
Bugfix/workflow task name handling

### DIFF
--- a/core/eolearn/core/eoworkflow.py
+++ b/core/eolearn/core/eoworkflow.py
@@ -327,7 +327,7 @@ class LinearWorkflow(EOWorkflow):
         tasks = [self._parse_task(task) for task in tasks]
         tasks = self._make_tasks_unique(tasks)
 
-        dependencies = [(task, [tasks[idx - 1][0]] if idx > 0 else []) for idx, (task, name) in enumerate(tasks)]
+        dependencies = [(task, [tasks[idx - 1][0]] if idx > 0 else [], name) for idx, (task, name) in enumerate(tasks)]
         super().__init__(dependencies, **kwargs)
 
     @staticmethod

--- a/core/eolearn/core/eoworkflow.py
+++ b/core/eolearn/core/eoworkflow.py
@@ -268,14 +268,25 @@ class EOWorkflow:
         """ Returns an ordered dictionary {task_name: task} of all tasks within this workflow
 
         :return: Ordered dictionary with key being task_name (str) and an instance of a corresponding task from this
-        workflow
+            workflow
         :rtype: OrderedDict
         """
-        tasks = collections.OrderedDict()
+        task_dict = collections.OrderedDict()
         for dep in self.ordered_dependencies:
-            tasks[dep.name] = dep.task
+            task_name = dep.name
 
-        return tasks
+            if task_name in task_dict:
+                new_task_name = task_name
+                count = 0
+                while new_task_name in task_dict:
+                    count += 1
+                    new_task_name = '{}({})'.format(task_name, count)
+
+                task_name = new_task_name
+
+            task_dict[task_name] = dep.task
+
+        return task_dict
 
     def get_dot(self):
         """ Generates the DOT description of the underlying computational graph

--- a/core/eolearn/core/eoworkflow.py
+++ b/core/eolearn/core/eoworkflow.py
@@ -268,7 +268,7 @@ class EOWorkflow:
         """ Returns an ordered dictionary {task_name: task} of all tasks within this workflow
 
         :return: Ordered dictionary with key being task_name (str) and an instance of a corresponding task from this
-            workflow
+            workflow. The order of tasks is the same as in which they will be executed.
         :rtype: OrderedDict
         """
         task_dict = collections.OrderedDict()

--- a/core/eolearn/core/eoworkflow.py
+++ b/core/eolearn/core/eoworkflow.py
@@ -276,13 +276,11 @@ class EOWorkflow:
             task_name = dep.name
 
             if task_name in task_dict:
-                new_task_name = task_name
                 count = 0
-                while new_task_name in task_dict:
+                while dep.get_custom_name(count) in task_dict:
                     count += 1
-                    new_task_name = '{}({})'.format(task_name, count)
 
-                task_name = new_task_name
+                task_name = dep.get_custom_name(count)
 
             task_dict[task_name] = dep.task
 
@@ -406,6 +404,13 @@ class Dependency:
         """ Sets a new name
         """
         self.name = name
+
+    def get_custom_name(self, number=0):
+        """ Provides custom task name according to given number. E.g. FooTask -> FooTask
+        """
+        if number:
+            return '{}_{}'.format(self.name, number)
+        return self.name
 
 
 class WorkflowResults(collections.Mapping):

--- a/core/eolearn/tests/test_eoworkflow.py
+++ b/core/eolearn/tests/test_eoworkflow.py
@@ -128,7 +128,7 @@ class TestEOWorkflow(unittest.TestCase):
         in_task = InputTask()
         inc_task = Inc()
 
-        task_names = ['InputTask', 'Inc', 'Inc(1)', 'Inc(2)']
+        task_names = ['InputTask', 'Inc', 'Inc_1', 'Inc_2']
         eow = LinearWorkflow(in_task, inc_task, inc_task, inc_task)
 
         returned_tasks = eow.get_tasks()

--- a/core/eolearn/tests/test_eoworkflow.py
+++ b/core/eolearn/tests/test_eoworkflow.py
@@ -127,35 +127,29 @@ class TestEOWorkflow(unittest.TestCase):
     def test_get_tasks(self):
         in_task = InputTask()
         inc_task = Inc()
-        pow_task = Pow()
 
-        task_names = ['InputTask', 'Inc', 'Pow']
-        workflow_tasks = [in_task, inc_task, pow_task]
-        eow = LinearWorkflow(*workflow_tasks)
+        task_names = ['InputTask', 'Inc', 'Inc(1)', 'Inc(2)']
+        eow = LinearWorkflow(in_task, inc_task, inc_task, inc_task)
 
         returned_tasks = eow.get_tasks()
 
         # check if tasks are present
-        for task_name in task_names:
-            self.assertIn(task_name, returned_tasks.keys())
+        self.assertEqual(sorted(task_names), sorted(returned_tasks))
 
         # check if tasks still work
         arguments_dict = {
             in_task: {'val': 2},
-            inc_task: {'d': 2},
-            pow_task: {'n': 3}
+            inc_task: {'d': 2}
         }
 
         res_workflow = eow.execute(arguments_dict)
-        res_workflow_value = [res_workflow[key] for key in res_workflow.keys()][0]
+        res_workflow_value = list(res_workflow.values())
 
-        for idx, task in enumerate(workflow_tasks):
-            if idx == 0:
-                res_tasks_value = task.execute(**arguments_dict[task])
-            else:
-                res_tasks_value = task.execute(res_tasks_value, **arguments_dict[task])
+        res_tasks_values = []
+        for idx, task in enumerate(returned_tasks.values()):
+            res_tasks_values = [task.execute(*res_tasks_values, **arguments_dict.get(task, {}))]
 
-        self.assertEqual(res_workflow_value, res_tasks_value)
+        self.assertEqual(res_workflow_value, res_tasks_values)
 
     def test_trivial_workflow(self):
         task = DummyTask()

--- a/core/eolearn/tests/test_eoworkflow.py
+++ b/core/eolearn/tests/test_eoworkflow.py
@@ -108,15 +108,21 @@ class TestEOWorkflow(unittest.TestCase):
 
     def test_linear_workflow(self):
         in_task = InputTask()
+        in_task_name = 'My input task'
         inc_task = Inc()
         pow_task = Pow()
-        eow = LinearWorkflow((in_task, 'task name'), inc_task, inc_task, pow_task)
+        eow = LinearWorkflow((in_task, in_task_name), inc_task, inc_task, pow_task)
         res = eow.execute({
             in_task: {'val': 2},
             inc_task: {'d': 2},  # Note that this will assign value only to one instance of Inc task
             pow_task: {'n': 3}
         })
         self.assertEqual(res[pow_task], (2 + 2 + 1) ** 3)
+
+        task_map = eow.get_tasks()
+        self.assertTrue(in_task_name in task_map, "A task with name '{}' should be amongst tasks".format(in_task_name))
+        self.assertEqual(task_map[in_task_name], in_task,
+                         "A task with name '{}' should map into {}".format(in_task_name, in_task))
 
     def test_get_tasks(self):
         in_task = InputTask()

--- a/visualization/eolearn/visualization/eoworkflow_visualization.py
+++ b/visualization/eolearn/visualization/eoworkflow_visualization.py
@@ -73,11 +73,7 @@ class EOWorkflowVisualization:
 
         dep_to_dot_name = {}
         for dot_name, deps in dot_name_to_deps.items():
-            if len(deps) == 1:
-                dep_to_dot_name[deps[0]] = dot_name
-                continue
-
             for idx, dep in enumerate(deps):
-                dep_to_dot_name[dep] = dot_name + str(idx)
+                dep_to_dot_name[dep] = dep.get_custom_name(idx)
 
         return dep_to_dot_name


### PR DESCRIPTION
This PR fixes 2 bugs regarding how EOTask names are handled in EOWorkflows.