### PR TITLE
windows fix absolute paths

### DIFF
--- a/core/eolearn/core/fs_utils.py
+++ b/core/eolearn/core/fs_utils.py
@@ -62,8 +62,9 @@ def get_base_filesystem_and_path(*path_parts, **kwargs):
     entire_path = os.path.abspath(os.path.join(*path_parts))
     pure_path = PurePath(entire_path)
     posix_path = pure_path.relative_to(pure_path.anchor).as_posix()
+    filesystem_path = base_path.split('\\')[0] or '/'
 
-    return get_filesystem('/', **kwargs), posix_path
+    return get_filesystem(filesystem_path, **kwargs), posix_path
 
 
 def load_s3_filesystem(path, strict=False, config=None):

--- a/core/eolearn/core/fs_utils.py
+++ b/core/eolearn/core/fs_utils.py
@@ -62,7 +62,7 @@ def get_base_filesystem_and_path(*path_parts, **kwargs):
     entire_path = os.path.abspath(os.path.join(*path_parts))
     pure_path = PurePath(entire_path)
     posix_path = pure_path.relative_to(pure_path.anchor).as_posix()
-    filesystem_path = base_path.split('\\')[0] or '/'
+    filesystem_path = base_path.split('\\')[0] if '\\' in base_path else '/'
 
     return get_filesystem(filesystem_path, **kwargs), posix_path
 


### PR DESCRIPTION
Tests passing on Windows:
* relative paths using both Unix and WIndows syntax:
    *  `.\\test-folder`
    *  `./test-folder`
* absolute paths using Windows syntax, script on C drive :
    *  `C:\\Users\\pippo\\test-folder`  
    *  `H:\\test-folder`

Is there any other possibility that should be covered, that I am not aware of?