### PR TITLE
Added subset of stream-temporal features from D4.6

### DIFF
--- a/features/eolearn/features/__init__.py
+++ b/features/eolearn/features/__init__.py
@@ -3,7 +3,7 @@ A collection of EOTasks for feature manipulation
 """
 
 from .temporal_features import AddSpatioTemporalFeaturesTask, AddMaxMinTemporalIndicesTask, \
-    AddMaxMinNDVISlopeIndicesTask
+    AddMaxMinNDVISlopeIndicesTask, TemporalRollingWindowTask, SurfaceExtractionTask, MaxMeanLenTask
 from .interpolation import InterpolationTask, LinearInterpolation, CubicInterpolation, SplineInterpolation, \
     BSplineInterpolation, AkimaInterpolation, ResamplingTask, NearestResampling, LinearResampling, CubicResampling, \
     KrigingInterpolation, LegacyInterpolation


### PR DESCRIPTION
Added a subset of the stream-temporal feature extraction task from D4.6.

Surface and derivative-based features are split into two smaller eotasks. 
`TemporalRollingWindowTask` is also included as it generalizes calculation of features over time based rolling window