### PR TITLE
Bugfix: added evalscript version

### DIFF
--- a/io/eolearn/io/processing_api.py
+++ b/io/eolearn/io/processing_api.py
@@ -206,6 +206,8 @@ class SentinelHubInputTask(SentinelHubInputBase):
         """ Generate the evalscript to be passed with the request, based on chosen bands
         """
         evalscript = """
+            //VERSION=3
+
             function setup() {{
                 return {{
                     input: [{{
@@ -363,6 +365,8 @@ class SentinelHubDemTask(SentinelHubInputBase):
         """ Build payloads for the requests to the service
         """
         evalscript = """
+            //VERSION=3
+
             function setup() {
                 return {
                     input: ["DEM"],


### PR DESCRIPTION
Sentinel-hub service has recently been updated and now `eo-learn`'s Processing API requests fail, because they didn't include evalscript version.

In this PR, evalscript version is added.