### PR TITLE
Fixed documentation

### DIFF
--- a/core/eolearn/core/constants.py
+++ b/core/eolearn/core/constants.py
@@ -182,9 +182,10 @@ class OverwritePermission(Enum):
     """ Enum class which specifies which content of saved EOPatch can be overwritten when saving new content.
 
     Permissions are in the following hierarchy:
+
     - `ADD_ONLY` - Only new features can be added, anything that is already saved cannot be changed.
     - `OVERWRITE_FEATURES` - Overwrite only data for features which have to be saved. The remaining content of saved
-        EOPatch will stay unchanged.
+      EOPatch will stay unchanged.
     - `OVERWRITE_PATCH` - Overwrite entire content of saved EOPatch and replace it with the new content.
     """
     ADD_ONLY = 0

--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -463,7 +463,7 @@ class MapFeatureTask(EOTask):
 
 class ZipFeatureTask(EOTask):
     """ Passes a set of input_features to a function, which returns a single features as a result and stores it in
-        the eopatch.
+    the given EOPatch.
 
         Example using inheritance:
 
@@ -527,10 +527,7 @@ class ZipFeatureTask(EOTask):
         return eopatch
 
     def zip_method(self, *f):
-        """A function that will be applied to the input features if overridden.
-
-        :raises NotImplementedError: When called and was neither overridden nor function argument was provided in
-        __init__.
+        """ A function that will be applied to the input features if overridden.
         """
         raise NotImplementedError('zip_method should be overridden.')
 

--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -302,10 +302,9 @@ class EOPatch:
         :type feature_type: FeatureType
         :param feature_name: Name of the feature of the attribute
         :type feature_name: str
-        :param new_feature_name : New Name of the feature of the attribute
+        :param new_feature_name: New Name of the feature of the attribute
         :type feature_name: str
         """
-
         self._check_if_dict(feature_type)
         if feature_name != new_feature_name:
             if feature_name in self[feature_type]:
@@ -498,7 +497,7 @@ class EOPatch:
         :param path: A location where to save EOPatch. It can be either a local path or a remote URL path.
         :type path: str
         :param features: A collection of features types specifying features of which type will be saved. By default
-        all features will be saved.
+            all features will be saved.
         :type features: list(FeatureType) or list((FeatureType, str)) or ...
         :param overwrite_permission: A level of permission for overwriting an existing EOPatch
         :type overwrite_permission: OverwritePermission or int
@@ -547,6 +546,7 @@ class EOPatch:
         :type features: object
         :param time_dependent_op: An operation to be used to join data for any time-dependent raster feature. Before
             joining time slices of all arrays will be sorted. Supported options are:
+
             - None (default): If time slices with matching timestamps have the same values, take one. Raise an error
               otherwise.
             - 'concatenate': Keep all time slices, even the ones with matching timestamps
@@ -557,6 +557,7 @@ class EOPatch:
         :type time_dependent_op: str or Callable or None
         :param timeless_op: An operation to be used to join data for any timeless raster feature. Supported options
             are:
+
             - None (default): If arrays are the same, take one. Raise an error otherwise.
             - 'concatenate': Join arrays over the last (i.e. bands) dimension
             - 'min': Join arrays by taking minimum values. Ignore NaN values.

--- a/core/eolearn/core/eoworkflow.py
+++ b/core/eolearn/core/eoworkflow.py
@@ -330,7 +330,7 @@ class LinearWorkflow(EOWorkflow):
     def __init__(self, *tasks, **kwargs):
         """
         :param tasks: Tasks in the order of execution
-        :type tasks: *EOTask
+        :type tasks: EOTask
         """
         tasks = [self._parse_task(task) for task in tasks]
         tasks = self._make_tasks_unique(tasks)

--- a/core/eolearn/core/utilities.py
+++ b/core/eolearn/core/utilities.py
@@ -49,8 +49,8 @@ class FeatureParser:
 
     General guidelines:
 
-    - Almost all EOTasks have take as a parameter some information about features. The purpose of this class is
-      to unite and generalize parsing of such parameter over entire eo-learn package
+    - Almost every `EOTask` requires an initialization parameter to define which features should be used by the task.
+      The purpose of this class is to unite and generalize parsing of such parameters over the entire eo-learn package.
     - The idea for this class is that it should support more or less any logical way how to describe a collection
       of features.
     - Parameter `...` is used as a contextual clue. In the supported formats it is used to describe the most obvious

--- a/core/eolearn/core/utilities.py
+++ b/core/eolearn/core/utilities.py
@@ -48,43 +48,60 @@ class FeatureParser:
     can be obtained by iterating over an instance of the class. An `EOPatch` is given as a parameter of the generator.
 
     General guidelines:
-        - Almost all `EOTask`s have take as a parameter some information about features. The purpose of this class is
-        to unite and generalize parsing of such parameter over entire eo-learn package
-        - The idea for this class is that it should support more or less any logical way how to describe a collection
-        of features.
-        - Parameter `...` is used as a contextual clue. In the supported formats it is used to describe the most obvious
-        way how to specify certain parts of feature collection.
-        - Supports formats defined with lists, tuples, sets and dictionaries.
+
+    - Almost all EOTasks have take as a parameter some information about features. The purpose of this class is
+      to unite and generalize parsing of such parameter over entire eo-learn package
+    - The idea for this class is that it should support more or less any logical way how to describe a collection
+      of features.
+    - Parameter `...` is used as a contextual clue. In the supported formats it is used to describe the most obvious
+      way how to specify certain parts of feature collection.
+    - Supports formats defined with lists, tuples, sets and dictionaries.
 
     Supported input formats:
-        - `...` - Anything that exists in a given `EOPatch`
-        - A feature type describing all features of that type. E.g. `FeatureType.DATA` or `FeatureType.BBOX`
-        - A single feature as a tuple. E.g. (FeatureType.DATA, 'BANDS')
-        - A single feature as a tuple with new name. E.g. (FeatureType.DATA, 'BANDS', 'NEW_BANDS')
-        - A list of features (new names or not).
-        E.g. [(FeatureType.DATA, 'BANDS'), (FeatureType.MASK, 'CLOUD_MASK', 'NEW_CLOUD_MASK')]
-        - A dictionary with feature types as keys and lists, sets, single feature or `...` of feature names as values.
-        E.g. {
-            FeatureType.DATA: ['S2-BANDS', 'L8-BANDS'],
-            FeatureType.MASK: {'IS_VALID', 'IS_DATA'},
-            FeatureType.MASK_TIMELESS: 'LULC',
-            FeatureType.TIMESTAMP: ...
-        }
-        - A dictionary with feature types as keys and dictionaries, where feature names are mapped into new names, as
-          values.
-        E.g. {
-            FeatureType.DATA: {
-                'S2-BANDS': 'INTERPOLATED_S2_BANDS',
-                'L8-BANDS': 'INTERPOLATED_L8_BANDS',
-                'NDVI': ...
-            },
-        }
+
+    - Anything that exists in a given `EOPatch` is defined with `...`
+    - A feature type describing all features of that type. Example: `FeatureType.DATA` or `FeatureType.BBOX`
+    - A single feature as a tuple. Example: `(FeatureType.DATA, 'BANDS')`
+    - A single feature as a tuple. Example: `(FeatureType.DATA, 'BANDS')`
+    - A single feature as a tuple with new name. Example `(FeatureType.DATA, 'BANDS', 'NEW_BANDS')`
+    - A list of features (new names or not). Example:
+
+        .. code-block:: python
+
+            [
+                (FeatureType.DATA, 'BANDS'),
+                (FeatureType.MASK, 'CLOUD_MASK', 'NEW_CLOUD_MASK')
+            ]
+    - A dictionary with feature types as keys and lists, sets, single feature or `...` of feature names as values.
+      Example:
+
+        .. code-block:: python
+
+            {
+                FeatureType.DATA: ['S2-BANDS', 'L8-BANDS'],
+                FeatureType.MASK: {'IS_VALID', 'IS_DATA'},
+                FeatureType.MASK_TIMELESS: 'LULC',
+                FeatureType.TIMESTAMP: ...
+            }
+    - A dictionary with feature types as keys and dictionaries, where feature names are mapped into new names, as
+      values. Example:
+
+        .. code-block:: python
+
+            {
+                FeatureType.DATA: {
+                    'S2-BANDS': 'INTERPOLATED_S2_BANDS',
+                    'L8-BANDS': 'INTERPOLATED_L8_BANDS',
+                    'NDVI': ...
+                }
+            }
 
     Note: Therese are most general input formats, but even more are supported or might be supported in the future.
 
     Outputs of the generator:
-        - tuples in form of (feature type, feature name) if parameter `new_names=False`
-        - tuples in form of (feature type, feature name, new feature name) if parameter `new_names=True`
+
+    - tuples in form of (feature type, feature name) if parameter `new_names=False`
+    - tuples in form of (feature type, feature name, new feature name) if parameter `new_names=True`
     """
     def __init__(self, features, new_names=False, rename_function=None, default_feature_type=None,
                  allowed_feature_types=None):
