### PR TITLE
Fixed value fillout bug

### DIFF
--- a/features/eolearn/tests/test_feature_manipulation.py
+++ b/features/eolearn/tests/test_feature_manipulation.py
@@ -53,6 +53,29 @@ class TestFeatureManipulation(unittest.TestCase):
         self.assertEqual(new_interval, updated_interval)
         self.assertEqual(new_timestamps, updated_timestamps)
 
+    def test_fill(self):
+        array = np.array([[np.NaN]*4 + [1., 2., 3., 4.] + [np.NaN]*3,
+                          [1., np.NaN, np.NaN, 2., 3., np.NaN, np.NaN, np.NaN, 4., np.NaN, 5.]])
+
+        array_ffill = ValueFilloutTask.fill(array, operation='f')
+        array_bfill = ValueFilloutTask.fill(array, operation='b')
+        array_fbfill = ValueFilloutTask.fill(array_ffill, operation='b')
+
+        self.assertTrue(np.array_equal(array_ffill,
+                                       np.array([[np.NaN]*4 + [1., 2., 3., 4., 4., 4., 4.],
+                                                 [1., 1., 1., 2., 3., 3., 3., 3., 4., 4., 5.]]),
+                                       equal_nan=True))
+
+        self.assertTrue(np.array_equal(array_bfill,
+                                       np.array([[1., 1., 1., 1., 1., 2., 3., 4.] + [np.NaN]*3,
+                                                 [1., 2., 2., 2., 3., 4., 4., 4., 4., 5., 5.]]),
+                                       equal_nan=True))
+
+        self.assertTrue(np.array_equal(array_fbfill,
+                                       np.array([[1., 1., 1., 1., 1., 2., 3., 4., 4., 4., 4.],
+                                                 [1., 1., 1., 2., 3., 3., 3., 3., 4., 4., 5.]]),
+                                       equal_nan=True))
+
     def test_value_fillout(self):
         feature = (FeatureType.DATA, 'TEST')
         shape = (8, 10, 10, 5)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ scikit-image>=0.14.1
 nbval
 attrs>=19.2.0
 moto
+numpy>=1.19.0


### PR DESCRIPTION
[This line](https://github.com/sentinel-hub/eo-learn/commit/4ad7bba060825c1047095885d420e296a5772e09#diff-43f01a19420680c6833c66a1a7366d22R165) in `ValueFilloutTask` contains a typo (the axis is wrong and `1` is added instead of subtracted), which causes problems in fillout in the backward direction. The result of chaining forward and backward fillout may also be corrupted by the latter operation.

The tests are a bit unfortunate in the sense that they all end up testing the function on data of the same particular form, which happens to work - specifically, where only the first element per row needs to be filled out, e.g.:
```python
>>> fill(np.array([[np.nan, 68., 62, 99., 67., 92., 22., 80.]]), operation='b')

array([[68., 68., 62., 99., 67., 92., 22., 80.]])  # Working as expected
```

However, a simple case such as this would still fail:
```python
>>> fill(np.array([[np.nan, 68., np.nan, 99., 67., 92., 22., 80.]]), operation='b')

array([[68., 68., nan, 99., 67., 92., 22., 80.]])  # The `NaN` in the middle is not filled out
```

After fixing the typo, the results are as expected. I've also simplified the code a bit and added a few more tests.