### PR TITLE
Bug with processing Api and no global config.json set up

### DIFF
--- a/core/eolearn/core/eoworkflow.py
+++ b/core/eolearn/core/eoworkflow.py
@@ -101,7 +101,7 @@ class EOWorkflow:
             if task.private_task_config.uuid in uuid_dict:
                 raise ValueError('EOWorkflow cannot execute the same instance of EOTask multiple times')
 
-            task.private_task_config.uuid = self.id_gen.next()
+            task.private_task_config.uuid = self.id_gen.get_next()
             uuid_dict[task.private_task_config.uuid] = dep
 
         return uuid_dict
@@ -501,7 +501,7 @@ class _UniqueIdGenerator:
                 self.uuids.add(uid)
                 return uid
 
-    def next(self):
+    def get_next(self):
         """ Generates an ID
         """
         return self._next().hex

--- a/core/eolearn/tests/test_eoworkflow.py
+++ b/core/eolearn/tests/test_eoworkflow.py
@@ -212,10 +212,10 @@ class TestUniqueIdGenerator(unittest.TestCase):
 
         id_gen = _UniqueIdGenerator()
         for _ in range(_UniqueIdGenerator.MAX_UUIDS):
-            id_gen.next()
+            id_gen.get_next()
 
         with self.assertRaises(MemoryError):
-            id_gen.next()
+            id_gen.get_next()
 
 
 if __name__ == '__main__':

--- a/io/eolearn/io/processing_api.py
+++ b/io/eolearn/io/processing_api.py
@@ -300,7 +300,7 @@ class SentinelHubInputTask(SentinelHubInputBase):
             return [time_interval[0]]
 
         wfs = WebFeatureService(
-            bbox=bbox, time_interval=time_interval, data_source=self.data_source, maxcc=self.maxcc
+            bbox=bbox, time_interval=time_interval, data_source=self.data_source, maxcc=self.maxcc, config=self.config
         )
 
         dates = wfs.get_dates()


### PR DESCRIPTION
Fixes 'Instance ID is not set.' when using SentinelHubInputTask without having global config.json set up

Minimal (non-working) example:
On fresh install of eolearn (e.g. pip install eo-learn), without setting up config.json with all parameters, it should be possible to use processing api with code like this:

```python
import datetime

from eolearn.core import FeatureType
from eolearn.io import SentinelHubInputTask

from sentinelhub import CRS, BBox, DataSource, SHConfig

if __name__ == '__main__':

    bbox = BBox(bbox=[268892, 4624365, 269892, 4625365], crs=CRS.UTM_33N)
    time_interval = ('2017-12-15', '2018-1-30')

    config = SHConfig()
    config.sh_client_id = '...'
    config.sh_client_secret = '...'
    config.instance_id = '...'

    task = SentinelHubInputTask(
        size=(100, 100),
        bands_feature=(FeatureType.DATA, 'test_feature'),
        additional_data=[(FeatureType.MASK, 'dataMask'), (FeatureType.DATA, 'SCL')],
        maxcc=0.8,
        time_difference=datetime.timedelta(minutes=120),
        data_source=DataSource.SENTINEL2_L2A,
        max_threads=3,
        config=config
    )

    eopatch_proc = task.execute(bbox=bbox, time_interval=time_interval)

```

Unfortunately, such code produces error:
```bash
Traceback (most recent call last):
  File "test_ProcessingApi.py", line 29, in <module>
    eopatch_proc = task.execute(bbox=bbox, time_interval=time_interval)
  File "/Users/batic/.pyenv/versions/eolearn-test/lib/python3.7/site-packages/eolearn/io/processing_api.py", line 67, in execute
    timestamp = self._get_timestamp(time_interval, bbox)
  File "/Users/batic/.pyenv/versions/eolearn-test/lib/python3.7/site-packages/eolearn/io/processing_api.py", line 303, in _get_timestamp
    bbox=bbox, time_interval=time_interval, data_source=self.data_source, maxcc=self.maxcc
  File "/Users/batic/.pyenv/versions/eolearn-test/lib/python3.7/site-packages/sentinelhub/ogc.py", line 369, in __init__
    super().__init__(**kwargs)
  File "/Users/batic/.pyenv/versions/eolearn-test/lib/python3.7/site-packages/sentinelhub/ogc.py", line 33, in __init__
    raise ValueError('Instance ID is not set. '
ValueError: Instance ID is not set. Set it either in request initialization or in configuration file. Check http://sentinelhub-py.readthedocs.io/en/latest/configure.html for more info.
```

Passing the config to WFS call inside SentinelHubInputTask fixes this.