### PR TITLE
Filesystem support for ExportToTiff and ImportFromTiff tasks

### DIFF
--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -50,7 +50,7 @@ class DeepCopyTask(CopyTask):
 class IOTask(EOTask):
     """ An abstract Input/Output task that can handle a path and a filesystem object
     """
-    def __init__(self, path, filesystem=None, create=False):
+    def __init__(self, path, filesystem=None, create=False, config=None):
         """
         :param path: root path where all EOPatches are saved
         :type path: str
@@ -59,10 +59,14 @@ class IOTask(EOTask):
         :type filesystem: fs.base.FS or None
         :param create: If the filesystem path doesn't exist this flag indicates to either create it or raise an error
         :type create: bool
+        :param config: A configuration object with AWS credentials. By default is set to None and in this case the
+            default configuration will be taken.
+        :type config: SHConfig or None
         """
         self.path = path
         self._filesystem = filesystem
         self._create = create
+        self.config = config
 
         self.filesystem_path = '/' if self._filesystem is None else self.path
 
@@ -71,7 +75,7 @@ class IOTask(EOTask):
         """ A filesystem property that is being lazy-loaded the first time it is needed
         """
         if self._filesystem is None:
-            self._filesystem = get_filesystem(self.path, create=self._create)
+            self._filesystem = get_filesystem(self.path, create=self._create, config=self.config)
 
         return self._filesystem
 
@@ -85,7 +89,7 @@ class IOTask(EOTask):
 class SaveTask(IOTask):
     """ Saves the given EOPatch to a filesystem
     """
-    def __init__(self, path, filesystem=None, **kwargs):
+    def __init__(self, path, filesystem=None, config=None, **kwargs):
         """
         :param path: root path where all EOPatches are saved
         :type path: str
@@ -100,9 +104,12 @@ class SaveTask(IOTask):
         :param compress_level: A level of data compression and can be specified with an integer from 0 (no compression)
             to 9 (highest compression).
         :type compress_level: int
+        :param config: A configuration object with AWS credentials. By default is set to None and in this case the
+            default configuration will be taken.
+        :type config: SHConfig or None
         """
         self.kwargs = kwargs
-        super().__init__(path, filesystem=filesystem, create=True)
+        super().__init__(path, filesystem=filesystem, create=True, config=config)
 
     def execute(self, eopatch, *, eopatch_folder=''):
         """Saves the EOPatch to disk: `folder/eopatch_folder`.
@@ -131,7 +138,7 @@ class SaveToDisk(SaveTask):
 class LoadTask(IOTask):
     """ Loads an EOPatch from a filesystem
     """
-    def __init__(self, path, filesystem=None, **kwargs):
+    def __init__(self, path, filesystem=None, config=None, **kwargs):
         """
         :param path: root directory where all EOPatches are saved
         :type path: str
@@ -142,9 +149,12 @@ class LoadTask(IOTask):
         :type features: an object supported by the :class:`FeatureParser<eolearn.core.utilities.FeatureParser>`
         :param lazy_loading: If `True` features will be lazy loaded. Default is `False`
         :type lazy_loading: bool
+        :param config: A configuration object with AWS credentials. By default is set to None and in this case the
+            default configuration will be taken.
+        :type config: SHConfig or None
         """
         self.kwargs = kwargs
-        super().__init__(path, filesystem=filesystem, create=False)
+        super().__init__(path, filesystem=filesystem, create=False, config=config)
 
     def execute(self, *, eopatch_folder=''):
         """Loads the EOPatch from disk: `folder/eopatch_folder`.