@@ -101,9 +118,10 @@ class FeatureParser:
         :type rename_function: function or None
         :param default_feature_type: If feature type of any given feature is not set, this will be used. By default this
             is set to `None`. In this case if feature type of any feature is not given the following will happen:
-                - if iterated over `EOPatch` - It will try to find a feature with matching name in EOPatch. If such
-                    features exist, it will return any of them. Otherwise it will raise an error.
-                - if iterated without `EOPatch` - It will return `...` instead of a feature type.
+
+            - if iterated over `EOPatch` - It will try to find a feature with matching name in EOPatch. If such
+              features exist, it will return any of them. Otherwise it will raise an error.
+            - if iterated without `EOPatch` - It will return `...` instead of a feature type.
         :type default_feature_type: FeatureType or None
         :param allowed_feature_types: Makes sure that only features of these feature types will be returned, otherwise
             an error is raised

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - sphinx-rtd-theme
   - nbsphinx
   - jupyter
-  - git+https://github.com/AleksMat/m2r@dev
+  - m2r2
 
   - ./../core
   - ./../coregistration

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -53,7 +53,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'nbsphinx',
     'IPython.sphinxext.ipython_console_highlighting',
-    'm2r'
+    'm2r2'
 ]
 
 # Both the class’ and the __init__ method’s docstring are concatenated and inserted.
@@ -209,7 +209,7 @@ epub_copyright = copyright
 epub_exclude_files = ['search.html']
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/3.6/': None}
+intersphinx_mapping = {'https://docs.python.org/3.8/': None}
 
 
 EXAMPLES_FOLDER = './examples'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -215,16 +215,36 @@ intersphinx_mapping = {'https://docs.python.org/3.8/': None}
 EXAMPLES_FOLDER = './examples'
 MARKDOWNS_FOLDER = './markdowns'
 
+
+def copy_documentation_examples(source_folder, target_folder):
+    """ Makes sure to copy only notebooks that are actually included in the documentation
+    """
+    notebooks_to_include = []
+
+    for rst_file in ['examples.rst', 'index.rst']:
+        with open(rst_file, 'r') as fp:
+            content = fp.read()
+
+        for line in content.split('\n'):
+            line = line.strip(' \t')
+            if line.startswith('examples/'):
+                notebooks_to_include.append(line.split('/', 1)[1])
+
+    for notebook in notebooks_to_include:
+        source_path = os.path.join(source_folder, notebook)
+        target_path = os.path.join(target_folder, notebook)
+        os.makedirs(os.path.dirname(target_path), exist_ok=True)
+        shutil.copyfile(source_path, target_path)
+
+
 # copy examples
 shutil.rmtree(EXAMPLES_FOLDER, ignore_errors=True)
-shutil.rmtree(MARKDOWNS_FOLDER, ignore_errors=True)
+copy_documentation_examples('../../examples', EXAMPLES_FOLDER)
 
-try:
-    shutil.copytree('../../examples', EXAMPLES_FOLDER)
-    os.mkdir(MARKDOWNS_FOLDER)
-    shutil.copyfile('../../CONTRIBUTING.md', os.path.join(MARKDOWNS_FOLDER, 'CONTRIBUTING.md'))
-except FileExistsError:
-    pass
+
+shutil.rmtree(MARKDOWNS_FOLDER, ignore_errors=True)
+os.mkdir(MARKDOWNS_FOLDER)
+shutil.copyfile('../../CONTRIBUTING.md', os.path.join(MARKDOWNS_FOLDER, 'CONTRIBUTING.md'))
 
 
 def process_readme():

--- a/docs/source/eolearn.core.eoexecution.rst
+++ b/docs/source/eolearn.core.eoexecution.rst
@@ -1,5 +1,5 @@
 eolearn.core.eoexecution
-===================
+========================
 
 .. automodule:: eolearn.core.eoexecution
     :members:

--- a/docs/source/eolearn.core.fs_utils.rst
+++ b/docs/source/eolearn.core.fs_utils.rst
@@ -1,0 +1,7 @@
+eolearn.core.fs_utils
+=====================
+
+.. automodule:: eolearn.core.fs_utils
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/eolearn.core.graph.rst
+++ b/docs/source/eolearn.core.graph.rst
@@ -1,7 +1,0 @@
-eolearn.core.graph
-==================
-
-.. automodule:: eolearn.core.graph
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/eolearn.core.plots.rst
+++ b/docs/source/eolearn.core.plots.rst
@@ -1,7 +1,0 @@
-eolearn.core.plots
-==================
-
-.. automodule:: eolearn.core.plots
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/eolearn.core.rst
+++ b/docs/source/eolearn.core.rst
@@ -16,6 +16,5 @@ Submodules:
    eolearn.core.eoexecution
    eolearn.core.eotask
    eolearn.core.eoworkflow
-   eolearn.core.graph
-   eolearn.core.plots
+   eolearn.core.fs_utils
    eolearn.core.utilities

