### PR TITLE
Fix mistake in description of MapFeatureTask

### DIFF
--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -394,7 +394,7 @@ class MapFeatureTask(EOTask):
         .. code-block:: python
 
             class MultiplyFeatures(MapFeatureTask):
-                def map_function(self, f):
+                def map_method(self, f):
                     return f * 2
 
             multiply = MultiplyFeatures({FeatureType.DATA: ['f1', 'f2', 'f3']},  # input features


### PR DESCRIPTION
The example in the description of `MapFeatureTask` incorrectly states that `map_function` has to be implemented when it should be `map_method`.