### PR TITLE
masking.MaskFeature: distinguish between MASK and MASK_TIMELESS FeatureTypes

### DIFF
--- a/mask/eolearn/mask/masking.py
+++ b/mask/eolearn/mask/masking.py
@@ -88,8 +88,15 @@ class MaskFeature(EOTask):
         if not isinstance(self.mask_values, list):
             raise ValueError('Incorrect format or values of argument `mask_values`')
 
-        for value in self.mask_values:
-            data[mask.squeeze() == value] = self.no_data_value
+        if mask_feature_type == FeatureType.MASK_TIMELESS:
+            for value in self.mask_values:
+                data[:, mask.squeeze() == value, :] = self.no_data_value
+        elif mask_feature_type == FeatureType.MASK:
+            for value in self.mask_values:
+                #data[mask.squeeze() == value] = self.no_data_value
+                data[mask == value] = self.no_data_value
+        else:
+            raise NotImplementedError
 
         eopatch.add_feature(feature_type, new_feature_name, data)
 


### PR DESCRIPTION
This PR is a start at dealing with IndexErrors that can occur when using masking.MaskFeature.

Example EOPatch (snipped for brevity):

```python
EOPatch(
  data: {
    B4: numpy.ndarray(shape=(1, 7991, 8491, 1), dtype=uint8)
  }
  mask: {
    CLOUD: numpy.ndarray(shape=(1, 7991, 8491, 1), dtype=uint8)
  }
  mask_timeless: {
    PR_MASK: numpy.ndarray(shape=(7991, 8491, 1), dtype=uint8)
  }
  bbox: BBox(((376785.0, 7305885.0), (631515.0, 7545615.0)), crs=CRS('32623'))
  timestamp: []
)
```

Apply the mask_timeless->PR_MASK' to data->B4:

```python
eo_task = masking.MaskFeature(
    (FeatureType.DATA, 'B4', 'B4_CROP'), 
    (FeatureType.MASK_TIMELESS, 'PR_MASK'), 
    [0,], no_data_value=-1)
patch = eo_task.execute(task)
```
This returns an IndexError:

> IndexError: During execution of task MaskFeature: boolean index did not match indexed array along dimension 0; dimension is 1 but corresponding boolean dimension is 7991

The proposed bug fix changes function behaviour to distinguish between MASK and MASK_TIMELESS types. 

There may be other edge cases where this causes a problem. I'm rather new to eo-learn so would appreciate input on this.