--- a/docs/source/eolearn.features.clustering.rst
+++ b/docs/source/eolearn.features.clustering.rst
@@ -1,0 +1,7 @@
+eolearn.features.clustering
+===========================
+
+.. automodule:: eolearn.features.clustering
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/eolearn.features.doubly_logistic_approximation.rst
+++ b/docs/source/eolearn.features.doubly_logistic_approximation.rst
@@ -1,0 +1,7 @@
+eolearn.features.doubly_logistic_approximation
+==============================================
+
+.. automodule:: eolearn.features.doubly_logistic_approximation
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/eolearn.features.rst
+++ b/docs/source/eolearn.features.rst
@@ -12,6 +12,8 @@ Submodules:
 
    eolearn.features.bands_extraction
    eolearn.features.blob
+   eolearn.features.clustering
+   eolearn.features.doubly_logistic_approximation
    eolearn.features.feature_extractor
    eolearn.features.feature_manipulation
    eolearn.features.haralick

--- a/docs/source/eolearn.io.rst
+++ b/docs/source/eolearn.io.rst
@@ -12,4 +12,4 @@ Submodules:
 
    eolearn.io.geopedia
    eolearn.io.local_io
-   eolearn.io.processing_api
+   eolearn.io.sentinelhub_process

--- a/docs/source/eolearn.io.sentinelhub_process.rst
+++ b/docs/source/eolearn.io.sentinelhub_process.rst
@@ -1,7 +1,7 @@
-eolearn.io.processing\_api
+eolearn.io.sentinelhub\_process
 ===============================
 
-.. automodule:: eolearn.io.processing_api
+.. automodule:: eolearn.io.sentinelhub_process
     :members:
     :undoc-members:
     :show-inheritance:

--- a/examples/water-monitor/WaterMonitorWorkflow.ipynb
+++ b/examples/water-monitor/WaterMonitorWorkflow.ipynb
@@ -112,9 +112,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Load the Polygon of nominal water extent and define a BBOX\n",
+    "### Load the Polygon of nominal water extent and define a `BBox`\n",
     "\n",
-    "The BBOX defines an area of interest and will be used to create an EOPatch."
+    "The `BBox` defines an area of interest and will be used to create an EOPatch."
    ]
   },
   {
@@ -609,7 +609,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/features/eolearn/features/haralick.py
+++ b/features/eolearn/features/haralick.py
@@ -19,8 +19,7 @@ from eolearn.core import EOTask, FeatureType
 
 
 class HaralickTask(EOTask):
-    """
-    Task to compute Haralick texture images
+    """ Task to compute Haralick texture images
 
     The task compute the grey-level co-occurrence matrix (GLCM) on a sliding window over the input image and extract the
     texture properties.
@@ -49,10 +48,9 @@ class HaralickTask(EOTask):
                  stride=1):
         """
         :param feature: A feature that will be used and a new feature name where data will be saved. If new name is not
-        specified it will be saved with name '<feature_name>_HARALICK'
+            specified it will be saved with name '<feature_name>_HARALICK'.
 
-        Example: (FeatureType.DATA, 'bands') or (FeatureType.DATA, 'bands', 'haralick_values')
-
+            Example: `(FeatureType.DATA, 'bands')` or `(FeatureType.DATA, 'bands', 'haralick_values')`
         :type feature: (FeatureType, str) or (FeatureType, str, str)
         :param texture_feature: Type of Haralick textural feature to be calculated
         :type texture_feature: str

--- a/features/eolearn/features/hog.py
+++ b/features/eolearn/features/hog.py
@@ -18,16 +18,19 @@ from eolearn.core import EOTask, FeatureType
 class HOGTask(EOTask):
     """ Task to compute the histogram of gradient
 
-        Divide the image into small connected regions called cells, and for each cell compute a histogram of gradient
-        directions or edge orientations for the pixels within the cell.
+    Divide the image into small connected regions called cells, and for each cell compute a histogram of gradient
+    directions or edge orientations for the pixels within the cell.
 
-        The algorithm stores the result in images where each band is the value of the histogram for a specific angular
-        bin. If the visualize is True, it also output the images representing the gradients for each orientation.
-
+    The algorithm stores the result in images where each band is the value of the histogram for a specific angular
+    bin. If the visualize is True, it also output the images representing the gradients for each orientation.
+    """
+    def __init__(self, feature, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
+                 visualize=True, hog_feature_vector=False, block_norm='L2-Hys', visualize_feature_name=''):
+        """
         :param feature: A feature that will be used and a new feature name where data will be saved. If new name is not
-                        specified it will be saved with name '<feature_name>_HOG'
+            specified it will be saved with name '<feature_name>_HOG'
 
-                        Example: (FeatureType.DATA, 'bands') or (FeatureType.DATA, 'bands', 'hog')
+            Example: `(FeatureType.DATA, 'bands')` or `(FeatureType.DATA, 'bands', 'hog')`
         :type feature: (FeatureType, str) or (FeatureType, str, str)
         :param orientations: Number of direction to use for the oriented gradient
         :type orientations: int