--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -35,7 +35,7 @@ def save_eopatch(eopatch, filesystem, patch_location, features=..., overwrite_pe
             patch_exists = False
 
     if not patch_exists:
-        filesystem.makedirs(patch_location)
+        filesystem.makedirs(patch_location, recreate=True)
 
     eopatch_features = list(walk_eopatch(eopatch, patch_location, features))
 
@@ -53,7 +53,7 @@ def save_eopatch(eopatch, filesystem, patch_location, features=..., overwrite_pe
     ftype_folder_map = {(ftype, fs.path.dirname(path)) for ftype, _, path in eopatch_features if not ftype.is_meta()}
     for ftype, folder in ftype_folder_map:
         if not filesystem.exists(folder):
-            filesystem.makedirs(folder)
+            filesystem.makedirs(folder, recreate=True)
 
     features_to_save = ((FeatureIO(filesystem, path),
                          eopatch[(ftype, fname)],

--- a/core/eolearn/core/fs_utils.py
+++ b/core/eolearn/core/fs_utils.py
@@ -16,13 +16,15 @@ from fs_s3fs import S3FS
 from sentinelhub import SHConfig
 
 
-def get_filesystem(path, create=False, **kwargs):
+def get_filesystem(path, create=False, config=None, **kwargs):
     """ A utility function for initializing any type of filesystem object with PyFilesystem2 package
 
     :param path: A filesystem path
     :type path: str
     :param create: If the filesystem path doesn't exist this flag indicates to either create it or raise an error
     :type create: bool
+    :param config: A configuration object with AWS credentials
+    :type config: SHConfig
     :param kwargs: Any keyword arguments to be passed forward
     :return: A filesystem object
     :rtype: fs.FS
@@ -31,7 +33,7 @@ def get_filesystem(path, create=False, **kwargs):
         path = str(path)
 
     if path.startswith('s3://'):
-        return load_s3_filesystem(path, **kwargs)
+        return load_s3_filesystem(path, config=config, **kwargs)
 
     return fs.open_fs(path, create=create, **kwargs)
 

--- a/core/eolearn/core/fs_utils.py
+++ b/core/eolearn/core/fs_utils.py
@@ -8,6 +8,8 @@ Copyright (c) 2017-2020 Nejc Vesel, Jovan Višnjić, Anže Zupanc (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+from pathlib import Path
+
 import fs
 from fs_s3fs import S3FS
 
@@ -25,6 +27,9 @@ def get_filesystem(path, create=False, **kwargs):
     :return: A filesystem object
     :rtype: fs.FS
     """
+    if isinstance(path, Path):
+        path = str(path)
+
     if path.startswith('s3://'):
         return load_s3_filesystem(path, **kwargs)
 

--- a/core/eolearn/core/fs_utils.py
+++ b/core/eolearn/core/fs_utils.py
@@ -26,7 +26,7 @@ def get_filesystem(path, create=False, **kwargs):
     :rtype: fs.FS
     """
     if path.startswith('s3://'):
-        return load_s3_filesystem(path, *kwargs)
+        return load_s3_filesystem(path, **kwargs)
 
     return fs.open_fs(path, create=create, **kwargs)
 

--- a/core/eolearn/tests/test_fs_utils.py
+++ b/core/eolearn/tests/test_fs_utils.py
@@ -8,7 +8,9 @@ file in the root directory of this source tree.
 """
 import unittest
 import logging
+import os
 import tempfile
+from pathlib import Path
 
 import fs
 from fs.osfs import OSFS
@@ -29,12 +31,18 @@ class TestFilesystemUtils(unittest.TestCase):
             filesystem = get_filesystem(tmp_dir_name)
             self.assertTrue(isinstance(filesystem, OSFS))
 
-            subfolder_path = fs.path.combine(tmp_dir_name, 'subfolder')
+            subfolder_path = os.path.join(tmp_dir_name, 'subfolder')
 
             with self.assertRaises(CreateFailed):
                 get_filesystem(subfolder_path, create=False)
 
             filesystem = get_filesystem(subfolder_path, create=True)
+            self.assertTrue(isinstance(filesystem, OSFS))
+
+    def test_pathlib_support(self):
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            path = Path(tmp_dir_name)
+            filesystem = get_filesystem(path)
             self.assertTrue(isinstance(filesystem, OSFS))
 
     @mock_s3

--- a/core/eolearn/tests/test_fs_utils.py
+++ b/core/eolearn/tests/test_fs_utils.py
@@ -57,10 +57,13 @@ class TestFilesystemUtils(unittest.TestCase):
         custom_config = SHConfig()
         custom_config.aws_access_key_id = 'fake-key'
         custom_config.aws_secret_access_key = 'fake-secret'
-        filesystem = load_s3_filesystem(s3_url, strict=False, config=custom_config)
-        self.assertTrue(isinstance(filesystem, S3FS))
-        self.assertEqual(filesystem.aws_access_key_id, custom_config.aws_access_key_id)
-        self.assertEqual(filesystem.aws_secret_access_key, custom_config.aws_secret_access_key)
+        filesystem1 = load_s3_filesystem(s3_url, strict=False, config=custom_config)
+        filesystem2 = get_filesystem(s3_url, config=custom_config)
+
+        for filesystem in [filesystem1, filesystem2]:
+            self.assertTrue(isinstance(filesystem, S3FS))
+            self.assertEqual(filesystem.aws_access_key_id, custom_config.aws_access_key_id)
+            self.assertEqual(filesystem.aws_secret_access_key, custom_config.aws_secret_access_key)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This feature enables using both tasks to load data from s3 by simply specifying `folder='s3://my-bucket/path'`.

Additionally, I have also added a few minor filesystem-related improvements in the core subpackage.