### PR TITLE
ImportFromTiff task is now able to load tiff files with uppercase extension

### DIFF
--- a/io/eolearn/io/local_io.py
+++ b/io/eolearn/io/local_io.py
@@ -83,7 +83,7 @@ class BaseLocalIo(EOTask):
     def _generate_paths(path_template, timestamps):
         """ Uses a filename path template to create a list of actual filename paths
         """
-        if not (path_template.endswith('.tif') or path_template.endswith('.tiff')):
+        if not (path_template.lower().endswith('.tif') or path_template.lower().endswith('.tiff')):
             path_template = f'{path_template}.tif'
 
         if not timestamps:


### PR DESCRIPTION
I have been trying to load Landsat-8 data to EOPatch and find out that EO-learn is not able to load GeoTiff files with extension in uppercase, e.g:

```
BC/LC80500092014231LGN00/LC80500092014231LGN00_B9.TIF
```

## How to reproduce?

```
$ cp ./example_data/import-tiff-test2.tiff ./example_data/import-tiff-test3.TIF
```

and then loading in interactive python shell results in something like this:
```python
Python 3.8.8 (v3.8.8:024d8058b0, Feb 19 2021, 08:48:17) 
[Clang 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from eolearn.io import ExportToTiff, ImportFromTiff
>>> from eolearn.core import EOPatch, FeatureType, MergeFeatureTask
>>> task_load = ImportFromTiff((FeatureType.DATA_TIMELESS, 'DATA'))
>>> eo_patch = task_load.execute(filename="./example_data/import-tiff-test3.TIF")
Traceback (most recent call last):
  File "venv/lib/python3.8/site-packages/fs/osfs.py", line 356, in openbin
    binary_file = io.open(
FileNotFoundError: [Errno 2] No such file or directory: b'./example_data/import-tiff-test3.TIF.tif'
```

We can see that `.tif` extension has been added to the end of the path.

This PR changes the way how the extension is checked by converting the whole path to lowercase before checking for `endswith`.

Should I include also a unit test, or it is not needed for such a tiny change?