### PR TITLE
Fix and improve coregistration

### DIFF
--- a/coregistration/eolearn/coregistration/coregistration.py
+++ b/coregistration/eolearn/coregistration/coregistration.py
@@ -71,6 +71,7 @@ class RegistrationTask(EOTask, ABC):
         :param params: Any other registration setting which will be passed to registration method
         :type params: object
     """
+
     def __init__(self, registration_feature, channel=0, valid_mask_feature=None, apply_to_features=...,
                  interpolation_type=InterpolationType.CUBIC, **params):
         self.registration_feature = self._parse_features(registration_feature, default_feature_type=FeatureType.DATA)
@@ -309,6 +310,7 @@ class ECCRegistration(RegistrationTask):
 class PointBasedRegistration(RegistrationTask):
     """ Registration class implementing a point-based registration from OpenCV contrib package
     """
+
     def get_params(self):
         LOGGER.info("{:s}:Params for this registration are:".format(self.__class__.__name__))
         LOGGER.info("\t\t\t\tModel: {:s}".format(self.params['Model']))
@@ -387,3 +389,20 @@ class PointBasedRegistration(RegistrationTask):
         # Rescale to uint8 range
         out_image = out_max_value + (image-s2_min_value)*(out_max_value-out_min_value)/(s2_max_value-s2_min_value)
         return out_image.astype(np.uint8)
+
+
+def get_gradient(src):
+    """ Method which calculates and returns the gradients for the input image, which are
+        better suited for co-registration
+
+        :param src: input image
+        :type src: ndarray
+        :return: ndarray
+    """
+    # Calculate the x and y gradients using Sobel operator
+    grad_x = cv2.Sobel(src, cv2.CV_32F, 1, 0, ksize=3)
+    grad_y = cv2.Sobel(src, cv2.CV_32F, 0, 1, ksize=3)
+
+    # Combine the two gradients
+    grad = cv2.addWeighted(np.absolute(grad_x), 0.5, np.absolute(grad_y), 0.5, 0)
+    return grad

--- a/coregistration/eolearn/coregistration/coregistration.py
+++ b/coregistration/eolearn/coregistration/coregistration.py
@@ -10,18 +10,17 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import logging
 import copy
-
+import logging
 from abc import ABC, abstractmethod
 from enum import Enum
-import registration
+
 import cv2
 import numpy as np
-
+import registration
 from eolearn.core import EOTask, FeatureType
 
-from .coregistration_utilities import ransac, EstimateEulerTransformModel
+from .coregistration_utilities import EstimateEulerTransformModel, ransac
 
 LOGGER = logging.getLogger(__name__)
 

--- a/coregistration/eolearn/coregistration/coregistration.py
+++ b/coregistration/eolearn/coregistration/coregistration.py
@@ -181,6 +181,8 @@ class RegistrationTask(EOTask, ABC):
         height, width = img.shape[:2]
         warped_img = np.zeros_like(img, dtype=img.dtype)
 
+        iflag += cv2.WARP_INVERSE_MAP
+
         # Check if image to warp is 2D or 3D. If 3D need to loop over channels
         if (self.interpolation_type == InterpolationType.LINEAR) or img.ndim == 2:
             warped_img = cv2.warpAffine(img.astype(np.float32), warp_matrix, (width, height),

--- a/coregistration/eolearn/tests/test_coregistration.py
+++ b/coregistration/eolearn/tests/test_coregistration.py
@@ -8,14 +8,12 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import unittest
 import logging
-
-from eolearn.core import EOPatch, FeatureType
-
-from eolearn.coregistration import InterpolationType, ECCRegistration
+import unittest
 
 import numpy as np
+from eolearn.core import EOPatch, FeatureType
+from eolearn.coregistration import ECCRegistration, InterpolationType
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -44,7 +42,7 @@ class TestEOPatch(unittest.TestCase):
                               apply_to_features={
                                   FeatureType.DATA: {'bands', 'ndvi'},
                                   FeatureType.MASK: {'cm'}
-                              })
+        })
         reop = reg.execute(eop)
 
         self.assertEqual(eop.data['bands'].shape, reop.data['bands'].shape,


### PR DESCRIPTION
- a bug was discovered in the coregistration where the warp matrix used has not been inverted in order to correct for the misalignments, causing them to increase instead of fixing them
- additionally, the algorithm was improved by calculating the coregistration matrix from the normalized gradients of the input images
- ~~the reference image has been set to be the last frame~~


### Original

![org_coreg_anim](https://user-images.githubusercontent.com/37869250/103885448-542c0700-50e0-11eb-940d-e6dbd15ac65f.gif)

### Bug

#### Using translation + rotation

![bug_tr_coreg_anim](https://user-images.githubusercontent.com/37869250/103885604-8d647700-50e0-11eb-96a5-2799f0786161.gif)

Very weird effect

#### Using just translation

![bug_t_coreg_anim](https://user-images.githubusercontent.com/37869250/103885628-96554880-50e0-11eb-80d8-f2d5329f0761.gif)

Also weird effect, probably due to the changing reference, where the reference itself was affected with the bug

#### Using just translation with last frame as reference

![bug_t_lf_coreg_anim](https://user-images.githubusercontent.com/37869250/103887623-a6225c00-50e3-11eb-8b58-3f62b7b92eca.gif)

The last frame was used as a reference and it was not altered at all, you can see the effects of increased misalignments, which  points into the direction of a non-inverted matrix

### After improvements

![new_coreg_anim](https://user-images.githubusercontent.com/37869250/103885555-7b82d400-50e0-11eb-8645-b39f56fdd3df.gif)

Everything is OK after the matrix has been inverted


