### PR TITLE
Possibility to create time-dependent feature from a list of filenames

### DIFF
--- a/io/eolearn/io/local_io.py
+++ b/io/eolearn/io/local_io.py
@@ -54,9 +54,23 @@ class BaseLocalIo(EOTask):
         """ It takes location parameters from init and execute methods, joins them together, and creates a filesystem
         object and file paths relative to the filesystem object.
         """
-        filesystem, relative_path = get_base_filesystem_and_path(self.folder, filename, config=self.config)
 
-        filename_paths = self._generate_paths(relative_path, timestamps)
+        if isinstance(filename, str):
+            filesystem, relative_path = get_base_filesystem_and_path(self.folder, filename, config=self.config)
+            filename_paths = self._generate_paths(relative_path, timestamps)
+        elif isinstance(filename, list):
+            filename_paths = []
+            for timestamp_index, path in enumerate(filename):
+                filesystem, relative_path = get_base_filesystem_and_path(self.folder, path, config=self.config)
+                if len(filename) == len(timestamps):
+                    filename_paths.append(*self._generate_paths(relative_path, [timestamps[timestamp_index]]))
+                elif not timestamps:
+                    filename_paths.append(*self._generate_paths(relative_path, timestamps))
+                else:
+                    raise ValueError('The number of provided timestamps does not match '
+                                     'the number of provided filenames.')
+        else:
+            raise TypeError('The data type for filename must either be "list" or "str".')
 
         if create_paths:
             paths_to_create = {fs.path.dirname(filename_path) for filename_path in filename_paths}
@@ -378,7 +392,7 @@ class ImportFromTiff(BaseLocalIo):
         :type eopatch: EOPatch or None
         :param filename: filename of tiff file or None if entire path has already been specified in `folder` parameter
             of task initialization.
