### PR TITLE
changing dtype of DEM

### DIFF
--- a/io/eolearn/io/processing_api.py
+++ b/io/eolearn/io/processing_api.py
@@ -369,7 +369,7 @@ class SentinelHubDemTask(SentinelHubInputBase):
                     output:{
                         id: "default",
                         bands: 1,
-                        sampleType: SampleType.UINT16
+                        sampleType: SampleType.FLOAT32
                     }
                 }
             }

--- a/io/eolearn/io/processing_api.py
+++ b/io/eolearn/io/processing_api.py
@@ -394,4 +394,4 @@ class SentinelHubDemTask(SentinelHubInputBase):
         """
         tif = images[0]['default.tif']
 
-        eopatch[self.dem_feature] = tif[..., np.newaxis].astype(np.int16)
+        eopatch[self.dem_feature] = tif[..., np.newaxis].astype(np.float32)


### PR DESCRIPTION
Based on the documentation [here](https://docs.sentinel-hub.com/api/latest/#/data/DEM?id=dataset-specific-constraints), the suggested `dtype` of DEM is `float32`, due to possible negative values that can occur. 

Since this is `data_timeless`, I guess it's not such a problem to have it as `float32`?