@@ -38,11 +41,9 @@ class HOGTask(EOTask):
         :param visualize: Produce a visualization for the HOG in an image
         :type visualize: bool
         :param visualize_feature_name: Name of the visualization feature to be added to the eopatch (if empty and
-        visualize is True, the become “new_name”_VIZU
+            visualize is True, the become “new_name”_VIZU
         :type visualize_feature_name: str
-    """
-    def __init__(self, feature, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
-                 visualize=True, hog_feature_vector=False, block_norm='L2-Hys', visualize_feature_name=''):
+        """
         self.feature = self._parse_features(feature, default_feature_type=FeatureType.DATA, new_names=True,
                                             rename_function='{}_HOG'.format)
 

--- a/features/eolearn/features/interpolation.py
+++ b/features/eolearn/features/interpolation.py
@@ -72,8 +72,7 @@ interpolation_function_parallel = numba.njit(base_interpolation_function, parall
 
 
 class InterpolationTask(EOTask):
-    """
-    Main EOTask class for interpolation and resampling of time-series.
+    """ Main EOTask class for interpolation and resampling of time-series.
 
     The task takes from EOPatch the specified data feature and timestamps. For each pixel in the spatial grid it
     creates an interpolation model using values that are not NaN or masked with `eopatch.mask['VALID_DATA']`. Then
@@ -112,7 +111,7 @@ class InterpolationTask(EOTask):
     :type scale_time: int
     :param interpolate_pixel_wise: Flag to indicate pixel wise interpolation or fast interpolation that creates a single
         interpolation object for the whole image
-    :type interpolate_pixel_wise : bool
+    :type interpolate_pixel_wise: bool
     :param interpolation_parameters: Parameters which will be propagated to ``interpolation_object``
     """
     def __init__(self, feature, interpolation_object, *, resample_range=None, result_interval=None, mask_feature=None,
@@ -457,13 +456,12 @@ class LegacyInterpolation(InterpolationTask):
 
 
 class LinearInterpolation(InterpolationTask):
-    """
-    Implements `eolearn.features.InterpolationTask` by using `numpy.interp` and @numb.jit(nopython=True)
+    """ Implements `eolearn.features.InterpolationTask` by using `numpy.interp` and `@numba.jit(nopython=True)`
 
     :param parallel: interpolation is calculated in parallel using as many CPUs as detected
         by the multiprocessing module.
     :type parallel: bool
-    :param **kwargs: parameters of InterpolationTask(EOTask)
+    :param kwargs: parameters of InterpolationTask(EOTask)
     """
     def __init__(self, feature, parallel=False, **kwargs):
         self.parallel = parallel

--- a/features/eolearn/features/local_binary_pattern.py
+++ b/features/eolearn/features/local_binary_pattern.py
@@ -18,23 +18,22 @@ from eolearn.core import EOTask, FeatureType
 class LocalBinaryPatternTask(EOTask):
     """ Task to compute the Local Binary Pattern images
 
-        LBP looks at points surrounding a central point and tests whether the surrounding points are greater than or
-        less than the central point
+    LBP looks at points surrounding a central point and tests whether the surrounding points are greater than or
+    less than the central point
 
-        The task uses skimage.feature.local_binary_pattern to extract the texture features.
-
+    The task uses skimage.feature.local_binary_pattern to extract the texture features.
+    """
+    def __init__(self, feature, nb_points=24, radius=3):
+        """
         :param feature: A feature that will be used and a new feature name where data will be saved. If new name is not
-        specified it will be saved with name '<feature_name>_LBP'
+            specified it will be saved with name '<feature_name>_LBP'.
 
-        Example: (FeatureType.DATA, 'bands') or (FeatureType.DATA, 'bands', 'lbp')
-
+            Example: (FeatureType.DATA, 'bands') or (FeatureType.DATA, 'bands', 'lbp')
         :param nb_points: Number of point to use
         :type nb_points: int
         :param radius: Radius of the circle of neighbors
         :type radius: int
-    """
-    def __init__(self, feature, nb_points=24, radius=3):
-
+        """
         self.feature = self._parse_features(feature, default_feature_type=FeatureType.DATA, new_names=True,
                                             rename_function='{}_LBP'.format)
 

--- a/geometry/eolearn/geometry/transformations.py
+++ b/geometry/eolearn/geometry/transformations.py
@@ -284,7 +284,7 @@ class RasterToVector(EOTask):
     """ Task for transforming raster mask feature into vector feature.
 
     Each connected component with the same value on the raster mask is turned into a shapely polygon. Polygon are
-    returned as a geometry column in a ``geopandas.GeoDataFrame``structure together with a column `VALUE` with
+    returned as a geometry column in a ``geopandas.GeoDataFrame`` structure together with a column `VALUE` with
     values of each polygon.
 
     If raster mask feature has time component, vector feature will also have a column `TIMESTAMP` with timestamps to
@@ -295,13 +295,12 @@ class RasterToVector(EOTask):
     def __init__(self, features, *, values=None, values_column='VALUE', raster_dtype=None, **rasterio_params):
         """
         :param features: One or more raster mask features which will be vectorized together with an optional new name
-        of vector feature. If no new name is given the same name will be used.
+            of vector feature. If no new name is given the same name will be used.
 
-        Examples:
-            features=(FeatureType.MASK, 'CLOUD_MASK', 'VECTOR_CLOUD_MASK')
+            Examples:
 
-            features=[(FeatureType.MASK_TIMELESS, 'CLASSIFICATION'), (FeatureType.MASK, 'MONOTEMPORAL_CLASSIFICATION')]
-
+            - `features=(FeatureType.MASK, 'CLOUD_MASK', 'VECTOR_CLOUD_MASK')`
+            - `features=[(FeatureType.MASK_TIMELESS, 'CLASSIFICATION'), (FeatureType.MASK, 'TEMPORAL_CLASSIFICATION')]`
         :type features: object supported by eolearn.core.utilities.FeatureParser class
         :param values: List of values which will be vectorized. By default is set to ``None`` and all values will be
             vectorized

--- a/io/eolearn/io/sentinelhub_process.py
+++ b/io/eolearn/io/sentinelhub_process.py
@@ -29,7 +29,7 @@ def get_available_timestamps(bbox, config, data_collection, time_difference, tim
     :param bbox: Bounding box
     :type bbox: BBox
     :param time_interval: Time interval to query available satellite data from
-    type time_interval: different input formats available (e.g. (str, str), or (datetime, datetime)
+        type time_interval: different input formats available (e.g. (str, str), or (datetime, datetime)
     :param data_collection: Source of requested satellite data.
     :type data_collection: DataCollection
     :param maxcc: Maximum cloud coverage, in ratio [0, 1], default is None

--- a/mask/eolearn/mask/snow_mask.py
+++ b/mask/eolearn/mask/snow_mask.py
@@ -24,7 +24,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 class BaseSnowMask(EOTask):
-    """ Base class for snow detection and masking"""
+    """ Base class for snow detection and masking
+    """
     def __init__(self, data_feature, band_indices, dilation_size=0, undefined_value=0, mask_name='SNOW_MASK'):
         """
         :param data_feature: EOPatch feature represented by a tuple in the form of `(FeatureType, 'feature_name')`
@@ -32,7 +33,7 @@ class BaseSnowMask(EOTask):
         :param band_indices: A list containing the indices at which the required bands can be found in the data_feature.
         :type band_indices: list(int)
         :param dilation_size: Size of the disk in pixels for performing dilation. Value 0 means do not perform
-                              this post-processing step.
+            this post-processing step.
         :type dilation_size: int
         """
         self.bands_feature = next(self._parse_features(data_feature)())
@@ -52,8 +53,7 @@ class BaseSnowMask(EOTask):
 
 
 class SnowMask(BaseSnowMask):
-    """
-    The task calculates the snow mask using the given thresholds.
+    """ The task calculates the snow mask using the given thresholds.
 
     The default values were optimised based on the Sentinel-2 L1C processing level. Values might not be optimal for L2A
     processing level
@@ -122,19 +122,17 @@ class TheiaSnowMask(BaseSnowMask):
     def __init__(self, data_feature, band_indices, cloud_mask_feature, dem_feature, dem_params=(100, 0.1),
                  red_params=(12, 0.3, 0.1, 0.2, 0.040), ndsi_params=(0.4, 0.15, 0.001), b10_index=None, **kwargs):
         """
-        Initialize the snow mask task.
         :param data_feature: EOPatch feature represented by a tuple in the form of `(FeatureType, 'feature_name')`
             containing the bands B3, B4, and B11
 
-            Example: (FeatureType.DATA, 'ALL-BANDS')
-
+            Example: `(FeatureType.DATA, 'ALL-BANDS')`
         :type data_feature: tuple(FeatureType, str)
         :param band_indices: A list containing the indices at which the required bands can be found in the bands
             feature. If all L1C band values are provided, `band_indices=[2, 3, 11]`. If all L2A band values are
             provided, then `band_indices=[2, 3, 10]`
         :type band_indices: list(int)
         :param cloud_mask_feature: EOPatch CLM feature represented by a tuple in the form of
-                                   `(FeatureType, 'feature_name')` containing the cloud mask
+            `(FeatureType, 'feature_name')` containing the cloud mask
         :type cloud_mask_feature: tuple(FeatureType, str)
         :param dem_feature: EOPatch DEM feature represented by a tuple in the form of `(FeatureType, 'feature_name')`
             containing the digital elevation model

--- a/ml_tools/eolearn/ml_tools/classifier.py
+++ b/ml_tools/eolearn/ml_tools/classifier.py
@@ -22,14 +22,14 @@ from .utilities import rolling_window
 
 
 class ImageBaseClassifier(ABC):
-    """
-    Abstract class for image classifiers.
+    """ Abstract class for image classifiers
 
     Image Classifier extends the receptive field of trained classifier with smaller
     receptive field over entire image. The classifier's receptive field is
     usually small, i.e.:
-        - pixel based classifier has receptive field (1,1)
-        - patch based classifier has receptive field (num_pixels_y, num_pixels_x)
+
+    - pixel based classifier has receptive field `(1,1)`
+    - patch based classifier has receptive field `(num_pixels_y, num_pixels_x)`
 
     Image Classifier divides the image into non-overlapping pieces of same size
     as trained classifier's receptive field and runs classifier over them thus
@@ -37,25 +37,22 @@ class ImageBaseClassifier(ABC):
 
     The classifier can be of any type as long as it has the following two
     methods implemented:
-        - predict(X)
-        - predict_proba(X)
+
+    - `predict(X)`
+    - `predict_proba(X)`
 
     This is true for all classifiers that follow scikit-learn's API.
     The APIs of scikit-learn's objects is described
     at: http://scikit-learn.org/stable/developers/contributing.html#apis-of-scikit-learn-objects.
-
-    Parameters:
-    -----------
-
-    classifier:
-        The actual trained classifier that will be executed over entire image
-
-    receptive_field: tuple, (n_rows, n_columns)
-        Sensitive area of the classifier ((1,1) for pixel based or (n,m) for patch base)
-
     """
 
     def __init__(self, classifier, receptive_field):
+        """
+        :param classifier: The actual trained classifier that will be executed over entire image
+        :type classifier: object
+        :param receptive_field: Sensitive area of the classifier ((1,1) for pixel based or (n,m) for patch base)
+        :type receptive_field: tuple, (n_rows, n_columns)
+        """
         self.receptive_field = receptive_field
 
         self._check_classifier(classifier)
@@ -107,64 +104,48 @@ class ImageBaseClassifier(ABC):
 
     @abstractmethod
     def image_predict(self, X):
-        """
-        Predicts class label for the entire image.
+        """ Predicts class label for the entire image.
 
-        Parameters:
-        -----------
-
-        X: array, shape = [n_samples, n_pixels_y, n_pixels_x, n_bands]
-            Array of training images
-
-        y: array, shape = [n_samples] or [n_samples, n_pixels_y, n_pixels_x]
-            Target labels or masks.
+        :param X: Data for prediction of shape `(n_samples, n_pixels_y, n_pixels_x, n_bands)`
+        :type X: np.ndarray
+        :returns: Predicted labels of shape `(n_samples,)` or `(n_samples, n_pixels_y, n_pixels_x)`
+        :rtype: np.ndarray
         """
         raise NotImplementedError
 
     @abstractmethod
     def image_predict_proba(self, X):
-        """
-        Predicts class probabilities for the entire image.
+        """ Predicts class probabilities for the entire image.
 
-        Parameters:
-        -----------
-
-        X: array, shape = [n_samples, n_pixels_x, n_pixels_y, n_bands]
-            Array of training images
-
-        y: array, shape = [n_samples] or [n_samples, n_pixels_x, n_pixels_y, n_classes]
-            Target probabilities
+        :param X: Data for prediction of shape `(n_samples, n_pixels_y, n_pixels_x, n_bands)`
+        :type X: np.ndarray
+        :returns: Predicted probabilities of shape `(n_samples,)` or `(n_samples, n_pixels_y, n_pixels_x, n_classes)`
+        :rtype: np.ndarray
         """
         raise NotImplementedError
 
 
 class ImagePixelClassifier(ImageBaseClassifier):
-    """
-    Pixel classifier divides the image into individual pixels,
-    runs classifier and collects the result in the shape of the input image.
+    """ Performs a per-pixel classification
 
-    Parameters:
-    -----------
-
-    classifier:
-        The actual trained classifier that will be executed over entire image
+    It divides the image into individual pixels, runs classifier and collects the result in the shape of the input
+    image.
     """
 
     def __init__(self, classifier):
+        """
+        :param classifier: The actual trained classifier that will be executed over entire image
+        :type classifier: object
+        """
         ImageBaseClassifier.__init__(self, classifier, (1, 1))
 
     def image_predict(self, X):
-        """
-        Predicts class label for the entire image.
+        """ Predicts class label for the entire image.
 
-        Parameters:
-        -----------
-
-        X: array, shape = [n_samples, n_pixels_y, n_pixels_x, n_bands]
-            Array of training images
-
-        y: array, shape = [n_samples] or [n_samples, n_pixels_y, n_pixels_x]
-            Target labels or masks.
+        :param X: Data for prediction of shape `(n_samples, n_pixels_y, n_pixels_x, n_bands)`
+        :type X: np.ndarray
+        :returns: Predicted labels of shape `(n_samples,)` or `(n_samples, n_pixels_y, n_pixels_x)`
+        :rtype: np.ndarray
         """
         self._check_image(X)
 
@@ -180,17 +161,12 @@ class ImagePixelClassifier(ImageBaseClassifier):
         return predictions.reshape(X.shape[0], X.shape[1], X.shape[2])
 
     def image_predict_proba(self, X):
-        """
-        Predicts class probabilities for the entire image.
+        """ Predicts class probabilities for the entire image.
 
-        Parameters:
-        -----------
-
-        X: array, shape = [n_samples, n_pixels_x, n_pixels_y, n_bands]
-            Array of training images
-
-        y: array, shape = [n_samples] or [n_samples, n_pixels_x, n_pixels_y, n_classes]
-            Target probabilities
+        :param X: Data for prediction of shape `(n_samples, n_pixels_y, n_pixels_x, n_bands)`
+        :type X: np.ndarray
+        :returns: Predicted probabilities of shape `(n_samples,)` or `(n_samples, n_pixels_y, n_pixels_x, n_classes)`
+        :rtype: np.ndarray
         """
         self._check_image(X)
 
@@ -208,25 +184,14 @@ class ImagePixelClassifier(ImageBaseClassifier):
 
 
 class ImagePatchClassifier(ImageBaseClassifier):
-    """
-    Patch classifier divides the image into non-overlapping patches of same size
-    as trained classifier's receptieve field and runs classifier over them thus
-    producing a classification mask of the same size as image.
+    """ Performs a per-patch classification
 
-    Parameters:
-    -----------
-
-    classifier:
-        The actual trained classifier that will be executed over entire image
-
-    receptive_field: tuple, (n_rows, n_columns)
-        Sensitive area of the classifier ((1,1) for pixel based or (n,m) for patch based)
-
+    It divides the image into non-overlapping patches of same size as trained classifier's receptieve field and
+    runs classifier over them thus producing a classification mask of the same size as image.
     """
 
     def _to_patches(self, X):
-        """
-        Reshapes input to patches of the size of classifier's receptive field.
+        """ Reshapes input to patches of the size of classifier's receptive field.
 
         For example:
 
@@ -256,17 +221,12 @@ class ImagePatchClassifier(ImageBaseClassifier):
         return image_view, new_shape
 
     def image_predict(self, X):
-        """
-        Predicts class label for the entire image.
+        """ Predicts class label for the entire image.
 
-        Parameters:
-        -----------
-
-        X: array, shape = [n_samples, n_pixels_y, n_pixels_x, n_bands]
-            Array of training images
-
-        y: array, shape = [n_samples] or [n_samples, n_pixels_y, n_pixels_x]
-            Target labels or masks.
+        :param X: Data for prediction of shape `(n_samples, n_pixels_y, n_pixels_x, n_bands)`
+        :type X: np.ndarray
+        :returns: Predicted labels of shape `(n_samples,)` or `(n_samples, n_pixels_y, n_pixels_x)`
+        :rtype: np.ndarray
         """
         self._check_image(X)
 
@@ -289,17 +249,12 @@ class ImagePatchClassifier(ImageBaseClassifier):
         return image_results
 
     def image_predict_proba(self, X):
-        """
-        Predicts class probabilities for the entire image.
+        """ Predicts class probabilities for the entire image.
 
-        Parameters:
-        -----------
-
-        X: array, shape = [n_samples, n_pixels_x, n_pixels_y, n_bands]
-            Array of training images
-
-        y: array, shape = [n_samples] or [n_samples, n_pixels_x, n_pixels_y, n_classes]
-            Target probabilities
+        :param X: Data for prediction of shape `(n_samples, n_pixels_y, n_pixels_x, n_bands)`
+        :type X: np.ndarray
+        :returns: Predicted probabilities of shape `(n_samples,)` or `(n_samples, n_pixels_y, n_pixels_x, n_classes)`
+        :rtype: np.ndarray
         """
         self._check_image(X)
 
@@ -323,32 +278,27 @@ class ImagePatchClassifier(ImageBaseClassifier):
 
 
 class ImagePixel2PatchClassifier(ImageBaseClassifier):
-    """
-    Pixel to patch classifier first performs classification on pixel level
+    """ Pixel to patch classifier first performs classification on pixel level
     and then combines the results in user defined patches. In case of combining
     probabilities the weighted sum is taken over all pixels in a patch. In case
     of predictions the user defines what fraction of pixels within the patch
     has to belong to signal class ot be considered as signal.
-
-    Parameters:
-    -----------
-
-    classifier:
-        The actual trained classifier that will be executed over entire image
-
-    patch_size: tuple, (n_rows, n_columns)
-        Patch size
-
-    target: int
-        Target class value. Set the patch class to this target class if its fractional representation within
-        this patch is above the target_threshols
-
-    target_threshold: float
-        See above
-
     """
 
     def __init__(self, classifier, patch_size, mode='mean_prob', target=None, target_threshold=None):
+        """
+        :param classifier: The actual trained classifier that will be executed over entire image
+        :type classifier: object
+        :param patch_size: A tuple defining `(n_rows, n_columns)`
+        :type patch_size: (int, int)
+        :param mode: The way predictions are obtained from prediction probabilities
+        :type mode: str
+        :param target: Target class value. Set the patch class to this target class if its fractional representation
+            within this patch is above the target_threshols
+        :param target: int or None
+        :param target_threshold: A target prediction threshold
+        :type target_threshold: float or None
+        """
         self.pixel_classifier = ImagePixelClassifier(classifier)
         self.patch_size = patch_size
         self.target = target
@@ -359,8 +309,7 @@ class ImagePixel2PatchClassifier(ImageBaseClassifier):
         ImageBaseClassifier.__init__(self, classifier, (1, 1))
 
     def _to_patches(self, X):
-        """
-        Reshapes input to patches of the size of classifier's receptive field.
+        """ Reshapes input to patches of the size of classifier's receptive field.
 
         For example:
 
@@ -369,7 +318,6 @@ class ImagePixel2PatchClassifier(ImageBaseClassifier):
         output: [n_samples * n_pixels_y/receptive_field_y * n_pixels_x/receptive_field_x,
                  receptive_field_y, receptive_field_x, n_bands]
         """
-
         window = self.patch_size
         asteps = self.patch_size
 
@@ -391,17 +339,12 @@ class ImagePixel2PatchClassifier(ImageBaseClassifier):
                     valuecount[self.target] / np.ma.size(array) >= self.target_threshold else 0
 
     def image_predict(self, X):
-        """
-        Predicts class label for the entire image.
+        """ Predicts class label for the entire image.
 
-        Parameters:
-        -----------
-
-        X: array, shape = [n_samples, n_pixels_y, n_pixels_x, n_bands]
-            Array of training images
-
-        y: array, shape = [n_samples] or [n_samples, n_pixels_y, n_pixels_x]
-            Target labels or masks.
+        :param X: Data for prediction of shape `(n_samples, n_pixels_y, n_pixels_x, n_bands)`
+        :type X: np.ndarray
+        :returns: Predicted labels of shape `(n_samples,)` or `(n_samples, n_pixels_y, n_pixels_x)`
+        :rtype: np.ndarray
         """
         self._check_image(X)
 
@@ -424,17 +367,12 @@ class ImagePixel2PatchClassifier(ImageBaseClassifier):
         return predictions
 
     def image_predict_proba(self, X):
-        """
-        Predicts class probabilities for the entire image.
+        """ Predicts class probabilities for the entire image.
 
-        Parameters:
-        -----------
-
-        X: array, shape = [n_samples, n_pixels_x, n_pixels_y, n_bands]
-            Array of training images
-
-        y: array, shape = [n_samples] or [n_samples, n_pixels_x, n_pixels_y, n_classes]
-            Target probabilities
+        :param X: Data for prediction of shape `(n_samples, n_pixels_y, n_pixels_x, n_bands)`
+        :type X: np.ndarray
+        :returns: Predicted probabilities of shape `(n_samples,)` or `(n_samples, n_pixels_y, n_pixels_x, n_classes)`
+        :rtype: np.ndarray
         """
         self._check_image(X)
 
@@ -456,22 +394,21 @@ class ImagePixel2PatchClassifier(ImageBaseClassifier):
 
 
 class ImageClassificationMaskTask(EOTask):
-    """
-    This task applies pixel-based uni-temporal classifier to each image in the patch
-    and appends to each image the classification mask.
+    """ This task applies pixel-based uni-temporal classifier to each image in the patch and appends to each image
+    the classification mask.
     """
     def __init__(self, input_feature, output_feature, classifier):
         """ Run a classification task on a EOPatch feature
 
-            Classifier is an instance of the ImageBaseClassifier that maps [w, h, d] numpy arrays (d-channel images)
-            into [w, h, 1] numpy arrays (classification masks).
+        Classifier is an instance of the ImageBaseClassifier that maps [w, h, d] numpy arrays (d-channel images)
+        into [w, h, 1] numpy arrays (classification masks).
 
-            :param input_feature: Feature which will be classified
-            :type input_feature: (FeatureType, str)
-            :param output_feature: Feature where classification results will be saved
-            :type output_feature: (FeatureType, str)
-            :param classifier: A classifier that works over [n, w, h, d]-dimensional numpy arrays.
-            :type classifier: ImageBaseClassifier
+        :param input_feature: Feature which will be classified
+        :type input_feature: (FeatureType, str)
+        :param output_feature: Feature where classification results will be saved
+        :type output_feature: (FeatureType, str)
+        :param classifier: A classifier that works over [n, w, h, d]-dimensional numpy arrays.
+        :type classifier: ImageBaseClassifier
         """
         self.input_feature = self._parse_features(input_feature)
         self.output_feature = self._parse_features(output_feature)
@@ -480,10 +417,10 @@ class ImageClassificationMaskTask(EOTask):
     def execute(self, eopatch):
         """ Transforms [n, w, h, d] eopatch into a [n, w, h, 1] eopatch, adding it the classification mask.
 
-            :param eopatch: An input EOPatch
-            :type eopatch: EOPatch
-            :return: Outputs EOPatch with n classification masks appended to out_feature_type with out_feature_name key
-            :rtype: EOPatch
+        :param eopatch: An input EOPatch
+        :type eopatch: EOPatch
+        :return: Outputs EOPatch with n classification masks appended to out_feature_type with out_feature_name key
+        :rtype: EOPatch
         """
         in_type, in_name = next(self.input_feature(eopatch))
         out_type, out_name = next(self.input_feature())

--- a/ml_tools/eolearn/ml_tools/truth_transformations.py
+++ b/ml_tools/eolearn/ml_tools/truth_transformations.py
@@ -16,28 +16,26 @@ import numpy as np
 
 
 class Mask2Label:
-    """
-    Transforms mask (shape n x m) into a single label. Transformation works in two modes:
-        - majority: assign label to the class with the largest contribution
-        - target: assign label to target if its contribution percentage is above or equal to target threshold.
-        In other cases label is set to 0.
-
-    The parameters target_value and target_threshold are taken into account only in target mode.
-
-    Parameters
-    ----------
-    mode: str ('majority', 'target')
-        conversion mode
-
-    target_value: int (default 1)
-        target value
-
-    target_threshold: float (default 0.5)
-        fraction of pixels in mask that need to belong to the target to be labeled as target
+    """ Transforms mask (shape n x m) into a single label.
     """
 
     def __init__(self, mode, target_value=1, target_threshold=0.5):
+        """
+        Transformation works in two modes:
 
+        - majority: assign label to the class with the largest contribution
+        - target: assign label to target if its contribution percentage is above or equal to target threshold.
+          In other cases label is set to 0.
+
+        The parameters target_value and target_threshold are taken into account only in target mode.
+
+        :param mode: A conversion mode, options are `'majority'` or `'target'`
+        :type mode: str
+        :param target_value: A target value
+        :type target_value: int
+        :param target_threshold: Fraction of pixels in mask that need to belong to the target to be labeled as target
+        :type target_threshold: float
+        """
         self.mode_ = mode
         if self.mode_ not in ['majority', 'target']:
             print('Invalid mode! Set mode to majority or target.')
@@ -60,10 +58,8 @@ class Mask2Label:
 
     def transform(self, X):
         """
-        Parameters
-        ----------
-        X : array-like, shape [n x m]
-            The mask in form of n x m array.
+        :param X: An array in form of (n, m)
+        :type X: np.ndarray
         """
         if self.mode_ == 'target':
             return np.apply_along_axis(self._target, 1, np.reshape(X, (X.shape[0], X.shape[1] * X.shape[2])))
@@ -79,16 +75,14 @@ class Mask2TwoClass:
     """
     The masks can include non-exclusive-multi-class labels described with bit pattern.
     This transformer simplifies the mask in form of bit-pattern to two class labels.
-
-    Parameters
-    ----------
-    positive_class_definition: int or string
-        int or string (bit pattern, i.e. '100001') defining the positive class
-        if argument is an int then the mask is not interpreted as bit pattern
     """
 
     def __init__(self, positive_class_definition):
-
+        """
+        :param positive_class_definition: A bit pattern, (e.g. '100001') defining the positive class
+            if argument is an int then the mask is not interpreted as bit pattern
+        :type positive_class_definition: int or string
+        """
         if isinstance(positive_class_definition, str):
             self.definition_ = int(positive_class_definition, 2)
             self.binary_ = True
@@ -98,10 +92,8 @@ class Mask2TwoClass:
 
     def transform(self, X):
         """
-        Parameters
-        ----------
-        X : array-like, shape [n x m]
-            The mask in form of n x m array.
+        :param X: An array in form of (n, m)
+        :type X: np.ndarray
         """
 
         if self.binary_:

--- a/ml_tools/eolearn/ml_tools/utilities.py
+++ b/ml_tools/eolearn/ml_tools/utilities.py
@@ -29,82 +29,81 @@ LOGGER = logging.getLogger(__name__)
 
 # This code was copied from https://gist.github.com/seberg/3866040
 def rolling_window(array, window=(0,), asteps=None, wsteps=None, axes=None, toend=True):
-    """Create a view of `array` which for every point gives the n-dimensional
-    neighbourhood of size window. New dimensions are added at the end of
-    `array` or after the corresponding original dimension.
+    """ Create a view of `array` which for every point gives the n-dimensional neighbourhood of size window. New
+    dimensions are added at the end of `array` or after the corresponding original dimension.
 
-    Parameters
-    ----------
-    array : array_like
-        Array to which the rolling window is applied.
-    window : int or tuple
-        Either a single integer to create a window of only the last axis or a
-        tuple to create it for the last len(window) axes. 0 can be used as a
-        to ignore a dimension in the window.
-    asteps : tuple
-        Aligned at the last axis, new steps for the original array, ie. for
-        creation of non-overlapping windows. (Equivalent to slicing result)
-    wsteps : int or tuple (same size as window)
-        steps for the added window dimensions. These can be 0 to repeat values
-        along the axis.
-    axes: int or tuple
-        If given, must have the same size as window. In this case window is
-        interpreted as the size in the dimension given by axes. IE. a window
-        of (2, 1) is equivalent to window=2 and axis=-2.
-    toend : bool
-        If False, the new dimensions are right after the corresponding original
-        dimension, instead of at the end of the array. Adding the new axes at the
-        end makes it easier to get the neighborhood, however toend=False will give
-        a more intuitive result if you view the whole array.
+    Examples:
 
-    Returns
-    -------
-    A view on `array` which is smaller to fit the windows and has windows added
-    dimensions (0s not counting), ie. every point of `array` is an array of size
-    window.
+    .. code-block:: python
 
-    Examples
-    --------
-    >>> a = np.arange(9).reshape(3,3)
-    >>> rolling_window(a, (2,2))
-    array([[[[0, 1],
-             [3, 4]],
-
-            [[1, 2],
-             [4, 5]]],
-
-
-           [[[3, 4],
-             [6, 7]],
-
-            [[4, 5],
-             [7, 8]]]])
+        >>> a = np.arange(9).reshape(3,3)
+        >>> rolling_window(a, (2,2))
+        array([[[[0, 1],
+                 [3, 4]],
+                [[1, 2],
+                 [4, 5]]],
+               [[[3, 4],
+                 [6, 7]],
+                [[4, 5],
+                 [7, 8]]]])
 
     Or to create non-overlapping windows, but only along the first dimension:
-    >>> rolling_window(a, (2,0), asteps=(2,1))
-    array([[[0, 3],
-            [1, 4],
-            [2, 5]]])
 
-    Note that the 0 is discared, so that the output dimension is 3:
-    >>> rolling_window(a, (2,0), asteps=(2,1)).shape
-    (1, 3, 2)
+    .. code-block:: python
 
-    This is useful for example to calculate the maximum in all (overlapping)
-    2x2 submatrixes:
-    >>> rolling_window(a, (2,2)).max((2,3))
-    array([[4, 5],
-           [7, 8]])
+        >>> rolling_window(a, (2,0), asteps=(2,1))
+        array([[[0, 3],
+                [1, 4],
+                [2, 5]]])
+
+    Note that the `0` is discared, so that the output dimension is `3`:
+
+    .. code-block:: python
+
+        >>> rolling_window(a, (2,0), asteps=(2,1)).shape
+        (1, 3, 2)
+
+    This is useful for example to calculate the maximum in all (overlapping) 2x2 submatrixes:
+
+    .. code-block:: python
+
+        >>> rolling_window(a, (2,2)).max((2,3))
+        array([[4, 5],
+               [7, 8]])
 
     Or delay embedding (3D embedding with delay 2):
-    >>> x = np.arange(10)
-    >>> rolling_window(x, 3, wsteps=2)
-    array([[0, 2, 4],
-           [1, 3, 5],
-           [2, 4, 6],
-           [3, 5, 7],
-           [4, 6, 8],
-           [5, 7, 9]])
+
+    .. code-block:: python
+
+        >>> x = np.arange(10)
+        >>> rolling_window(x, 3, wsteps=2)
+        array([[0, 2, 4],
+               [1, 3, 5],
+               [2, 4, 6],
+               [3, 5, 7],
+               [4, 6, 8],
+               [5, 7, 9]])
+
+    :param array: Array to which the rolling window is applied
+    :type array: np.ndarray
+    :param window: Either a single integer to create a window of only the last axis or a tuple to create it for
+        the last len(window) axes. 0 can be used as a to ignore a dimension in the window.
+    :type window: int or (int, int)
+    :param asteps: Aligned at the last axis, new steps for the original array, ie. for creation of non-overlapping
+        windows. (Equivalent to slicing result)
+    :type asteps: tuple
+    :param wsteps: Steps for the added window dimensions. These can be 0 to repeat values along the axis.
+    :type wsteps: int or tuple (same size as window) or None
+    :param axes: If given, must have the same size as window. In this case window is interpreted as the size in the
+        dimension given by axes. E.g. a window of (2, 1) is equivalent to window=2 and axis=-2.
+    :type axes: int or tuple
+    :param toend: If False, the new dimensions are right after the corresponding original dimension, instead of at
+        the end of the array. Adding the new axes at the end makes it easier to get the neighborhood, however
+        toend=False will give a more intuitive result if you view the whole array.
+    :type toend: bool
+    :returns: A view on `array` which is smaller to fit the windows and has windows added dimensions (0s not counting),
+        ie. every point of `array` is an array of size window.
+    :rtype: np.ndarray
     """
     # pylint: disable=too-many-branches
     # pylint: disable=too-many-statements

--- a/ml_tools/eolearn/ml_tools/validator.py
+++ b/ml_tools/eolearn/ml_tools/validator.py
@@ -20,38 +20,40 @@ import pandas as pd
 
 
 class SGMLBaseValidator(ABC):
-    """
-    Abstract class for various validations of SGML image classifiers.
+    """ Abstract class for various validations of SGML image classifiers.
 
     All the work is performed in the validate method, where
     for each EOPatch the following actions are performed:
-        - 1. execute WOWorkflow on EOPatch
-        - 2. extract ground truth (reference) from the EOPatch
-            - sets self.truth_masks
-            - the class values in ground truth has to the same as
-              in the provided dictionary
-        - 3. count truth labeled pixels
-            - sets self.pixel_truth_counts
-        - 4. extract classification from the EOPatch
-            - sets self.classification_masks
-        - 6. count classified pixels
-            - sets self.pixel_classification_counts
-        - 7. collect results
-            - sets pixel_truth_sum and pixel_classification_sum
 
-    Parameters:
-    -----------
+    - 1. execute WOWorkflow on EOPatch
+    - 2. extract ground truth (reference) from the EOPatch
 
-    workflow: EOWorkflow that is executed on EOPatches (can be simply load EOPacth)
+      * sets self.truth_masks
+      * the class values in ground truth has to the same as
+        in the provided dictionary
 
-    class_dictionary: dictionary
-        Dictionary of class names and class values.
+    - 3. count truth labeled pixels
 
-    validation_dirs: list
-        List of directories containing EOPatches of this validation sample
+      * sets self.pixel_truth_counts
+
+    - 4. extract classification from the EOPatch
+
+      * sets self.classification_masks
+
+    - 6. count classified pixels
+
+      * sets self.pixel_classification_counts
+
+    - 7. collect results
+
+      * sets pixel_truth_sum and pixel_classification_sum
     """
 
     def __init__(self, class_dictionary):
+        """
+        :param class_dictionary: Dictionary of class names and class values
+        :type class_dictionary: dict
+        """
         self.class_dictionary = class_dictionary
 
         self.n_validation_sets = 0
@@ -72,13 +74,7 @@ class SGMLBaseValidator(ABC):
 
     @abstractmethod
     def _transform_truth(self, patch):
-        """
-        Transform and extract the truth mask form the EOPatch and store the transformed masks in self.truth_masks.
-
-        Parameters:
-        -----------
-
-        patch: EOPatch containing ground truth
+        """ Transform and extract the truth mask form the EOPatch and store the transformed masks in self.truth_masks.
         """
 
     def reset_counters(self):

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,7 +2,7 @@ Sphinx
 sphinx-rtd-theme
 nbsphinx
 jupyter
-git+https://github.com/AleksMat/m2r@dev
+m2r2
 
 -e ./core
 -e ./coregistration


### PR DESCRIPTION
Changes:

- Documentation build was failing because the new Sphinx version wasn't compatible anymore with my fork of `m2r` package. Fortunately there exists now a stable and maintained fork `m2r2`. So I replaced a dependency and it worked.
- After that build was still failing and the issue was that Sphinx was parsing all example notebooks, even the ones that we don't include in the documentation. But then the new global timelapse notebook was using some extra package dependencies and because of that, the build would fail. I fixed this in a way that now only notebooks that we actually use in the documentation are being parsed and the other ones are left alone.
- After that, I decided to go through the entire documentation and fix all the errors about which Sphinx was complaining. This was quite a tedious process but I managed to fix everything. This has actually never been done before for eo-learn. Now Sphinx build process shows only a few warnings that are not problematic and would be hard to get rid of.