### PR TITLE
comparison_modes 

### DIFF
--- a/io/eolearn/io/geometry_io.py
+++ b/io/eolearn/io/geometry_io.py
@@ -261,11 +261,13 @@ class GeoDBVectorImportTask(_BaseVectorImportTask):
         """
         prepared_bbox = bbox.transform_bounds(self.dataset_crs).geometry.bounds if bbox else None
 
+        if 'comparison_mode' not in self.geodb_kwargs:
+            self.geodb_kwargs['comparison_mode'] = 'intersects'
+
         return self.geodb_client.get_collection_by_bbox(
             collection=self.geodb_collection,
             database=self.geodb_db,
             bbox=prepared_bbox,
-            comparison_mode="contains",
             bbox_crs=self.dataset_crs.epsg,
             **self.geodb_kwargs
         )

--- a/io/eolearn/tests/test_geometry_io.py
+++ b/io/eolearn/tests/test_geometry_io.py
@@ -75,13 +75,15 @@ def test_clipping_wrong_crs(gpkg_file):
     argnames='reproject, clip, n_features, bbox',
     ids=['bbox', 'bbox_smaller'],
     argvalues=[
-        (False, False, 193, BBox([857000, 6521500, 861000, 6525500], crs='epsg:2154')),
-        (True, True, 116, BBox([857400, 6521900, 860600, 6525100], crs='epsg:2154'))
+        (False, False, 227, BBox([857000, 6521500, 861000, 6525500], crs='epsg:2154')),
+        (True, True, 162, BBox([857400, 6521900, 860600, 6525100], crs='epsg:2154'))
     ])
 def test_import_from_geodb(geodb_client, reproject, clip, n_features, bbox):
     """Test for importing from GeoDB.
     It will only run if geodb credentials are available as the environment variables
     """
+    assert geodb_client.whoami, 'Client is not set-up correctly'
+
     feature = FeatureType.VECTOR_TIMELESS, 'lpis_iacs'
     import_task = GeoDBVectorImportTask(
         feature=feature,


### PR DESCRIPTION
geodb supports more `comparison_mode`s as advertised in docs.
The default for the ImportVectorTask should have been  'intersects', which this PR resolves.