### PR TITLE
Clean up LULC example notebook

### DIFF
--- a/examples/land-cover-map/.gitignore
+++ b/examples/land-cover-map/.gitignore
@@ -4,6 +4,5 @@ figs
 tile-def
 eopatches
 eopatches_sampled
-grid_slovenia_500x500.gpkg
-model_SI_LULC.pkl
+results
 predicted_tiff


### PR DESCRIPTION
Made a few improvements to the example notebook, mainly:
- changes to satisfy PEP8 guidelines
- directory paths are now specified at the start and not over multiple cells
- longer variable names to improve readability
- fixed `numpy` deprecation warnings and an issue with dates