### PR TITLE
Docs/m2r fix

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
 
 python:
   version: 3.7

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,10 @@
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
 python:
   version: 3.7
 
 conda:
-  file: docs/environment.yml
+  environment: docs/environment.yml

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,11 +4,11 @@ channels:
 dependencies:
 - cartopy=0.17.0
 - pip:
-  - Sphinx==2.4.4
+  - Sphinx
   - sphinx-rtd-theme
   - nbsphinx
   - ipython
-  - m2r>=0.2.0
+  - git+https://github.com/CrossNox/m2r@dev
 
   - ./../core
   - ./../coregistration

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - sphinx-rtd-theme
   - nbsphinx
   - ipython
-  - git+https://github.com/CrossNox/m2r@dev
+  - git+https://github.com/AleksMat/m2r@dev
 
   - ./../core
   - ./../coregistration

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,8 +1,8 @@
-Sphinx==2.4.4
+Sphinx
 sphinx-rtd-theme
 nbsphinx
 ipython
-m2r>=0.2.0
+git+https://github.com/CrossNox/m2r@dev
 
 -e ./core
 -e ./coregistration

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,7 +2,7 @@ Sphinx
 sphinx-rtd-theme
 nbsphinx
 ipython
-git+https://github.com/CrossNox/m2r@dev
+git+https://github.com/AleksMat/m2r@dev
 
 -e ./core
 -e ./coregistration


### PR DESCRIPTION
I tried a few different options and this was the only one that worked:

Package `m2r` is outdated but also essential for our build. Therefore I replaced it with my fork of a fork that fixes issues in `m2r`. The solution is not optimal but it should hold until newer versions of Sphinx don't break `m2r` again.

I also updated `.readthedocs.yml` file to version 2 of their style.