-        :type filename: str or None
+        :type filename: str, list of str or None
         :return: New EOPatch with added raster layer
         :rtype: EOPatch
         """
@@ -390,15 +404,29 @@ class ImportFromTiff(BaseLocalIo):
 
         with filesystem:
             with filesystem.openbin(filename_paths[0], 'r') as file_handle:
-                with rasterio.open(file_handle) as source:
+                with rasterio.open(file_handle) as src:
 
-                    data_bbox = BBox(source.bounds, CRS(source.crs.to_epsg()))
+                    data_bbox = BBox(src.bounds, CRS(src.crs.to_epsg()))
                     if eopatch.bbox is None:
                         eopatch.bbox = data_bbox
 
-                    reading_window = self._get_reading_window(source.width, source.height, data_bbox, eopatch.bbox)
+                    reading_window = self._get_reading_window(src.width, src.height, data_bbox, eopatch.bbox)
 
-                    data = source.read(window=reading_window, boundless=True, fill_value=self.no_data_value)
+                    data = src.read(window=reading_window, boundless=True, fill_value=self.no_data_value)
+
+            if len(filename_paths) > 1:
+                for path in filename_paths[1:]:
+                    with filesystem.openbin(path, 'r') as file_handle:
+                        with rasterio.open(file_handle) as src:
+
+                            data_bbox = BBox(src.bounds, CRS(src.crs.to_epsg()))
+                            if eopatch.bbox is None:
+                                eopatch.bbox = data_bbox
+
+                            reading_window = self._get_reading_window(src.width, src.height, data_bbox, eopatch.bbox)
+
+                            data = np.concatenate([data, src.read(window=reading_window, boundless=True,
+                                                                  fill_value=self.no_data_value)], axis=0)
 
         if self.image_dtype is not None:
             data = data.astype(self.image_dtype)

--- a/io/eolearn/io/local_io.py
+++ b/io/eolearn/io/local_io.py
@@ -18,7 +18,6 @@ from abc import abstractmethod
 
 import dateutil
 import fs
-import fs.errors
 import rasterio
 import numpy as np
 from sentinelhub import CRS, BBox

--- a/io/eolearn/tests/test_local_io.py
+++ b/io/eolearn/tests/test_local_io.py
@@ -15,6 +15,7 @@ import unittest
 from unittest.mock import patch
 import logging
 import tempfile
+import datetime
 
 import numpy as np
 import boto3
@@ -294,9 +295,9 @@ class TestS3ExportAndImport(unittest.TestCase):
 
     def test_time_dependent_feature(self):
         feature = FeatureType.DATA, 'NDVI'
+        filename_export = 'relative-path/*.tiff'
         filename_import = [f'relative-path/{timestamp.strftime("%Y%m%dT%H%M%S")}.tiff'
                            for timestamp in self.eopatch.timestamp]
-        filename_export = 'relative-path/*.tiff'
 
         export_task = ExportToTiff(feature, folder=self.path)
         import_task = ImportFromTiff(feature, folder=self.path, timestamp_size=68)
@@ -306,17 +307,22 @@ class TestS3ExportAndImport(unittest.TestCase):
 
         self.assertTrue(np.array_equal(new_eopatch[feature], self.eopatch[feature]))
 
+        self.eopatch.timestamp[2] = datetime.datetime(2020, 10, 10)
+        filename_import = [f'relative-path/{timestamp.strftime("%Y%m%dT%H%M%S")}.tiff'
+                       for timestamp in self.eopatch.timestamp]
+
+        with self.assertRaises(FileNotFoundError):
+            import_task.execute(filename=filename_import)
+
     def test_time_dependent_feature_with_timestamps(self):
         feature = FeatureType.DATA, 'NDVI'
-        filename_import = [f'relative-path/{timestamp.strftime("%Y%m%dT%H%M%S")}.tiff'
-                           for timestamp in self.eopatch.timestamp]
-        filename_export = 'relative-path/*.tiff'
+        filename = f'relative-path/%Y%m%dT%H%M%S.tiff'
 
         export_task = ExportToTiff(feature, folder=self.path)
         import_task = ImportFromTiff(feature, folder=self.path)
 
-        export_task.execute(self.eopatch, filename=filename_export)
-        new_eopatch = import_task.execute(self.eopatch, filename=filename_import)
+        export_task.execute(self.eopatch, filename=filename)
+        new_eopatch = import_task.execute(self.eopatch, filename=filename)
 
         self.assertTrue(np.array_equal(new_eopatch[feature], self.eopatch[feature]))
 

--- a/io/eolearn/tests/test_local_io.py
+++ b/io/eolearn/tests/test_local_io.py
@@ -292,6 +292,33 @@ class TestS3ExportAndImport(unittest.TestCase):
 
         self.assertTrue(np.array_equal(new_eopatch[feature], self.eopatch[feature]))
 
+    def test_time_dependent_feature(self):
+        feature = FeatureType.DATA, 'NDVI'
+        filename_import = [f'relative-path/{timestamp.strftime("%Y%m%dT%H%M%S")}.tiff'
+                           for timestamp in self.eopatch.timestamp]
+        filename_export = 'relative-path/*.tiff'
+
+        export_task = ExportToTiff(feature, folder=self.path)
+        import_task = ImportFromTiff(feature, folder=self.path, timestamp_size=68)
+
+        export_task.execute(self.eopatch, filename=filename_export)
+        new_eopatch = import_task.execute(filename=filename_import)
+
+        self.assertTrue(np.array_equal(new_eopatch[feature], self.eopatch[feature]))
+
+    def test_time_dependent_feature_with_timestamps(self):
+        feature = FeatureType.DATA, 'NDVI'
+        filename_import = [f'relative-path/{timestamp.strftime("%Y%m%dT%H%M%S")}.tiff'
+                           for timestamp in self.eopatch.timestamp]
+        filename_export = 'relative-path/*.tiff'
+
+        export_task = ExportToTiff(feature, folder=self.path)
+        import_task = ImportFromTiff(feature, folder=self.path)
+
+        export_task.execute(self.eopatch, filename=filename_export)
+        new_eopatch = import_task.execute(self.eopatch, filename=filename_import)
+
+        self.assertTrue(np.array_equal(new_eopatch[feature], self.eopatch[feature]))
 
 if __name__ == '__main__':
     unittest.main()

--- a/io/eolearn/tests/test_local_io.py
+++ b/io/eolearn/tests/test_local_io.py
@@ -307,16 +307,16 @@ class TestS3ExportAndImport(unittest.TestCase):
 
         self.assertTrue(np.array_equal(new_eopatch[feature], self.eopatch[feature]))
 
-        self.eopatch.timestamp[2] = datetime.datetime(2020, 10, 10)
+        self.eopatch.timestamp[-1] = datetime.datetime(2020, 10, 10)
         filename_import = [f'relative-path/{timestamp.strftime("%Y%m%dT%H%M%S")}.tiff'
-                       for timestamp in self.eopatch.timestamp]
+                           for timestamp in self.eopatch.timestamp]
 
         with self.assertRaises(FileNotFoundError):
             import_task.execute(filename=filename_import)
 
     def test_time_dependent_feature_with_timestamps(self):
         feature = FeatureType.DATA, 'NDVI'
-        filename = f'relative-path/%Y%m%dT%H%M%S.tiff'
+        filename = 'relative-path/%Y%m%dT%H%M%S.tiff'
 
         export_task = ExportToTiff(feature, folder=self.path)
         import_task = ImportFromTiff(feature, folder=self.path)
@@ -325,6 +325,7 @@ class TestS3ExportAndImport(unittest.TestCase):
         new_eopatch = import_task.execute(self.eopatch, filename=filename)
 
         self.assertTrue(np.array_equal(new_eopatch[feature], self.eopatch[feature]))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
As follow-up to [https://github.com/sentinel-hub/eo-learn/pull/257](https://github.com/sentinel-hub/eo-learn/pull/257), extending the functionality of `ImportFromTiff` in order to build time-dependent features from a list of filenames.

For this use case, I am expanding on the usage of `*` or `strftime` for `ImportFromTiff`, which creates a hypothetical list of files and checks for their existence before attempting to open them.

A custom file list can also be passed with (import into existing `EOPatch`) or without (create a new `EOPatch`) timestamps. 

If the former, the length of the file list provided should match the number of timestamps of the existing EOPatch.
If the latter, the timestamps should be assigned by the user outside of the `ImportFromTiff` method, as there is no effective way of retrieving those timestamps from the files themselves, especially if those files do not contain the timestamp in them, which would be a typical use case.

