### PR TITLE
Update tests to use pytest

### DIFF
--- a/features/eolearn/features/temporal_features.py
+++ b/features/eolearn/features/temporal_features.py
@@ -84,8 +84,8 @@ class AddSpatioTemporalFeaturesTask(EOTask):
         """
         # pylint: disable=invalid-name
         amax_ndvi, amin_ndvi = eopatch.data_timeless[self.argmax_ndvi], eopatch.data_timeless[self.argmin_ndvi]
-        amax_ndvi_slope, amin_ndvi_slope = eopatch.data_timeless[self.argmax_ndvi_slope], \
-                                           eopatch.data_timeless[self.argmin_ndvi_slope]
+        amax_ndvi_slope = eopatch.data_timeless[self.argmax_ndvi_slope]
+        amin_ndvi_slope = eopatch.data_timeless[self.argmin_ndvi_slope]
         amax_red = eopatch.data_timeless[self.argmax_red]
 
         stf_idx = [amax_ndvi, amin_ndvi, amax_ndvi_slope, amin_ndvi_slope, amax_red]

--- a/features/eolearn/tests/conftest.py
+++ b/features/eolearn/tests/conftest.py
@@ -1,0 +1,24 @@
+"""
+Module with global fixtures
+"""
+import os
+
+import pytest
+
+from eolearn.core import EOPatch
+
+
+TEST_EOPATCH_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'TestInputs', 'TestPatch')
+EXAMPLE_EOPATCH_PATH = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', 'example_data', 'TestEOPatch'
+)
+
+
+@pytest.fixture(name='test_eopatch')
+def test_eopatch_fixture():
+    return EOPatch.load(TEST_EOPATCH_PATH, lazy_loading=True)
+
+
+@pytest.fixture(name='example_eopatch')
+def example_eopatch_fixture():
+    return EOPatch.load(EXAMPLE_EOPATCH_PATH, lazy_loading=True)

--- a/features/eolearn/tests/conftest.py
+++ b/features/eolearn/tests/conftest.py
@@ -9,9 +9,8 @@ from eolearn.core import EOPatch
 
 
 TEST_EOPATCH_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'TestInputs', 'TestPatch')
-EXAMPLE_EOPATCH_PATH = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', 'example_data', 'TestEOPatch'
-)
+EXAMPLE_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', 'example_data')
+EXAMPLE_EOPATCH_PATH = os.path.join(EXAMPLE_DATA_PATH, 'TestEOPatch')
 
 
 @pytest.fixture(name='test_eopatch')

--- a/features/eolearn/tests/test_blob.py
+++ b/features/eolearn/tests/test_blob.py
@@ -8,115 +8,53 @@ Copyright (c) 2017-2019 Matej Aleksandrov, Devis Peresutti (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+import copy
 
-import unittest
-import os.path
+import pytest
+from pytest import approx
 import numpy as np
+from numpy.testing import assert_array_equal
 from skimage.feature import blob_dog
 
-from eolearn.core import EOPatch, FeatureType
+from eolearn.core import FeatureType
 from eolearn.features import BlobTask, DoGBlobTask, LoGBlobTask, DoHBlobTask
 
 
-class TestBlob(unittest.TestCase):
-
-    TEST_PATCH_FILENAME = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'TestInputs', 'TestPatch')
-
-    @classmethod
-    def setUpClass(cls):
-        cls.patch = EOPatch.load(cls.TEST_PATCH_FILENAME)
-        cls._prepare_patch(cls.patch)
-
-        BlobTask((FeatureType.DATA, 'ndvi', 'blob'), blob_dog, sigma_ratio=1.6, min_sigma=1, max_sigma=30,
-                 overlap=0.5, threshold=0).execute(cls.patch)
-        DoGBlobTask((FeatureType.DATA, 'ndvi', 'blob_dog'), threshold=0).execute(cls.patch)
-        LoGBlobTask((FeatureType.DATA, 'ndvi', 'blob_log'), log_scale=True, threshold=0).execute(cls.patch)
-        DoHBlobTask((FeatureType.DATA, 'ndvi', 'blob_doh'), num_sigma=5, threshold=0).execute(cls.patch)
-
-        cls.initial_patch = EOPatch.load(cls.TEST_PATCH_FILENAME)
-        cls._prepare_patch(cls.initial_patch)
-
-    @staticmethod
-    def _prepare_patch(patch):
-        ndvi = patch.data['ndvi'][:10]
-        ndvi[np.isnan(ndvi)] = 0
-        patch.data['ndvi'] = ndvi
-
-    def test_blob_feature(self):
-        self.assertTrue(np.allclose(self.patch.data['blob'], self.patch.data['blob_dog']),
-                        msg='DoG derived class result not equal to base class result')
-
-    def test_dog_feature(self):
-        blob = self.patch.data['blob_dog']
-        delta = 1e-4
-
-        test_min = np.min(blob)
-        exp_min = 0.0
-        self.assertAlmostEqual(test_min, exp_min, delta=delta, msg="Expected min {}, got {}".format(exp_min, test_min))
-
-        test_max = np.max(blob)
-        exp_max = 37.9625
-        self.assertAlmostEqual(test_max, exp_max, delta=delta, msg="Expected max {}, got {}".format(exp_max, test_max))
-
-        test_mean = np.mean(blob)
-        exp_mean = 0.0545
-        self.assertAlmostEqual(test_mean, exp_mean, delta=delta,
-                               msg="Expected mean {}, got {}".format(exp_mean, test_mean))
-
-        test_median = np.median(blob)
-        exp_median = 0.0
-        self.assertAlmostEqual(test_median, exp_median, delta=delta,
-                               msg="Expected median {}, got {}".format(exp_median, test_median))
-
-    def test_log_feature(self):
-        blob = self.patch.data['blob_log']
-        delta = 5e-4
-
-        test_min = np.min(blob)
-        exp_min = 0.0
-        self.assertAlmostEqual(test_min, exp_min, delta=delta, msg="Expected min {}, got {}".format(exp_min, test_min))
-
-        test_max = np.max(blob)
-        exp_max = 13.65408
-        self.assertAlmostEqual(test_max, exp_max, delta=delta, msg="Expected max {}, got {}".format(exp_max, test_max))
-
-        test_mean = np.mean(blob)
-        exp_mean = 0.05728
-        self.assertAlmostEqual(test_mean, exp_mean, delta=delta,
-                               msg="Expected mean {}, got {}".format(exp_mean, test_mean))
-
-        test_median = np.median(blob)
-        exp_median = 0.0
-        self.assertAlmostEqual(test_median, exp_median, delta=delta,
-                               msg="Expected median {}, got {}".format(exp_median, test_median))
-
-    def test_doh_feature(self):
-        blob = self.patch.data['blob_doh']
-        delta = 1e-4
-
-        test_min = np.min(blob)
-        exp_min = 0.0
-        self.assertAlmostEqual(test_min, exp_min, delta=delta, msg="Expected min {}, got {}".format(exp_min, test_min))
-
-        test_max = np.max(blob)
-        exp_max = 1.4142
-        self.assertAlmostEqual(test_max, exp_max, delta=delta, msg="Expected max {}, got {}".format(exp_max, test_max))
-
-        test_mean = np.mean(blob)
-        exp_mean = 0.0007
-        self.assertAlmostEqual(test_mean, exp_mean, delta=delta,
-                               msg="Expected mean {}, got {}".format(exp_mean, test_mean))
-
-        test_median = np.median(blob)
-        exp_median = 0.0
-        self.assertAlmostEqual(test_median, exp_median, delta=delta,
-                               msg="Expected median {}, got {}".format(exp_median, test_median))
-
-    def test_unchanged_features(self):
-        for feature, value in self.initial_patch.data.items():
-            self.assertTrue(np.array_equal(value, self.patch.data[feature]),
-                            msg="EOPatch data feature '{}' was changed in the process".format(feature))
+FEATURE = (FeatureType.DATA, 'ndvi', 'blob')
 
 
-if __name__ == '__main__':
-    unittest.main()
+@pytest.fixture(name='eopatch')
+def eopatch_fixture(test_eopatch):
+    ndvi = test_eopatch.data['ndvi'][:10]
+    ndvi[np.isnan(ndvi)] = 0
+    test_eopatch.data['ndvi'] = ndvi
+    return test_eopatch
+
+
+def test_blob_feature(eopatch):
+    BlobTask(FEATURE, blob_dog, sigma_ratio=1.6, min_sigma=1, max_sigma=30, overlap=0.5, threshold=0)(eopatch)
+    DoGBlobTask((FeatureType.DATA, 'ndvi', 'blob_dog'), threshold=0)(eopatch)
+    assert eopatch.data['blob'] == approx(eopatch.data['blob_dog']), \
+        'DoG derived class result not equal to base class result'
+
+
+@pytest.mark.parametrize('task, expected_min, expected_max, expected_mean, expected_median', (
+    [DoGBlobTask(FEATURE, threshold=0), 0.0, 37.9625, 0.0545, 0.0],
+    [LoGBlobTask(FEATURE, log_scale=True, threshold=0), 0, 13.65408, 0.05768, 0.0],
+    [DoHBlobTask(FEATURE, num_sigma=5, threshold=0), 0.0, 1.4142, 0.0007, 0.0],
+))
+def test_haralick(eopatch, task, expected_min, expected_max, expected_mean, expected_median):
+    initial_patch = copy.deepcopy(eopatch)
+    task.execute(eopatch)
+
+    # Test that no other features were modified
+    for feature, value in initial_patch.data.items():
+        assert_array_equal(value, eopatch.data[feature], err_msg=f"EOPatch data feature '{feature}' has changed")
+
+    delta = 1e-4
+
+    blob = eopatch.data[FEATURE[-1]]
+    assert np.min(blob) == approx(expected_min, abs=delta)
+    assert np.max(blob) == approx(expected_max, abs=delta)
+    assert np.mean(blob) == approx(expected_mean, abs=delta)
+    assert np.median(blob) == approx(expected_median, abs=delta)

--- a/features/eolearn/tests/test_doubly_logistic_approximation.py
+++ b/features/eolearn/tests/test_doubly_logistic_approximation.py
@@ -1,53 +1,30 @@
-import unittest
-import os.path
+from pytest import approx
 import numpy as np
+
 from eolearn.core import EOPatch, FeatureType
 from eolearn.features.doubly_logistic_approximation import DoublyLogisticApproximationTask
 
 
-class TestDoublyLogisticApproximation(unittest.TestCase):
-    TEST_PATCH_FILENAME = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../example_data',
-                                       'TestEOPatch')
+def test_double_logistic_approximation(example_eopatch):
 
-    @classmethod
-    def setUpClass(cls):
-        cls.patch = EOPatch.load(cls.TEST_PATCH_FILENAME)
-        data = cls.patch.data['NDVI']
-        timestamps = cls.patch.timestamp
-        mask = cls.patch.mask['IS_VALID']
-        indices = list(np.nonzero([t.year == 2016 for t in timestamps])[0])
-        cls.patch = EOPatch()
-        cls.patch.timestamp = timestamps[indices[0]:(indices[-1] + 2)]
-        cls.patch.data['TEST'] = np.reshape(data[indices[0]:(indices[-1] + 2), 0, 0, 0], (-1, 1, 1, 1))
-        cls.patch.mask['IS_VALID'] = np.reshape(mask[indices[0]:(indices[-1] + 2), 0, 0, 0], (-1, 1, 1, 1))
-        cls.patch = DoublyLogisticApproximationTask(feature='TEST', valid_mask=(FeatureType.MASK, 'IS_VALID'),
-                                                    new_feature=f'TEST_OUT').execute(cls.patch)
+    data = example_eopatch.data['NDVI']
+    timestamps = example_eopatch.timestamp
+    mask = example_eopatch.mask['IS_VALID']
+    indices = list(np.nonzero([t.year == 2016 for t in timestamps])[0])
+    start, stop = indices[0], indices[-1] + 2
 
-    def test_parameters(self):
-        c1, c2, a1, a2, a3, a4, a5 = self.patch.data_timeless['TEST_OUT'].squeeze()
-        delta = 0.1
+    eopatch = EOPatch()
+    eopatch.timestamp = timestamps[start:stop]
+    eopatch.data['TEST'] = np.reshape(data[start:stop, 0, 0, 0], (-1, 1, 1, 1))
+    eopatch.mask['IS_VALID'] = np.reshape(mask[start:stop, 0, 0, 0], (-1, 1, 1, 1))
+    eopatch = DoublyLogisticApproximationTask(
+        feature='TEST', valid_mask=(FeatureType.MASK, 'IS_VALID'), new_feature='TEST_OUT'
+    ).execute(eopatch)
 
-        exp_c1 = 0.207
-        self.assertAlmostEqual(c1, exp_c1, delta=delta)
+    names = 'c1', 'c2', 'a1', 'a2', 'a3', 'a4', 'a5'
+    values = eopatch.data_timeless['TEST_OUT'].squeeze()
+    expected_values = 0.207, 0.464, 0.686, 0.222, 1.204, 0.406, 15.701
+    delta = 0.1
 
-        exp_c2 = 0.464
-        self.assertAlmostEqual(c2, exp_c2, delta=delta)
-
-        exp_a1 = 0.686
-        self.assertAlmostEqual(a1, exp_a1, delta=delta)
-
-        exp_a2 = 0.222
-        self.assertAlmostEqual(a2, exp_a2, delta=delta)
-
-        exp_a3 = 1.204
-        self.assertAlmostEqual(a3, exp_a3, delta=delta)
-
-        exp_a4 = 0.406
-        self.assertAlmostEqual(a4, exp_a4, delta=delta)
-
-        exp_a5 = 15.701
-        self.assertAlmostEqual(a5, exp_a5, delta=delta)
-
-
-if __name__ == '__main__':
-    unittest.main()
+    for name, value, expected_value in zip(names, values, expected_values):
+        assert value == approx(expected_value, abs=delta), f'Missmatch in value of {name}'

--- a/features/eolearn/tests/test_feature_extractor.py
+++ b/features/eolearn/tests/test_feature_extractor.py
@@ -7,44 +7,37 @@ Copyright (c) 2017-2019 Blaž Sovdat, Nejc Vesel, Jovan Višnjić, Anže Zupanc,
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-
-import unittest
+import numpy as np
 
 from eolearn.features import feature_extractor as fe
 from eolearn.features import FeatureExtractionTask
 from eolearn.core import EOPatch, FeatureType
 
-import numpy as np
+
+def test_simple():
+    x = [1.0] * 13
+    fee = fe.FeatureExtendedExtractor(
+        "B8A ; B09 ; B08 ; I(B02, B03) ; S(B05, B03) ; R(B01, B02) ; D(B01, B02, B03) ; I(B8A, B04)"
+        )
+    assert fee(x) == [1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 2.0, 0.0]
 
 
-class TestFeatureExtendedExtractor(unittest.TestCase):
-    def test_simple(self):
-        x = [1.0] * 13
-        fee = fe.FeatureExtendedExtractor("B8A ; B09 ; B08 ; I(B02, B03) ; S(B05, B03) ; R(B01, B02) ; D(B01, B02, B03)"
-                                          " ; I(B8A, B04)")
-        self.assertEqual(fee(x), [1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 2.0, 0.0])
-
-    def test_nested(self):
-        x = [1.0] * 13
-        fee = fe.FeatureExtendedExtractor("D(D(B8, B7, B2), D(B1, B2, B3), R(B10, B8A))")
-        self.assertEqual(fee(x), [4.0])
+def test_nested():
+    x = [1.0] * 13
+    fee = fe.FeatureExtendedExtractor("D(D(B8, B7, B2), D(B1, B2, B3), R(B10, B8A))")
+    assert fee(x) == [4.0]
 
 
-class TestFeatureExtractionTask(unittest.TestCase):
-    def test_add_ndvi(self):
-        a = np.arange(2 * 3 * 3 * 13).reshape(2, 3, 3, 13)
-        eop = EOPatch()
-        eop[FeatureType.DATA]['bands'] = a
+def test_add_ndvi():
+    array = np.arange(2 * 3 * 3 * 13).reshape(2, 3, 3, 13)
+    eopatch = EOPatch()
+    eopatch[FeatureType.DATA]['bands'] = array
 
-        eotask_ndvi = FeatureExtractionTask((FeatureType.DATA, 'bands', 'ndvi'), 'I(B4, B8A)')
+    eotask_ndvi = FeatureExtractionTask((FeatureType.DATA, 'bands', 'ndvi'), 'I(B4, B8A)')
 
-        eop_ndvi = eotask_ndvi(eop)
+    eopatch_ndvi = eotask_ndvi(eopatch)
 
-        in_shape = eop.data['bands'].shape
-        out_shape = in_shape[:-1] + (1,)
+    in_shape = eopatch.data['bands'].shape
+    out_shape = in_shape[:-1] + (1,)
 
-        self.assertEqual(eop_ndvi.data['ndvi'].shape, out_shape)
-
-
-if __name__ == '__main__':
-    unittest.main()
+    assert eopatch_ndvi.data['ndvi'].shape == out_shape

--- a/features/eolearn/tests/test_feature_manipulation.py
+++ b/features/eolearn/tests/test_feature_manipulation.py
@@ -38,7 +38,7 @@ def test_content_after_timefilter():
     old_interval = (timestamps[0], timestamps[-1])
     new_interval = (timestamps[new_start], timestamps[new_end])
 
-    new_timestamps = [ts for ts in timestamps[new_start:new_end+1]]
+    new_timestamps = timestamps[new_start:new_end+1]
 
     eop = EOPatch(timestamp=timestamps, data={'data': data}, meta_info={'time_interval': old_interval})
 

--- a/features/eolearn/tests/test_feature_manipulation.py
+++ b/features/eolearn/tests/test_feature_manipulation.py
@@ -8,133 +8,139 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import unittest
 import datetime
+
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose, assert_array_equal
 
 from eolearn.features import FilterTimeSeries, ValueFilloutTask
 from eolearn.core import EOPatch, FeatureType
 
-import numpy as np
+
+def test_content_after_timefilter():
+    timestamps = [
+        datetime.datetime(2017, 1, 1, 10, 4, 7),
+        datetime.datetime(2017, 1, 4, 10, 14, 5),
+        datetime.datetime(2017, 1, 11, 10, 3, 51),
+        datetime.datetime(2017, 1, 14, 10, 13, 46),
+        datetime.datetime(2017, 1, 24, 10, 14, 7),
+        datetime.datetime(2017, 2, 10, 10, 1, 32),
+        datetime.datetime(2017, 2, 20, 10, 6, 35),
+        datetime.datetime(2017, 3, 2, 10, 0, 20),
+        datetime.datetime(2017, 3, 12, 10, 7, 6),
+        datetime.datetime(2017, 3, 15, 10, 12, 14)
+    ]
+    data = np.random.rand(10, 100, 100, 3)
+
+    new_start, new_end = 4, -3
+
+    old_interval = (timestamps[0], timestamps[-1])
+    new_interval = (timestamps[new_start], timestamps[new_end])
+
+    new_timestamps = [ts for ts in timestamps[new_start:new_end+1]]
+
+    eop = EOPatch(timestamp=timestamps, data={'data': data}, meta_info={'time_interval': old_interval})
+
+    filter_task = FilterTimeSeries(start_date=new_interval[0], end_date=new_interval[1])
+    filter_task.execute(eop)
+
+    updated_interval = eop.meta_info['time_interval']
+    updated_timestamps = eop.timestamp
+
+    assert new_interval == updated_interval
+    assert new_timestamps == updated_timestamps
 
 
-class TestFeatureManipulation(unittest.TestCase):
+def test_fill():
+    array = np.array([
+        [np.NaN]*4 + [1., 2., 3., 4.] + [np.NaN]*3,
+        [1., np.NaN, np.NaN, 2., 3., np.NaN, np.NaN, np.NaN, 4., np.NaN, 5.]
+    ])
 
-    def test_content_after_timefilter(self):
-        timestamps = [datetime.datetime(2017, 1, 1, 10, 4, 7),
-                      datetime.datetime(2017, 1, 4, 10, 14, 5),
-                      datetime.datetime(2017, 1, 11, 10, 3, 51),
-                      datetime.datetime(2017, 1, 14, 10, 13, 46),
-                      datetime.datetime(2017, 1, 24, 10, 14, 7),
-                      datetime.datetime(2017, 2, 10, 10, 1, 32),
-                      datetime.datetime(2017, 2, 20, 10, 6, 35),
-                      datetime.datetime(2017, 3, 2, 10, 0, 20),
-                      datetime.datetime(2017, 3, 12, 10, 7, 6),
-                      datetime.datetime(2017, 3, 15, 10, 12, 14)]
-        data = np.random.rand(10, 100, 100, 3)
+    array_ffill = ValueFilloutTask.fill(array, operation='f')
+    array_bfill = ValueFilloutTask.fill(array, operation='b')
+    array_fbfill = ValueFilloutTask.fill(array_ffill, operation='b')
 
-        new_start = 4
-        new_end = -3
+    assert_allclose(
+        array_ffill,
+        np.array([[np.NaN]*4 + [1., 2., 3., 4., 4., 4., 4.], [1., 1., 1., 2., 3., 3., 3., 3., 4., 4., 5.]]),
+        equal_nan=True
+    )
 
-        old_interval = (timestamps[0], timestamps[-1])
-        new_interval = (timestamps[new_start], timestamps[new_end])
+    assert_allclose(
+        array_bfill,
+        np.array([[1., 1., 1., 1., 1., 2., 3., 4.] + [np.NaN]*3, [1., 2., 2., 2., 3., 4., 4., 4., 4., 5., 5.]]),
+        equal_nan=True
+    )
 
-        new_timestamps = [ts for ts in timestamps[new_start:new_end+1]]
-
-        eop = EOPatch(timestamp=timestamps,
-                      data={'data': data},
-                      meta_info={'time_interval': old_interval})
-
-        filter_task = FilterTimeSeries(start_date=new_interval[0], end_date=new_interval[1])
-        filter_task.execute(eop)
-
-        updated_interval = eop.meta_info['time_interval']
-        updated_timestamps = eop.timestamp
-
-        self.assertEqual(new_interval, updated_interval)
-        self.assertEqual(new_timestamps, updated_timestamps)
-
-    def test_fill(self):
-        array = np.array([[np.NaN]*4 + [1., 2., 3., 4.] + [np.NaN]*3,
-                          [1., np.NaN, np.NaN, 2., 3., np.NaN, np.NaN, np.NaN, 4., np.NaN, 5.]])
-
-        array_ffill = ValueFilloutTask.fill(array, operation='f')
-        array_bfill = ValueFilloutTask.fill(array, operation='b')
-        array_fbfill = ValueFilloutTask.fill(array_ffill, operation='b')
-
-        self.assertTrue(np.array_equal(array_ffill,
-                                       np.array([[np.NaN]*4 + [1., 2., 3., 4., 4., 4., 4.],
-                                                 [1., 1., 1., 2., 3., 3., 3., 3., 4., 4., 5.]]),
-                                       equal_nan=True))
-
-        self.assertTrue(np.array_equal(array_bfill,
-                                       np.array([[1., 1., 1., 1., 1., 2., 3., 4.] + [np.NaN]*3,
-                                                 [1., 2., 2., 2., 3., 4., 4., 4., 4., 5., 5.]]),
-                                       equal_nan=True))
-
-        self.assertTrue(np.array_equal(array_fbfill,
-                                       np.array([[1., 1., 1., 1., 1., 2., 3., 4., 4., 4., 4.],
-                                                 [1., 1., 1., 2., 3., 3., 3., 3., 4., 4., 5.]]),
-                                       equal_nan=True))
-
-    def test_value_fillout(self):
-        feature = (FeatureType.DATA, 'TEST')
-        shape = (8, 10, 10, 5)
-        data = np.random.randint(0, 100, size=shape).astype(float)
-        eopatch = EOPatch(data={'TEST': data})
-
-        self.assertRaises(ValueError, ValueFilloutTask, feature, operations='x')
-        self.assertRaises(ValueError, ValueFilloutTask, feature, operations=4)
-
-        self.assertRaises(ValueError, ValueFilloutTask.fill, None, operation='f')
-        self.assertRaises(ValueError, ValueFilloutTask.fill, np.zeros((4, 5)), operation='x')
-
-        # nothing to be filled, return the same eopatch object immediately
-        eopatch_new = ValueFilloutTask(feature, operations='fb', axis=0)(eopatch)
-        self.assertEqual(eopatch, eopatch_new)
-
-        eopatch[feature][0, 0, 0, :] = np.nan
-
-        def execute_fillout(eopatch, feature, **kwargs):
-            input_array = eopatch[feature]
-            eopatch = ValueFilloutTask(feature, **kwargs)(eopatch)
-            output_array = eopatch[feature]
-            return eopatch, input_array, output_array
-
-        # filling forward temporally should not fill nans
-        eopatch, input_array, output_array = execute_fillout(eopatch, feature, operations='f', axis=0)
-        compare_mask = ~np.isnan(input_array)
-        self.assertTrue(np.isnan(output_array[0, 0, 0, :]).all())
-        self.assertTrue(np.array_equal(input_array[compare_mask], output_array[compare_mask]))
-        self.assertNotEqual(id(input_array), id(output_array))
-
-        # filling in any direction along axis=-1 should also not fill nans since all neighbors are nans
-        eopatch, input_array, output_array = execute_fillout(eopatch, feature, operations='fb', axis=-1)
-        self.assertTrue(np.isnan(output_array[0, 0, 0, :]).all())
-        self.assertNotEqual(id(input_array), id(output_array))
-
-        # filling nans backwards temporally should fill nans
-        eopatch, input_array, output_array = execute_fillout(eopatch, feature, operations='b', axis=0)
-        self.assertFalse(np.isnan(output_array).any())
-        self.assertNotEqual(id(input_array), id(output_array))
-
-        # try filling something else than nan (e.g.: -1)
-        eopatch[feature][0, :, 0, 0] = -1
-        eopatch, input_array, output_array = execute_fillout(eopatch, feature, operations='b', value=-1, axis=-1)
-        self.assertFalse((output_array == -1).any())
-        self.assertNotEqual(id(input_array), id(output_array))
-
-        # [nan, 1, nan, 2, ... ]  ---('fb')---> [1, 1, 1, 2, ... ]
-        eopatch[feature][0, 0, 0, 0:4] = [np.nan, 1, np.nan, 2]
-        eopatch, input_array, output_array = execute_fillout(eopatch, feature, operations='fb', axis=-1)
-        self.assertTrue(np.array_equal(output_array[0, 0, 0, 0:4], [1, 1, 1, 2]))
-        self.assertNotEqual(id(input_array), id(output_array))
-
-        # [nan, 1, nan, 2, ... ]  ---('bf')---> [1, 1, 2, 2, ... ]
-        eopatch[feature][0, 0, 0, 0:4] = [np.nan, 1, np.nan, 2]
-        eopatch, input_array, output_array = execute_fillout(eopatch, feature, operations='bf', axis=-1)
-        self.assertTrue(np.array_equal(output_array[0, 0, 0, 0:4], [1, 1, 2, 2]))
-        self.assertNotEqual(id(input_array), id(output_array))
+    assert_allclose(
+        array_fbfill,
+        np.array([[1., 1., 1., 1., 1., 2., 3., 4., 4., 4., 4.], [1., 1., 1., 2., 3., 3., 3., 3., 4., 4., 5.]]),
+        equal_nan=True
+    )
 
 
-if __name__ == '__main__':
-    unittest.main()
+@pytest.mark.parametrize('input_feature, operation', [
+    ((FeatureType.DATA, 'TEST'), 'x'),
+    ((FeatureType.DATA, 'TEST'), 4),
+    (None, 'f'),
+    (np.zeros((4, 5)), 'x')
+])
+def test_bad_input(input_feature, operation):
+    with pytest.raises(ValueError):
+        ValueFilloutTask(input_feature, operations=operation)
+
+
+def test_value_fillout():
+    feature = (FeatureType.DATA, 'TEST')
+    shape = (8, 10, 10, 5)
+    data = np.random.randint(0, 100, size=shape).astype(float)
+    eopatch = EOPatch(data={'TEST': data})
+
+    # nothing to be filled, return the same eopatch object immediately
+    eopatch_new = ValueFilloutTask(feature, operations='fb', axis=0)(eopatch)
+    assert eopatch == eopatch_new
+
+    eopatch[feature][0, 0, 0, :] = np.nan
+
+    def execute_fillout(eopatch, feature, **kwargs):
+        input_array = eopatch[feature]
+        eopatch = ValueFilloutTask(feature, **kwargs)(eopatch)
+        output_array = eopatch[feature]
+        return eopatch, input_array, output_array
+
+    # filling forward temporally should not fill nans
+    eopatch, input_array, output_array = execute_fillout(eopatch, feature, operations='f', axis=0)
+    compare_mask = ~np.isnan(input_array)
+    assert np.isnan(output_array[0, 0, 0, :]).all()
+    assert_array_equal(input_array[compare_mask], output_array[compare_mask])
+    assert id(input_array) != id(output_array)
+
+    # filling in any direction along axis=-1 should also not fill nans since all neighbors are nans
+    eopatch, input_array, output_array = execute_fillout(eopatch, feature, operations='fb', axis=-1)
+    assert np.isnan(output_array[0, 0, 0, :]).all()
+    assert id(input_array) != id(output_array)
+
+    # filling nans backwards temporally should fill nans
+    eopatch, input_array, output_array = execute_fillout(eopatch, feature, operations='b', axis=0)
+    assert not np.isnan(output_array).any()
+    assert id(input_array) != id(output_array)
+
+    # try filling something else than nan (e.g.: -1)
+    eopatch[feature][0, :, 0, 0] = -1
+    eopatch, input_array, output_array = execute_fillout(eopatch, feature, operations='b', value=-1, axis=-1)
+    assert not (output_array == -1).any()
+    assert id(input_array) != id(output_array)
+
+    # [nan, 1, nan, 2, ... ]  ---('fb')---> [1, 1, 1, 2, ... ]
+    eopatch[feature][0, 0, 0, 0:4] = [np.nan, 1, np.nan, 2]
+    eopatch, input_array, output_array = execute_fillout(eopatch, feature, operations='fb', axis=-1)
+    assert_array_equal(output_array[0, 0, 0, 0:4], [1, 1, 1, 2])
+    assert id(input_array) != id(output_array)
+
+    # [nan, 1, nan, 2, ... ]  ---('bf')---> [1, 1, 2, 2, ... ]
+    eopatch[feature][0, 0, 0, 0:4] = [np.nan, 1, np.nan, 2]
+    eopatch, input_array, output_array = execute_fillout(eopatch, feature, operations='bf', axis=-1)
+    assert_array_equal(output_array[0, 0, 0, 0:4], [1, 1, 2, 2])
+    assert id(input_array) != id(output_array)

--- a/features/eolearn/tests/test_haralick.py
+++ b/features/eolearn/tests/test_haralick.py
@@ -6,109 +6,60 @@ Copyright (c) 2017-2019 Matej Aleksandrov (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+import copy
 
-import unittest
-import os.path
+import pytest
+from pytest import approx
 import numpy as np
+from numpy.testing import assert_array_equal
 
-from eolearn.core import EOPatch, FeatureType
+from eolearn.core import FeatureType
 from eolearn.features import HaralickTask
 
 
-class TestHaralick(unittest.TestCase):
-
-    TEST_PATCH_FILENAME = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'TestInputs', 'TestPatch')
-
-    @classmethod
-    def setUpClass(cls):
-        cls.patch = EOPatch.load(cls.TEST_PATCH_FILENAME)
-        cls._prepare_patch(cls.patch)
-
-        HaralickTask((FeatureType.DATA, 'ndvi', 'haralick_contrast'), texture_feature='contrast', distance=1, angle=0,
-                     levels=255, window_size=3, stride=1).execute(cls.patch)
-
-        HaralickTask((FeatureType.DATA, 'ndvi', 'haralick_sum_of_square_variance'),
-                     texture_feature='sum_of_square_variance', distance=1, angle=np.pi/2,
-                     levels=8, window_size=5, stride=1).execute(cls.patch)
-
-        HaralickTask((FeatureType.DATA, 'ndvi', 'haralick_sum_entropy'),
-                     texture_feature='sum_entropy', distance=1, angle=-np.pi/2,
-                     levels=8, window_size=7, stride=1).execute(cls.patch)
-
-        cls.initial_patch = EOPatch.load(cls.TEST_PATCH_FILENAME)
-        cls._prepare_patch(cls.initial_patch)
-
-    @staticmethod
-    def _prepare_patch(patch):
-        ndvi = patch.data['ndvi'][:10]
-        ndvi[np.isnan(ndvi)] = 0
-        patch.data['ndvi'] = ndvi
-
-    def test_new_feature(self):
-        haralick = self.patch.data['haralick_contrast']
-        delta = 1e-4
-
-        test_min = np.min(haralick)
-        exp_min = 0.0
-        self.assertAlmostEqual(test_min, exp_min, delta=delta, msg="Expected min {}, got {}".format(exp_min, test_min))
-
-        test_max = np.max(haralick)
-        exp_max = 15620.83333
-        self.assertAlmostEqual(test_max, exp_max, delta=delta, msg="Expected max {}, got {}".format(exp_max, test_max))
-
-        test_mean = np.mean(haralick)
-        exp_mean = 1585.0905
-        self.assertAlmostEqual(test_mean, exp_mean, delta=delta,
-                               msg="Expected mean {}, got {}".format(exp_mean, test_mean))
-
-        test_median = np.median(haralick)
-        exp_median = 1004.916666
-        self.assertAlmostEqual(test_median, exp_median, delta=delta,
-                               msg="Expected median {}, got {}".format(exp_median, test_median))
-
-        haralick = self.patch.data['haralick_sum_of_square_variance']
-        test_min = np.min(haralick)
-        exp_min = 7.7174
-        self.assertAlmostEqual(test_min, exp_min, delta=delta, msg="Expected min {}, got {}".format(exp_min, test_min))
-
-        test_max = np.max(haralick)
-        exp_max = 48.7814
-        self.assertAlmostEqual(test_max, exp_max, delta=delta, msg="Expected max {}, got {}".format(exp_max, test_max))
-
-        test_mean = np.mean(haralick)
-        exp_mean = 31.9490
-        self.assertAlmostEqual(test_mean, exp_mean, delta=delta,
-                               msg="Expected mean {}, got {}".format(exp_mean, test_mean))
-
-        test_median = np.median(haralick)
-        exp_median = 25.0357
-        self.assertAlmostEqual(test_median, exp_median, delta=delta,
-                               msg="Expected median {}, got {}".format(exp_median, test_median))
-
-        haralick = self.patch.data['haralick_sum_entropy']
-        test_min = np.min(haralick)
-        exp_min = 0
-        self.assertAlmostEqual(test_min, exp_min, delta=delta, msg="Expected min {}, got {}".format(exp_min, test_min))
-
-        test_max = np.max(haralick)
-        exp_max = 1.2971
-        self.assertAlmostEqual(test_max, exp_max, delta=delta, msg="Expected max {}, got {}".format(exp_max, test_max))
-
-        test_mean = np.mean(haralick)
-        exp_mean = 0.3898
-        self.assertAlmostEqual(test_mean, exp_mean, delta=delta,
-                               msg="Expected mean {}, got {}".format(exp_mean, test_mean))
-
-        test_median = np.median(haralick)
-        exp_median = 0.4019
-        self.assertAlmostEqual(test_median, exp_median, delta=delta,
-                               msg="Expected median {}, got {}".format(exp_median, test_median))
-
-    def test_unchanged_features(self):
-        for feature, value in self.initial_patch.data.items():
-            self.assertTrue(np.array_equal(value, self.patch.data[feature]),
-                            msg="EOPatch data feature '{}' was changed in the process".format(feature))
+@pytest.fixture(name='eopatch')
+def eopatch_fixture(test_eopatch):
+    ndvi = test_eopatch.data['ndvi'][:10]
+    ndvi[np.isnan(ndvi)] = 0
+    test_eopatch.data['ndvi'] = ndvi
+    return test_eopatch
 
 
-if __name__ == '__main__':
-    unittest.main()
+FEATURE = (FeatureType.DATA, 'ndvi', 'haralick')
+
+
+@pytest.mark.parametrize('task, expected_min, expected_max, expected_mean, expected_median', (
+    [
+        HaralickTask(
+            FEATURE, texture_feature='contrast', angle=0, levels=255, window_size=3
+        ),
+        0.0, 15620.8333, 1585.0905, 1004.9167
+    ],
+    [
+        HaralickTask(
+            FEATURE, texture_feature='sum_of_square_variance', angle=np.pi/2, levels=8, window_size=5
+        ),
+        7.7174, 48.7814, 31.9490, 25.0357
+    ],
+    [
+        HaralickTask(
+            FEATURE, texture_feature='sum_entropy', angle=-np.pi/2, levels=8, window_size=7
+        ),
+        0, 1.2971, 0.3898, 0.4019
+    ],
+))
+def test_haralick(eopatch, task, expected_min, expected_max, expected_mean, expected_median):
+    initial_patch = copy.deepcopy(eopatch)
+    task.execute(eopatch)
+
+    # Test that no other features were modified
+    for feature, value in initial_patch.data.items():
+        assert_array_equal(value, eopatch.data[feature], err_msg=f"EOPatch data feature '{feature}' has changed")
+
+    delta = 1e-4
+
+    haralick = eopatch.data['haralick']
+    assert np.min(haralick) == approx(expected_min, abs=delta)
+    assert np.max(haralick) == approx(expected_max, abs=delta)
+    assert np.mean(haralick) == approx(expected_mean, abs=delta)
+    assert np.median(haralick) == approx(expected_median, abs=delta)

--- a/features/eolearn/tests/test_hog.py
+++ b/features/eolearn/tests/test_hog.py
@@ -6,82 +6,45 @@ Copyright (c) 2017-2019 Matej Aleksandrov, Devis Peresutti (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+import copy
 
-import unittest
-import os.path
+import pytest
+from pytest import approx
 import numpy as np
+from numpy.testing import assert_array_equal
 
-from eolearn.core import EOPatch, FeatureType
+from eolearn.core import FeatureType
 from eolearn.features import HOGTask
 
 
-class TestHog(unittest.TestCase):
-
-    TEST_PATCH_FILENAME = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'TestInputs', 'TestPatch')
-
-    @classmethod
-    def setUpClass(cls):
-        cls.patch = EOPatch.load(cls.TEST_PATCH_FILENAME)
-        cls._prepare_patch(cls.patch)
-
-        HOGTask((FeatureType.DATA, 'ndvi', 'hog'), orientations=9, pixels_per_cell=(2, 2), cells_per_block=(2, 2),
-                visualize=True, visualize_feature_name='hog_visu').execute(cls.patch)
-
-        cls.initial_patch = EOPatch.load(cls.TEST_PATCH_FILENAME)
-        cls._prepare_patch(cls.initial_patch)
-
-    @staticmethod
-    def _prepare_patch(patch):
-        ndvi = patch.data['ndvi'][:10]
-        ndvi[np.isnan(ndvi)] = 0
-        patch.data['ndvi'] = ndvi
-
-    def test_new_feature(self):
-        hog = self.patch.data['hog']
-        delta = 1e-4
-
-        test_min = np.min(hog)
-        exp_min = 0.0
-        self.assertAlmostEqual(test_min, exp_min, delta=delta, msg="Expected min {}, got {}".format(exp_min, test_min))
-
-        test_max = np.max(hog)
-        exp_max = 0.4427
-        self.assertAlmostEqual(test_max, exp_max, delta=delta, msg="Expected max {}, got {}".format(exp_max, test_max))
-
-        test_mean = np.mean(hog)
-        exp_mean = 0.0564
-        self.assertAlmostEqual(test_mean, exp_mean, delta=delta,
-                               msg="Expected mean {}, got {}".format(exp_mean, test_mean))
-
-        test_median = np.median(hog)
-        exp_median = 0.0
-        self.assertAlmostEqual(test_median, exp_median, delta=delta,
-                               msg="Expected median {}, got {}".format(exp_median, test_median))
-
-        hog_visu = self.patch.data['hog_visu']
-        test_min = np.min(hog_visu)
-        exp_min = 0.0
-        self.assertAlmostEqual(test_min, exp_min, delta=delta, msg="Expected min {}, got {}".format(exp_min, test_min))
-
-        test_max = np.max(hog_visu)
-        exp_max = 0.1386
-        self.assertAlmostEqual(test_max, exp_max, delta=delta, msg="Expected max {}, got {}".format(exp_max, test_max))
-
-        test_mean = np.mean(hog_visu)
-        exp_mean = 0.0052
-        self.assertAlmostEqual(test_mean, exp_mean, delta=delta,
-                               msg="Expected mean {}, got {}".format(exp_mean, test_mean))
-
-        test_median = np.median(hog_visu)
-        exp_median = 0.0
-        self.assertAlmostEqual(test_median, exp_median, delta=delta,
-                               msg="Expected median {}, got {}".format(exp_median, test_median))
-
-    def test_unchanged_features(self):
-        for feature, value in self.initial_patch.data.items():
-            self.assertTrue(np.array_equal(value, self.patch.data[feature]),
-                            msg="EOPatch data feature '{}' was changed in the process".format(feature))
+@pytest.fixture(name='eopatch')
+def eopatch_fixture(test_eopatch):
+    ndvi = test_eopatch.data['ndvi'][:10]
+    ndvi[np.isnan(ndvi)] = 0
+    test_eopatch.data['ndvi'] = ndvi
+    return test_eopatch
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_hog(eopatch):
+    task = HOGTask(
+        (FeatureType.DATA, 'ndvi', 'hog'), orientations=9, pixels_per_cell=(2, 2), cells_per_block=(2, 2),
+        visualize=True, visualize_feature_name='hog_visu'
+    )
+
+    initial_patch = copy.deepcopy(eopatch)
+    task.execute(eopatch)
+
+    # Test that no other features were modified
+    for feature, value in initial_patch.data.items():
+        assert_array_equal(value, eopatch.data[feature], err_msg=f"EOPatch data feature '{feature}' has changed")
+
+    delta = 1e-4
+    for feature, expected_min, expected_max, expected_mean, expected_median in [
+        ('hog', 0.0, 0.4427, 0.0564, 0.0),
+        ('hog_visu', 0.0, 0.1386, 0.0052, 0.0),
+    ]:
+        hog = eopatch.data[feature]
+        assert np.min(hog) == approx(expected_min, abs=delta)
+        assert np.max(hog) == approx(expected_max, abs=delta)
+        assert np.mean(hog) == approx(expected_mean, abs=delta)
+        assert np.median(hog) == approx(expected_median, abs=delta)

--- a/features/eolearn/tests/test_interpolation.py
+++ b/features/eolearn/tests/test_interpolation.py
@@ -10,269 +10,247 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import unittest
-import os.path
 from datetime import datetime
-import numpy as np
+import dataclasses
+from typing import Optional
 
-from eolearn.core import EOPatch, FeatureType
+import numpy as np
+import pytest
+from pytest import approx
+
+from eolearn.core import EOTask, FeatureType
 from eolearn.features import LinearInterpolation, CubicInterpolation, SplineInterpolation, BSplineInterpolation, \
     AkimaInterpolation, LinearResampling, CubicResampling, NearestResampling, KrigingInterpolation, LegacyInterpolation
 
 
-class TestInterpolation(unittest.TestCase):
+@dataclasses.dataclass
+class InterpolationTestCase:
+    name: str
+    task: EOTask
+    result_len: int
+    img_min: float
+    img_max: float
+    img_mean: float
+    img_median: float
+    nan_replace: Optional[float] = None
 
-    class InterpolationTestCase:
-        """
-        Container for each interpolation test case
-        """
-        TEST_PATCH_FILENAME = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../example_data',
-                                           'TestEOPatch')
+    def execute(self, eopatch):
+        feature_type, feature_name, _ = next(self.task.feature(eopatch))
 
-        def __init__(self, name, task, result_len, img_min=None, img_max=None, img_mean=None, img_median=None,
-                     nan_replace=None):
-            self.name = name
-            self.task = task
-            self.result_len = result_len
-            self.img_min = img_min
-            self.img_max = img_max
-            self.img_mean = img_mean
-            self.img_median = img_median
-            self.nan_replace = nan_replace
+        result = self.task.execute(eopatch)
 
-            self.result = None
-            self.feature_type = None
-            self.feature_name = None
+        if self.nan_replace is not None:
+            data = result[feature_type, feature_name]
+            data[np.isnan(data)] = self.nan_replace
+            result[feature_type, feature_name] = data
 
-        def execute(self):
-            patch = EOPatch.load(self.TEST_PATCH_FILENAME)
-            self.feature_type, self.feature_name, _ = next(self.task.feature(patch))
+        return result
 
-            self.result = self.task.execute(patch)
 
-            if self.nan_replace is not None:
-                data = self.result[self.feature_type][self.feature_name]
-                data[np.isnan(data)] = self.nan_replace
-                self.result[self.feature_type][self.feature_name] = data
+INTERPOLATION_TEST_CASES = [
+    InterpolationTestCase(
+        'linear',
+        LegacyInterpolation(
+            'NDVI', result_interval=(0.0, 1.0), mask_feature=(FeatureType.MASK, 'IS_VALID'), unknown_value=10
+        ),
+        result_len=68, img_min=0.0, img_max=10.0, img_mean=0.720405, img_median=0.59765935
+    ),
+    InterpolationTestCase(
+        'linear_change_timescale',
+        LegacyInterpolation(
+            'NDVI', result_interval=(0.0, 1.0), mask_feature=(FeatureType.MASK, 'IS_VALID'), unknown_value=10,
+            scale_time=1
+        ),
+        result_len=68, img_min=0.0, img_max=10.0, img_mean=0.720405, img_median=0.597656965
+    ),
+    InterpolationTestCase(
+        'linear',
+        LinearInterpolation(
+            'NDVI', result_interval=(0.0, 1.0), mask_feature=(FeatureType.MASK, 'IS_VALID'), unknown_value=10
+        ),
+        result_len=68, img_min=0.0, img_max=10.0, img_mean=0.720405, img_median=0.59765935
+    ),
+    InterpolationTestCase(
+        'linear-p',
+        LinearInterpolation(
+            'NDVI', result_interval=(0.0, 1.0), mask_feature=(FeatureType.MASK, 'IS_VALID'), unknown_value=10,
+            interpolate_pixel_wise=True
+        ),
+        result_len=68, img_min=0.0, img_max=10.0, img_mean=0.720405, img_median=0.59765935
+    ),
+    InterpolationTestCase(
+        'linear_change_timescale',
+        LinearInterpolation(
+            'NDVI', result_interval=(0.0, 1.0), mask_feature=(FeatureType.MASK, 'IS_VALID'), unknown_value=10,
+            scale_time=1
+        ),
+        result_len=68, img_min=0.0, img_max=10.0, img_mean=0.7204042, img_median=0.59765697
+    ),
+    InterpolationTestCase(
+        'cubic',
+        CubicInterpolation(
+            'NDVI', result_interval=(0.0, 1.0), mask_feature=(FeatureType.MASK, 'IS_VALID'),
+            resample_range=('2015-01-01', '2018-01-01', 16), unknown_value=5, bounds_error=False
+        ),
+        result_len=69, img_min=0.0, img_max=5.0, img_mean=1.3592644, img_median=0.6174331
+    ),
+    InterpolationTestCase(
+        'spline',
+        SplineInterpolation(
+            'NDVI', result_interval=(-0.3, 1.0), mask_feature=(FeatureType.MASK, 'IS_VALID'),
+            resample_range=('2016-01-01', '2018-01-01', 5), spline_degree=3, smoothing_factor=0, unknown_value=0
+        ),
+        result_len=147, img_min=-0.3, img_max=1.0, img_mean=0.492752, img_median=0.53776133
+    ),
+    InterpolationTestCase(
+        'bspline',
+        BSplineInterpolation(
+            'NDVI', unknown_value=-3, mask_feature=(FeatureType.MASK, 'IS_VALID'),
+            resample_range=('2017-01-01', '2017-02-01', 50), spline_degree=5
+        ),
+        result_len=1, img_min=-0.032482587, img_max=0.701796, img_mean=0.42080238, img_median=0.42889267
+    ),
+    InterpolationTestCase(
+        'bspline-p',
+        BSplineInterpolation(
+            'NDVI', unknown_value=-3, mask_feature=(FeatureType.MASK, 'IS_VALID'), spline_degree=5,
+            resample_range=('2017-01-01', '2017-02-01', 50), interpolate_pixel_wise=True
+        ),
+        result_len=1, img_min=-0.032482587, img_max=0.701796, img_mean=0.42080238, img_median=0.42889267
+    ),
+    InterpolationTestCase(
+        'akima',
+        AkimaInterpolation('NDVI', unknown_value=0, mask_feature=(FeatureType.MASK, 'IS_VALID')),
+        result_len=68, img_min=-0.13793105, img_max=0.860242, img_mean=0.53159297, img_median=0.59087014
+    ),
+    InterpolationTestCase(
+        'kriging interpolation',
+        KrigingInterpolation('NDVI', result_interval=(-10, 10), resample_range=('2016-01-01', '2018-01-01', 5)),
+        result_len=147, img_min=-0.252500534, img_max=0.659086704, img_mean=0.3825493, img_median=0.39931053
+    ),
+    InterpolationTestCase(
+        'nearest resample',
+        NearestResampling('NDVI', result_interval=(0.0, 1.0), resample_range=('2016-01-01', '2018-01-01', 5)),
+        result_len=147, img_min=-0.2, img_max=0.860242, img_mean=0.35143828, img_median=0.37481314, nan_replace=-0.2
+    ),
+    InterpolationTestCase(
+        'linear resample',
+        LinearResampling('NDVI', result_interval=(0.0, 1.0), resample_range=('2016-01-01', '2018-01-01', 5)),
+        result_len=147, img_min=-0.2, img_max=0.8480114, img_mean=0.350186, img_median=0.3393997, nan_replace=-0.2
+    ),
+    InterpolationTestCase(
+        'cubic resample',
+        CubicResampling(
+            'NDVI', result_interval=(-0.2, 1.0), resample_range=('2015-01-01', '2018-01-01', 16), unknown_value=5
+        ),
+        result_len=69, img_min=-0.2, img_max=5.0, img_mean=1.234881997, img_median=0.465670556, nan_replace=-0.2
+    ),
+    InterpolationTestCase(
+        'linear custom list',
+        LinearInterpolation(
+            'NDVI', result_interval=(-0.2, 1.0), unknown_value=-2, parallel=True,
+            resample_range=('2015-09-01', '2016-01-01', '2016-07-01', '2017-01-01', '2017-07-01')
+        ),
+        result_len=5, img_min=-0.032482587, img_max=0.8427637, img_mean=0.5108417, img_median=0.5042224
+    ),
+    InterpolationTestCase(
+        'linear with bands and multiple masks',
+        LinearInterpolation(
+            'BANDS-S2-L1C', result_interval=(0.0, 1.0), unknown_value=10,
+            mask_feature=[
+                (FeatureType.MASK, 'IS_VALID'),
+                (FeatureType.MASK_TIMELESS, 'RANDOM_UINT8'),
+                (FeatureType.LABEL, 'RANDOM_DIGIT'),
+            ]
+        ),
+        result_len=68, img_min=0.000200, img_max=10.0, img_mean=0.3487376, img_median=0.10036667
+    ),
+    InterpolationTestCase(
+        'linear custom list',
+        LegacyInterpolation(
+            'NDVI', result_interval=(-0.2, 1.0), unknown_value=-2,
+            resample_range=('2015-09-01', '2016-01-01', '2016-07-01', '2017-01-01', '2017-07-01'),
+        ),
+        result_len=5, img_min=-0.032482587, img_max=0.8427637, img_mean=0.5108417, img_median=0.5042224
+    ),
+    InterpolationTestCase(
+        'linear with bands and multiple masks',
+        LegacyInterpolation(
+            'BANDS-S2-L1C', result_interval=(0.0, 1.0), unknown_value=10,
+            mask_feature=[
+                (FeatureType.MASK, 'IS_VALID'),
+                (FeatureType.MASK_TIMELESS, 'RANDOM_UINT8'),
+                (FeatureType.LABEL, 'RANDOM_DIGIT'),
+            ]
+        ),
+        result_len=68, img_min=0.000200, img_max=10.0, img_mean=0.34815648, img_median=0.1003600
+    ),
+]
 
-    @classmethod
-    def setUpClass(cls):
 
-        cls.test_cases = [
-            cls.InterpolationTestCase('linear', LegacyInterpolation('NDVI', result_interval=(0.0, 1.0),
-                                                                    mask_feature=(FeatureType.MASK, 'IS_VALID'),
-                                                                    unknown_value=10),
-                                      result_len=68, img_min=0.0, img_max=10.0, img_mean=0.720405,
-                                      img_median=0.59765935),
+COPY_FEATURE_CASES = [
+    InterpolationTestCase(
+        'cubic_copy_success',
+        CubicInterpolation(
+            'NDVI', result_interval=(0.0, 1.0), mask_feature=(FeatureType.MASK, 'IS_VALID'),
+            resample_range=('2015-01-01', '2018-01-01', 16), unknown_value=5, bounds_error=False,
+            copy_features=[
+                (FeatureType.MASK, 'IS_VALID'),
+                (FeatureType.DATA, 'NDVI', 'NDVI_OLD'),
+                (FeatureType.MASK_TIMELESS, 'LULC'),
+            ]
+        ),
+        result_len=69, img_min=0.0, img_max=5.0, img_mean=1.3592644, img_median=0.6174331
+    ),
+    InterpolationTestCase(
+        'cubic_copy_fail',
+        CubicInterpolation(
+            'NDVI', result_interval=(0.0, 1.0), mask_feature=(FeatureType.MASK, 'IS_VALID'),
+            resample_range=('2015-01-01', '2018-01-01', 16), unknown_value=5, bounds_error=False,
+            copy_features=[
+                (FeatureType.MASK, 'IS_VALID'),
+                (FeatureType.DATA, 'NDVI'),
+                (FeatureType.MASK_TIMELESS, 'LULC'),
+            ]
+        ),
+        result_len=69, img_min=0.0, img_max=5.0, img_mean=1.3592644, img_median=0.6174331
+    ),
+]
 
-            cls.InterpolationTestCase('linear_change_timescale',
-                                      LegacyInterpolation('NDVI', result_interval=(0.0, 1.0),
-                                                          mask_feature=(FeatureType.MASK, 'IS_VALID'),
-                                                          unknown_value=10, scale_time=1),
-                                      result_len=68, img_min=0.0, img_max=10.0, img_mean=0.720405,
-                                      img_median=0.597656965),
 
-            cls.InterpolationTestCase('linear', LinearInterpolation('NDVI', result_interval=(0.0, 1.0),
-                                                                    mask_feature=(FeatureType.MASK, 'IS_VALID'),
-                                                                    unknown_value=10),
-                                      result_len=68, img_min=0.0, img_max=10.0, img_mean=0.720405,
-                                      img_median=0.59765935),
+@pytest.mark.parametrize('test_case', INTERPOLATION_TEST_CASES)
+def test_interpolation(test_case, example_eopatch):
+    eopatch = test_case.execute(example_eopatch)
 
-            cls.InterpolationTestCase('linear-p', LinearInterpolation('NDVI', result_interval=(0.0, 1.0),
-                                                                      mask_feature=(FeatureType.MASK, 'IS_VALID'),
-                                                                      unknown_value=10, interpolate_pixel_wise=True),
-                                      result_len=68, img_min=0.0, img_max=10.0, img_mean=0.720405,
-                                      img_median=0.59765935),
+    # Check types and shapes
+    assert isinstance(eopatch.timestamp, list), 'Expected a list of timestamps'
+    assert isinstance(eopatch.timestamp[0], datetime), 'Expected timestamps of type datetime.datetime'
+    assert len(eopatch.timestamp) == test_case.result_len
+    assert eopatch.data['NDVI'].shape == (test_case.result_len, 101, 100, 1)
 
-            cls.InterpolationTestCase('linear_change_timescale',
-                                      LinearInterpolation('NDVI', result_interval=(0.0, 1.0),
-                                                          mask_feature=(FeatureType.MASK, 'IS_VALID'),
-                                                          unknown_value=10, scale_time=1),
-                                      result_len=68, img_min=0.0, img_max=10.0, img_mean=0.7204042,
-                                      img_median=0.59765697),
+    # Check results
+    delta = 1e-5  # Can't be higher accuracy because of Kriging interpolation
+    feature_type, feature_name, _ = next(test_case.task.feature(eopatch))
+    data = eopatch[feature_type, feature_name]
 
-            cls.InterpolationTestCase('cubic', CubicInterpolation('NDVI', result_interval=(0.0, 1.0),
-                                                                  mask_feature=(FeatureType.MASK, 'IS_VALID'),
-                                                                  resample_range=('2015-01-01', '2018-01-01', 16),
-                                                                  unknown_value=5, bounds_error=False),
-                                      result_len=69, img_min=0.0, img_max=5.0, img_mean=1.3592644,
-                                      img_median=0.6174331),
+    assert np.min(data) == approx(test_case.img_min, abs=delta)
+    assert np.max(data) == approx(test_case.img_max, abs=delta)
+    assert np.mean(data) == approx(test_case.img_mean, abs=delta)
+    assert np.median(data) == approx(test_case.img_median, abs=delta)
 
-            cls.InterpolationTestCase('spline', SplineInterpolation('NDVI', result_interval=(-0.3, 1.0),
-                                                                    mask_feature=(FeatureType.MASK, 'IS_VALID'),
-                                                                    resample_range=('2016-01-01', '2018-01-01', 5),
-                                                                    spline_degree=3, smoothing_factor=0,
-                                                                    unknown_value=0),
-                                      result_len=147, img_min=-0.3, img_max=1.0, img_mean=0.492752,
-                                      img_median=0.53776133),
 
-            cls.InterpolationTestCase('bspline', BSplineInterpolation('NDVI', unknown_value=-3,
-                                                                      mask_feature=(FeatureType.MASK, 'IS_VALID'),
-                                                                      resample_range=('2017-01-01', '2017-02-01', 50),
-                                                                      spline_degree=5),
-                                      result_len=1, img_min=-0.032482587, img_max=0.701796, img_mean=0.42080238,
-                                      img_median=0.42889267),
+@pytest.mark.parametrize('test_case', COPY_FEATURE_CASES)
+def test_copied_fields(test_case, example_eopatch):
+    try:
+        eopatch = test_case.execute(example_eopatch)
+    except ValueError:
+        eopatch = None
 
-            cls.InterpolationTestCase('bspline-p', BSplineInterpolation('NDVI', unknown_value=-3,
-                                                                        mask_feature=(FeatureType.MASK, 'IS_VALID'),
-                                                                        resample_range=('2017-01-01', '2017-02-01', 50),
-                                                                        spline_degree=5, interpolate_pixel_wise=True),
-                                      result_len=1, img_min=-0.032482587, img_max=0.701796, img_mean=0.42080238,
-                                      img_median=0.42889267),
-
-            cls.InterpolationTestCase('akima', AkimaInterpolation('NDVI', unknown_value=0,
-                                                                  mask_feature=(FeatureType.MASK, 'IS_VALID')),
-                                      result_len=68, img_min=-0.13793105, img_max=0.860242, img_mean=0.53159297,
-                                      img_median=0.59087014),
-
-            cls.InterpolationTestCase('kriging interpolation',
-                                      KrigingInterpolation('NDVI', result_interval=(-10, 10),
-                                                           resample_range=('2016-01-01', '2018-01-01', 5)),
-                                      result_len=147, img_min=-0.252500534, img_max=0.659086704, img_mean=0.3825493,
-                                      img_median=0.39931053),
-
-            cls.InterpolationTestCase('nearest resample', NearestResampling('NDVI', result_interval=(0.0, 1.0),
-                                                                            resample_range=('2016-01-01',
-                                                                                            '2018-01-01', 5)),
-                                      result_len=147, img_min=-0.2, img_max=0.860242, img_mean=0.35143828,
-                                      img_median=0.37481314, nan_replace=-0.2),
-
-            cls.InterpolationTestCase('linear resample', LinearResampling('NDVI', result_interval=(0.0, 1.0),
-                                                                          resample_range=('2016-01-01',
-                                                                                          '2018-01-01', 5)),
-                                      result_len=147, img_min=-0.2, img_max=0.8480114, img_mean=0.350186,
-                                      img_median=0.3393997, nan_replace=-0.2),
-
-            cls.InterpolationTestCase('cubic resample', CubicResampling('NDVI', result_interval=(-0.2, 1.0),
-                                                                        resample_range=('2015-01-01', '2018-01-01', 16),
-                                                                        unknown_value=5),
-                                      result_len=69, img_min=-0.2, img_max=5.0, img_mean=1.234881997,
-                                      img_median=0.465670556, nan_replace=-0.2),
-
-            cls.InterpolationTestCase('linear custom list', LinearInterpolation(
-                'NDVI', result_interval=(-0.2, 1.0),
-                resample_range=('2015-09-01', '2016-01-01', '2016-07-01', '2017-01-01', '2017-07-01'),
-                unknown_value=-2, parallel=True),
-                                      result_len=5, img_min=-0.032482587, img_max=0.8427637, img_mean=0.5108417,
-                                      img_median=0.5042224),
-
-            cls.InterpolationTestCase('linear with bands and multiple masks',
-                                      LinearInterpolation('BANDS-S2-L1C', result_interval=(0.0, 1.0), unknown_value=10,
-                                                          mask_feature=[(FeatureType.MASK, 'IS_VALID'),
-                                                                        (FeatureType.MASK_TIMELESS, 'RANDOM_UINT8'),
-                                                                        (FeatureType.LABEL, 'RANDOM_DIGIT')]),
-                                      result_len=68, img_min=0.000200, img_max=10.0, img_mean=0.3487376,
-                                      img_median=0.10036667),
-
-            cls.InterpolationTestCase('linear custom list', LegacyInterpolation(
-                'NDVI', result_interval=(-0.2, 1.0),
-                resample_range=('2015-09-01', '2016-01-01', '2016-07-01', '2017-01-01', '2017-07-01'),
-                unknown_value=-2),
-                                      result_len=5, img_min=-0.032482587, img_max=0.8427637, img_mean=0.5108417,
-                                      img_median=0.5042224),
-
-            cls.InterpolationTestCase('linear with bands and multiple masks',
-                                      LegacyInterpolation('BANDS-S2-L1C', result_interval=(0.0, 1.0), unknown_value=10,
-                                                          mask_feature=[(FeatureType.MASK, 'IS_VALID'),
-                                                                        (FeatureType.MASK_TIMELESS, 'RANDOM_UINT8'),
-                                                                        (FeatureType.LABEL, 'RANDOM_DIGIT')]),
-                                      result_len=68, img_min=0.000200, img_max=10.0, img_mean=0.34815648,
-                                      img_median=0.1003600)
+    if eopatch is not None:
+        copied_features = [
+            (FeatureType.MASK, 'IS_VALID'),
+            (FeatureType.DATA, 'NDVI_OLD'),
+            (FeatureType.MASK_TIMELESS, 'LULC')
         ]
-
-        cls.copy_feature_cases = [
-            cls.InterpolationTestCase('cubic_copy_success',
-                                      CubicInterpolation('NDVI', result_interval=(0.0, 1.0),
-                                                         mask_feature=(
-                                                             FeatureType.MASK, 'IS_VALID'),
-                                                         resample_range=(
-                                                             '2015-01-01', '2018-01-01', 16),
-                                                         unknown_value=5, bounds_error=False,
-                                                         copy_features=[
-                                                             (FeatureType.MASK, 'IS_VALID'),
-                                                             (FeatureType.DATA, 'NDVI', 'NDVI_OLD'),
-                                                             (FeatureType.MASK_TIMELESS, 'LULC'),
-                                                         ]),
-                                      result_len=69, img_min=0.0, img_max=5.0, img_mean=1.3592644,
-                                      img_median=0.6174331),
-
-            cls.InterpolationTestCase('cubic_copy_fail',
-                                      CubicInterpolation('NDVI', result_interval=(0.0, 1.0),
-                                                         mask_feature=(FeatureType.MASK, 'IS_VALID'),
-                                                         resample_range=(
-                                                             '2015-01-01', '2018-01-01', 16),
-                                                         unknown_value=5, bounds_error=False,
-                                                         copy_features=[
-                                                             (FeatureType.MASK, 'IS_VALID'),
-                                                             (FeatureType.DATA, 'NDVI'),
-                                                             (FeatureType.MASK_TIMELESS, 'LULC'),
-                                                         ]),
-                                      result_len=69, img_min=0.0, img_max=5.0, img_mean=1.3592644,
-                                      img_median=0.6174331),
-        ]
-
-        for test_case in cls.test_cases:
-            test_case.execute()
-
-        for test_case in cls.copy_feature_cases:
-            try:
-                test_case.execute()
-            except ValueError:
-                pass
-
-    def test_output_type(self):
-        for test_case in self.test_cases:
-            with self.subTest(msg='Test case {}'.format(test_case.name)):
-                self.assertTrue(isinstance(test_case.result.timestamp, list), "Expected a list of timestamps")
-                self.assertTrue(isinstance(test_case.result.timestamp[0], datetime),
-                                "Expected timestamps of type datetime.datetime")
-                ts_len = len(test_case.result.timestamp)
-                self.assertEqual(ts_len, test_case.result_len,
-                                 msg="Expected timestamp len {}, got {}".format(test_case.result_len, ts_len))
-                data_shape = test_case.result.data['NDVI'].shape
-                exp_shape = (test_case.result_len, 101, 100, 1)
-                self.assertEqual(data_shape, exp_shape,
-                                 "Expected data shape {}, got {}".format(exp_shape, data_shape))
-
-    def test_stats(self):
-        for test_case in self.test_cases:
-            delta = 1e-5  # Can't be higher accuracy because of Kriging interpolation
-            data = test_case.result[test_case.feature_type][test_case.feature_name]
-
-            if test_case.img_min is not None:
-                min_val = np.amin(data)
-                with self.subTest(msg='Test case {}'.format(test_case.name)):
-                    self.assertAlmostEqual(test_case.img_min, min_val, delta=delta,
-                                           msg="Expected min {}, got {}".format(test_case.img_min, min_val))
-            if test_case.img_max is not None:
-                max_val = np.amax(data)
-                with self.subTest(msg='Test case {}'.format(test_case.name)):
-                    self.assertAlmostEqual(test_case.img_max, max_val, delta=delta,
-                                           msg="Expected max {}, got {}".format(test_case.img_max, max_val))
-            if test_case.img_mean is not None:
-                mean_val = np.mean(data)
-                with self.subTest(msg='Test case {}'.format(test_case.name)):
-                    self.assertAlmostEqual(test_case.img_mean, mean_val, delta=delta,
-                                           msg="Expected mean {}, got {}".format(test_case.img_mean, mean_val))
-            if test_case.img_median is not None:
-                median_val = np.median(data)
-                with self.subTest(msg='Test case {}'.format(test_case.name)):
-                    self.assertAlmostEqual(test_case.img_median, median_val, delta=delta,
-                                           msg="Expected median {}, got {}".format(test_case.img_median, median_val))
-
-    def test_copied_fields(self):
-        for test_case in self.copy_feature_cases:
-            with self.subTest(msg='Test case {}'.format(test_case.name)):
-                if test_case.result is not None:
-                    copied_features = [
-                        (FeatureType.MASK, 'IS_VALID'),
-                        (FeatureType.DATA, 'NDVI_OLD'),
-                        (FeatureType.MASK_TIMELESS, 'LULC')
-                    ]
-                    for feature in copied_features:
-                        self.assertTrue(feature in test_case.result.get_feature_list(),
-                                        msg="Expected feature {} is not present in EOPatch".format(feature))
-
-
-if __name__ == '__main__':
-    unittest.main()
+        for feature in copied_features:
+            assert feature in eopatch.get_feature_list(), f'Expected feature `{feature}` is not present in EOPatch'

--- a/features/eolearn/tests/test_local_binary_pattern.py
+++ b/features/eolearn/tests/test_local_binary_pattern.py
@@ -7,61 +7,43 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import unittest
-import os.path
-import numpy as np
+import copy
 
-from eolearn.core import EOPatch, FeatureType
+import pytest
+from pytest import approx
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from eolearn.core import FeatureType
 from eolearn.features import LocalBinaryPatternTask
 
 
-class TestLocalBinaryPattern(unittest.TestCase):
-
-    TEST_PATCH_FILENAME = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'TestInputs', 'TestPatch')
-
-    @classmethod
-    def setUpClass(cls):
-        cls.patch = EOPatch.load(cls.TEST_PATCH_FILENAME)
-        cls._prepare_patch(cls.patch)
-
-        LocalBinaryPatternTask((FeatureType.DATA, 'ndvi', 'lbp'), nb_points=24, radius=3).execute(cls.patch)
-
-        cls.initial_patch = EOPatch.load(cls.TEST_PATCH_FILENAME)
-        cls._prepare_patch(cls.initial_patch)
-
-    @staticmethod
-    def _prepare_patch(patch):
-        ndvi = patch.data['ndvi'][:10]
-        ndvi[np.isnan(ndvi)] = 0
-        patch.data['ndvi'] = ndvi
-
-    def test_new_feature(self):
-        lbp = self.patch.data['lbp']
-        delta = 1e-4
-
-        test_min = np.min(lbp)
-        exp_min = 0.0
-        self.assertAlmostEqual(test_min, exp_min, delta=delta, msg="Expected min {}, got {}".format(exp_min, test_min))
-
-        test_max = np.max(lbp)
-        exp_max = 25.0
-        self.assertAlmostEqual(test_max, exp_max, delta=delta, msg="Expected max {}, got {}".format(exp_max, test_max))
-
-        test_mean = np.mean(lbp)
-        exp_mean = 22.3147
-        self.assertAlmostEqual(test_mean, exp_mean, delta=delta,
-                               msg="Expected mean {}, got {}".format(exp_mean, test_mean))
-
-        test_median = np.median(lbp)
-        exp_median = 24.0
-        self.assertAlmostEqual(test_median, exp_median, delta=delta,
-                               msg="Expected median {}, got {}".format(exp_median, test_median))
-
-    def test_unchanged_features(self):
-        for feature, value in self.initial_patch.data.items():
-            self.assertTrue(np.array_equal(value, self.patch.data[feature]),
-                            msg="EOPatch data feature '{}' was changed in the process".format(feature))
+@pytest.fixture(name='eopatch')
+def eopatch_fixture(test_eopatch):
+    ndvi = test_eopatch.data['ndvi'][:10]
+    ndvi[np.isnan(ndvi)] = 0
+    test_eopatch.data['ndvi'] = ndvi
+    return test_eopatch
 
 
-if __name__ == '__main__':
-    unittest.main()
+@pytest.mark.parametrize('task, expected_min, expected_max, expected_mean, expected_median', (
+    [
+        LocalBinaryPatternTask((FeatureType.DATA, 'ndvi', 'lbp'), nb_points=24, radius=3),
+        0.0, 25.0, 22.3147, 24.0
+    ],
+))
+def test_local_binary_pattern(eopatch, task, expected_min, expected_max, expected_mean, expected_median):
+    initial_patch = copy.deepcopy(eopatch)
+    task.execute(eopatch)
+
+    # Test that no other features were modified
+    for feature, value in initial_patch.data.items():
+        assert_array_equal(value, eopatch.data[feature], err_msg=f"EOPatch data feature '{feature}' has changed")
+
+    delta = 1e-4
+
+    haralick = eopatch.data['lbp']
+    assert np.min(haralick) == approx(expected_min, abs=delta)
+    assert np.max(haralick) == approx(expected_max, abs=delta)
+    assert np.mean(haralick) == approx(expected_mean, abs=delta)
+    assert np.median(haralick) == approx(expected_median, abs=delta)

--- a/features/eolearn/tests/test_radiometric_normalization.py
+++ b/features/eolearn/tests/test_radiometric_normalization.py
@@ -6,151 +6,106 @@ Copyright (c) 2017-2019 Matej Aleksandrov, Matic Lubej, Devis Peresutti (Sinergi
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-
-import unittest
-import os.path
-import numpy as np
 from datetime import datetime
+import copy
 
-from eolearn.core import EOPatch, FeatureType
+import numpy as np
+from numpy.testing import assert_array_equal
+import pytest
+from pytest import approx
+
+from eolearn.core import FeatureType
 from eolearn.mask import MaskFeature
 from eolearn.features import ReferenceScenes, BlueCompositing, HOTCompositing, MaxNDVICompositing, \
     MaxNDWICompositing, MaxRatioCompositing, HistogramMatching
 
 
-class TestRadiometricNormalization(unittest.TestCase):
-
-    class RadiometricNormalizationTestCase:
-        """
-        Container for each interpolation test case
-        """
-        TEST_PATCH_FILENAME = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../example_data',
-                                           'TestEOPatch')
-
-        def __init__(self, name, task, img_min=None, img_max=None, img_mean=None, img_median=None):
-            self.name = name
-            self.task = task
-            self.img_min = img_min
-            self.img_max = img_max
-            self.img_mean = img_mean
-            self.img_median = img_median
-            self.result = None
-
-        def execute(self):
-            patch = EOPatch.load(self.TEST_PATCH_FILENAME)
-            np.random.seed(0)
-            patch.mask['SCL'] = np.random.randint(0, 11, patch.data['BANDS-S2-L1C'].shape, np.uint8)
-            blue = BlueCompositing((FeatureType.DATA, 'REFERENCE_SCENES'),
-                                   (FeatureType.DATA_TIMELESS, 'REFERENCE_COMPOSITE'), blue_idx=0,
-                                   interpolation='geoville')
-            blue.execute(patch)
-            self.result = self.task.execute(patch)
-
-    @classmethod
-    def setUpClass(cls):
-
-        cls.test_cases = [
-            cls.RadiometricNormalizationTestCase('mask feature', MaskFeature(
-                (FeatureType.DATA, 'BANDS-S2-L1C', 'TEST'), (FeatureType.MASK, 'SCL'),
-                mask_values=[0, 1, 2, 3, 8, 9, 10, 11]), img_min=0.0002, img_max=1.4244, img_mean=0.21167801,
-                img_median=0.142),
-
-            cls.RadiometricNormalizationTestCase('reference scene', ReferenceScenes(
-                (FeatureType.DATA, 'BANDS-S2-L1C', 'TEST'), (FeatureType.SCALAR, 'CLOUD_COVERAGE'),
-                max_scene_number=5), img_min=0.0005, img_max=0.5318, img_mean=0.16823094,
-                img_median=0.1404),
-
-            cls.RadiometricNormalizationTestCase('blue compositing', BlueCompositing(
-                (FeatureType.DATA, 'REFERENCE_SCENES'), (FeatureType.DATA_TIMELESS, 'TEST'),
-                blue_idx=0, interpolation='geoville'), img_min=0.0005, img_max=0.5075, img_mean=0.11658352,
-                img_median=0.0833),
-
-            cls.RadiometricNormalizationTestCase('hot compositing', HOTCompositing(
-                (FeatureType.DATA, 'REFERENCE_SCENES'), (FeatureType.DATA_TIMELESS, 'TEST'),
-                blue_idx=0, red_idx=2, interpolation='geoville'), img_min=0.0005, img_max=0.5075, img_mean=0.117758796,
-                img_median=0.0846),
-
-            cls.RadiometricNormalizationTestCase('max ndvi compositing', MaxNDVICompositing(
-                (FeatureType.DATA, 'REFERENCE_SCENES'), (FeatureType.DATA_TIMELESS, 'TEST'),
-                red_idx=2, nir_idx=7, interpolation='geoville'), img_min=0.0005, img_max=0.5075,
-                img_mean=0.13430128, img_median=0.0941),
-
-            cls.RadiometricNormalizationTestCase('max ndwi compositing', MaxNDWICompositing(
-                (FeatureType.DATA, 'REFERENCE_SCENES'), (FeatureType.DATA_TIMELESS, 'TEST'),
-                nir_idx=6, swir1_idx=8, interpolation='geoville'), img_min=0.0005, img_max=0.5318,
-                img_mean=0.2580135, img_median=0.2888),
-
-            cls.RadiometricNormalizationTestCase('max ratio compositing', MaxRatioCompositing(
-                (FeatureType.DATA, 'REFERENCE_SCENES'), (FeatureType.DATA_TIMELESS, 'TEST'),
-                blue_idx=0, nir_idx=6, swir1_idx=8, interpolation='geoville'), img_min=0.0006, img_max=0.5075,
-                img_mean=0.13513365, img_median=0.0958),
-
-            cls.RadiometricNormalizationTestCase('histogram matching', HistogramMatching(
-                (FeatureType.DATA, 'BANDS-S2-L1C', 'TEST'),
-                (FeatureType.DATA_TIMELESS, 'REFERENCE_COMPOSITE')),
-                img_min=-0.049050678, img_max=0.68174845, img_mean=0.1165936, img_median=0.08370649)
-        ]
-
-        for test_case in cls.test_cases:
-            test_case.execute()
-
-    def test_output_type(self):
-        for test_case in self.test_cases:
-            with self.subTest(msg='Test case {}'.format(test_case.name)):
-                self.assertTrue(isinstance(test_case.result.timestamp, list), "Expected a list of timestamps")
-                self.assertTrue(isinstance(test_case.result.timestamp[0], datetime),
-                                "Expected timestamps of type datetime.datetime")
-
-    def test_stats(self):
-        for tci, test_case in enumerate(self.test_cases):
-            delta = 1e-3
-
-            if tci not in [2, 3, 4, 5, 6]:
-                if test_case.img_min is not None:
-                    min_val = np.nanmin(test_case.result.data['TEST'])
-                    with self.subTest(msg='Test case {}'.format(test_case.name)):
-                        self.assertAlmostEqual(test_case.img_min, min_val, delta=delta,
-                                               msg="Expected min {}, got {}".format(test_case.img_min, min_val))
-                if test_case.img_max is not None:
-                    max_val = np.nanmax(test_case.result.data['TEST'])
-                    with self.subTest(msg='Test case {}'.format(test_case.name)):
-                        self.assertAlmostEqual(test_case.img_max, max_val, delta=delta,
-                                               msg="Expected max {}, got {}".format(test_case.img_max, max_val))
-                if test_case.img_mean is not None:
-                    mean_val = np.nanmean(test_case.result.data['TEST'])
-                    with self.subTest(msg='Test case {}'.format(test_case.name)):
-                        self.assertAlmostEqual(test_case.img_mean, mean_val, delta=delta,
-                                               msg="Expected mean {}, got {}".format(test_case.img_mean, mean_val))
-                if test_case.img_median is not None:
-                    median_val = np.nanmedian(test_case.result.data['TEST'])
-                    with self.subTest(msg='Test case {}'.format(test_case.name)):
-                        self.assertAlmostEqual(test_case.img_median, median_val, delta=delta,
-                                               msg="Expected median {}, got {}".format(test_case.img_median,
-                                                                                       median_val))
-
-            else:
-                if test_case.img_min is not None:
-                    min_val = np.nanmin(test_case.result.data_timeless['TEST'])
-                    with self.subTest(msg='Test case {}'.format(test_case.name)):
-                        self.assertAlmostEqual(test_case.img_min, min_val, delta=delta,
-                                               msg="Expected min {}, got {}".format(test_case.img_min, min_val))
-                if test_case.img_max is not None:
-                    max_val = np.nanmax(test_case.result.data_timeless['TEST'])
-                    with self.subTest(msg='Test case {}'.format(test_case.name)):
-                        self.assertAlmostEqual(test_case.img_max, max_val, delta=delta,
-                                               msg="Expected max {}, got {}".format(test_case.img_max, max_val))
-                if test_case.img_mean is not None:
-                    mean_val = np.nanmean(test_case.result.data_timeless['TEST'])
-                    with self.subTest(msg='Test case {}'.format(test_case.name)):
-                        self.assertAlmostEqual(test_case.img_mean, mean_val, delta=delta,
-                                               msg="Expected mean {}, got {}".format(test_case.img_mean, mean_val))
-                if test_case.img_median is not None:
-                    median_val = np.nanmedian(test_case.result.data_timeless['TEST'])
-                    with self.subTest(msg='Test case {}'.format(test_case.name)):
-                        self.assertAlmostEqual(test_case.img_median, median_val, delta=delta,
-                                               msg="Expected median {}, got {}".format(test_case.img_median,
-                                                                                       median_val))
+@pytest.fixture(name='eopatch')
+def eopatch_fixture(example_eopatch):
+    np.random.seed(0)
+    example_eopatch.mask['SCL'] = np.random.randint(0, 11, example_eopatch.data['BANDS-S2-L1C'].shape, np.uint8)
+    blue = BlueCompositing(
+        (FeatureType.DATA, 'REFERENCE_SCENES'), (FeatureType.DATA_TIMELESS, 'REFERENCE_COMPOSITE'),
+        blue_idx=0, interpolation='geoville'
+    )
+    blue.execute(example_eopatch)
+    return example_eopatch
 
 
-if __name__ == '__main__':
-    unittest.main()
+DATA_TEST_FEATURE = FeatureType.DATA, 'TEST'
+DATA_TIMELESS_TEST_FEATURE = FeatureType.DATA_TIMELESS, 'TEST'
+
+
+@pytest.mark.parametrize('task, test_feature, expected_min, expected_max, expected_mean, expected_median', (
+    [
+        MaskFeature(
+            (FeatureType.DATA, 'BANDS-S2-L1C', 'TEST'), (FeatureType.MASK, 'SCL'),
+            mask_values=[0, 1, 2, 3, 8, 9, 10, 11]
+        ),
+        DATA_TEST_FEATURE, 0.0002, 1.4244, 0.21167801, 0.142
+    ],
+    [
+        ReferenceScenes(
+            (FeatureType.DATA, 'BANDS-S2-L1C', 'TEST'), (FeatureType.SCALAR, 'CLOUD_COVERAGE'), max_scene_number=5
+        ),
+        DATA_TEST_FEATURE, 0.0005, 0.5318, 0.16823094, 0.1404
+    ],
+    [
+        BlueCompositing(
+            (FeatureType.DATA, 'REFERENCE_SCENES'), (FeatureType.DATA_TIMELESS, 'TEST'),
+            blue_idx=0, interpolation='geoville'
+        ),
+        DATA_TIMELESS_TEST_FEATURE, 0.0005, 0.5075, 0.11658352, 0.0833
+    ],
+    [
+        HOTCompositing(
+            (FeatureType.DATA, 'REFERENCE_SCENES'), (FeatureType.DATA_TIMELESS, 'TEST'),
+            blue_idx=0, red_idx=2, interpolation='geoville'
+        ),
+        DATA_TIMELESS_TEST_FEATURE, 0.0005, 0.5075, 0.117758796, 0.0846
+    ],
+    [
+        MaxNDVICompositing(
+            (FeatureType.DATA, 'REFERENCE_SCENES'), (FeatureType.DATA_TIMELESS, 'TEST'),
+            red_idx=2, nir_idx=7, interpolation='geoville'
+        ),
+        DATA_TIMELESS_TEST_FEATURE, 0.0005, 0.5075, 0.13430128, 0.0941
+    ],
+    [
+        MaxNDWICompositing(
+            (FeatureType.DATA, 'REFERENCE_SCENES'), (FeatureType.DATA_TIMELESS, 'TEST'),
+            nir_idx=6, swir1_idx=8, interpolation='geoville'
+        ),
+        DATA_TIMELESS_TEST_FEATURE, 0.0005, 0.5318, 0.2580135, 0.2888
+    ],
+    [
+        MaxRatioCompositing(
+            (FeatureType.DATA, 'REFERENCE_SCENES'), (FeatureType.DATA_TIMELESS, 'TEST'),
+            blue_idx=0, nir_idx=6, swir1_idx=8, interpolation='geoville'
+        ),
+        DATA_TIMELESS_TEST_FEATURE, 0.0006, 0.5075, 0.13513365, 0.0958
+    ],
+    [
+        HistogramMatching(
+            (FeatureType.DATA, 'BANDS-S2-L1C', 'TEST'), (FeatureType.DATA_TIMELESS, 'REFERENCE_COMPOSITE')
+        ),
+        DATA_TEST_FEATURE, -0.049050678, 0.68174845, 0.1165936, 0.08370649
+    ],
+))
+def test_haralick(eopatch, task, test_feature, expected_min, expected_max, expected_mean, expected_median):
+    initial_patch = copy.deepcopy(eopatch)
+    eopatch = task.execute(eopatch)
+
+    # Test that no other features were modified
+    for feature, value in initial_patch.data.items():
+        assert_array_equal(value, eopatch.data[feature], err_msg=f"EOPatch data feature '{feature}' has changed")
+
+    assert isinstance(eopatch.timestamp, list), "Expected a list of timestamps"
+    assert isinstance(eopatch.timestamp[0], datetime), "Expected timestamps of type datetime.datetime"
+
+    delta = 1e-3
+    result = eopatch[test_feature]
+    assert np.nanmin(result) == approx(expected_min, abs=delta)
+    assert np.nanmax(result) == approx(expected_max, abs=delta)
+    assert np.nanmean(result) == approx(expected_mean, abs=delta)
+    assert np.nanmedian(result) == approx(expected_median, abs=delta)

--- a/features/eolearn/tests/test_temporal_features.py
+++ b/features/eolearn/tests/test_temporal_features.py
@@ -8,8 +8,9 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import unittest
+import pytest
 import numpy as np
+from numpy.testing import assert_array_equal
 
 from datetime import date, timedelta
 
@@ -18,151 +19,115 @@ from eolearn.features import AddMaxMinNDVISlopeIndicesTask, AddMaxMinTemporalInd
     AddSpatioTemporalFeaturesTask
 
 
-def perdelta(start, end, delta):
-    curr = start
-    while curr < end:
-        yield curr
-        curr += delta
+def test_temporal_indices():
+    eopatch = EOPatch()
+    t, h, w, c = 5, 3, 3, 2
+
+    ndvi_shape = (t, h, w, 1)
+    eopatch[FeatureType.DATA, 'NDVI'] = np.arange(np.prod(ndvi_shape)).reshape(ndvi_shape)
+
+    valid_data = np.ones(ndvi_shape, bool)
+    valid_data[0] = 0
+    valid_data[-1] = 0
+    eopatch[FeatureType.MASK, 'IS_DATA'] = np.ones(ndvi_shape, dtype=np.int16)
+    eopatch[FeatureType.MASK, 'VALID_DATA'] = valid_data
+
+    new_eopatch = AddMaxMinTemporalIndicesTask(mask_data=False)(eopatch)
+
+    assert_array_equal(new_eopatch.data_timeless['ARGMIN_NDVI'], np.zeros((h, w, 1)))
+    assert_array_equal(new_eopatch.data_timeless['ARGMAX_NDVI'], (t-1) * np.ones((h, w, 1)))
+
+    new_eopatch = AddMaxMinTemporalIndicesTask(mask_data=True)(eopatch)
+
+    assert_array_equal(new_eopatch.data_timeless['ARGMIN_NDVI'], np.ones((h, w, 1)))
+    assert_array_equal(new_eopatch.data_timeless['ARGMAX_NDVI'], (t-2)*np.ones((h, w, 1)))
+
+    bands_shape = (t, h, w, c)
+    eopatch.add_feature(FeatureType.DATA, 'BANDS', np.arange(np.prod(bands_shape)).reshape(bands_shape))
+    add_bands = AddMaxMinTemporalIndicesTask(
+        data_feature='BANDS', data_index=1, amax_data_feature='ARGMAX_B1', amin_data_feature='ARGMIN_B1',
+        mask_data=False
+    )
+    new_eopatch = add_bands(eopatch)
+
+    assert_array_equal(new_eopatch.data_timeless['ARGMIN_B1'], np.zeros((h, w, 1)))
+    assert_array_equal(new_eopatch.data_timeless['ARGMAX_B1'], (t-1) * np.ones((h, w, 1)))
 
 
-class TestTemporalFeaturesTasks(unittest.TestCase):
+def test_ndvi_slope_indices():
+    timestamp = [date(2018, 3, 1) + timedelta(days=x) for x in range(11)]
+    eopatch = EOPatch(timestamp=list(timestamp))
 
-    def test_temporal_indices(self):
-        """ Test case for computation of argmax/argmin of NDVI and another band
+    t, h, w, = 10, 3, 3
+    ndvi_shape = (t, h, w, 1)
+    xx = np.zeros(ndvi_shape, np.float32)
+    x = np.linspace(0, np.pi, t)
+    xx[:, :, :, :] = x[:, None, None, None]
 
-        Cases with and without data masking are tested
-        """
-        # EOPatch
-        eopatch = EOPatch()
-        t, h, w, c = 5, 3, 3, 2
-        # NDVI
-        ndvi_shape = (t, h, w, 1)
-        # VAlid data mask
-        valid_data = np.ones(ndvi_shape, bool)
-        valid_data[0] = 0
-        valid_data[-1] = 0
-        # Fill in eopatch
-        eopatch.add_feature(FeatureType.DATA, 'NDVI', np.arange(np.prod(ndvi_shape)).reshape(ndvi_shape))
-        eopatch.add_feature(FeatureType.MASK, 'IS_DATA', np.ones(ndvi_shape, dtype=np.int16))
-        eopatch.add_feature(FeatureType.MASK, 'VALID_DATA', valid_data)
-        # Task
-        add_ndvi = AddMaxMinTemporalIndicesTask(mask_data=False)
-        # Run task
-        new_eopatch = add_ndvi(eopatch)
-        # Asserts
-        self.assertTrue(np.array_equal(new_eopatch.data_timeless['ARGMIN_NDVI'], np.zeros((h, w, 1))))
-        self.assertTrue(np.array_equal(new_eopatch.data_timeless['ARGMAX_NDVI'], (t-1)*np.ones((h, w, 1))))
-        del add_ndvi, new_eopatch
-        # Repeat with valid dat amask
-        add_ndvi = AddMaxMinTemporalIndicesTask(mask_data=True)
-        new_eopatch = add_ndvi(eopatch)
-        # Asserts
-        self.assertTrue(np.array_equal(new_eopatch.data_timeless['ARGMIN_NDVI'], np.ones((h, w, 1))))
-        self.assertTrue(np.array_equal(new_eopatch.data_timeless['ARGMAX_NDVI'], (t-2)*np.ones((h, w, 1))))
-        del add_ndvi, new_eopatch, valid_data
-        # BANDS
-        bands_shape = (t, h, w, c)
-        eopatch.add_feature(FeatureType.DATA, 'BANDS', np.arange(np.prod(bands_shape)).reshape(bands_shape))
-        add_bands = AddMaxMinTemporalIndicesTask(data_feature='BANDS',
-                                                 data_index=1,
-                                                 amax_data_feature='ARGMAX_B1',
-                                                 amin_data_feature='ARGMIN_B1',
-                                                 mask_data=False)
-        new_eopatch = add_bands(eopatch)
-        self.assertTrue(np.array_equal(new_eopatch.data_timeless['ARGMIN_B1'], np.zeros((h, w, 1))))
-        self.assertTrue(np.array_equal(new_eopatch.data_timeless['ARGMAX_B1'], (t-1)*np.ones((h, w, 1))))
+    eopatch[FeatureType.DATA, 'NDVI'] = np.sin(xx)
 
-    def test_ndvi_slope_indices(self):
-        """ Test case for computation of argmax/argmin of NDVI slope
+    valid_data = np.ones(ndvi_shape, np.uint8)
+    valid_data[1] = 0
+    valid_data[-1] = 0
+    valid_data[4] = 0
 
-            The NDVI is a sinusoid over 0-pi over the temporal dimension
+    eopatch[FeatureType.MASK, 'IS_DATA'] = np.ones(ndvi_shape, bool)
+    eopatch[FeatureType.MASK, 'VALID_DATA'] = valid_data
 
-            Cases with and without data masking are tested
-        """
-        # Slope needs timestamps
-        timestamp = perdelta(date(2018, 3, 1), date(2018, 3, 11), timedelta(days=1))
-        # EOPatch
-        eopatch = EOPatch(timestamp=list(timestamp))
-        t, h, w, = 10, 3, 3
-        # NDVI is a sinusoid where max slope is at index 1 and min slope at index 8
-        ndvi_shape = (t, h, w, 1)
-        xx = np.zeros(ndvi_shape, np.float32)
-        x = np.linspace(0, np.pi, t)
-        xx[:, :, :, :] = x[:, None, None, None]
-        # Valid data mask
-        valid_data = np.ones(ndvi_shape, np.uint8)
-        valid_data[1] = 0
-        valid_data[-1] = 0
-        valid_data[4] = 0
-        # Fill EOPatch
-        eopatch.add_feature(FeatureType.DATA, 'NDVI', np.sin(xx))
-        eopatch.add_feature(FeatureType.MASK, 'IS_DATA', np.ones(ndvi_shape, bool))
-        eopatch.add_feature(FeatureType.MASK, 'VALID_DATA', valid_data)
-        # Tasks
-        add_ndvi = AddMaxMinTemporalIndicesTask(mask_data=False)
-        add_ndvi_slope = AddMaxMinNDVISlopeIndicesTask(mask_data=False)
-        # Run
-        new_eopatch = add_ndvi_slope(add_ndvi(eopatch))
-        # Assert
-        self.assertTrue(np.array_equal(new_eopatch.data_timeless['ARGMIN_NDVI'], (t-1)*np.ones((h, w, 1))))
-        self.assertTrue(np.array_equal(new_eopatch.data_timeless['ARGMAX_NDVI'], (t//2-1)*np.ones((h, w, 1))))
-        self.assertTrue(np.array_equal(new_eopatch.data_timeless['ARGMIN_NDVI_SLOPE'], (t-2)*np.ones((h, w, 1))))
-        self.assertTrue(np.array_equal(new_eopatch.data_timeless['ARGMAX_NDVI_SLOPE'], np.ones((h, w, 1))))
-        del add_ndvi_slope, add_ndvi, new_eopatch
-        # Run on valid data only now
-        add_ndvi = AddMaxMinTemporalIndicesTask(mask_data=True)
-        add_ndvi_slope = AddMaxMinNDVISlopeIndicesTask(mask_data=True)
-        # Run
-        new_eopatch = add_ndvi_slope(add_ndvi(eopatch))
-        # Assert
-        self.assertTrue(np.array_equal(new_eopatch.data_timeless['ARGMIN_NDVI'], 0 * np.ones((h, w, 1))))
-        self.assertTrue(np.array_equal(new_eopatch.data_timeless['ARGMAX_NDVI'], (t // 2) * np.ones((h, w, 1))))
-        self.assertTrue(np.array_equal(new_eopatch.data_timeless['ARGMIN_NDVI_SLOPE'], (t - 3) * np.ones((h, w, 1))))
-        self.assertTrue(np.array_equal(new_eopatch.data_timeless['ARGMAX_NDVI_SLOPE'], 2 * np.ones((h, w, 1))))
+    add_ndvi_task = AddMaxMinTemporalIndicesTask(mask_data=False)
+    add_ndvi_slope_task = AddMaxMinNDVISlopeIndicesTask(mask_data=False)
 
-    def test_stf_task(self):
-        """ Test case for computation of spatio-temporal features
+    new_eopatch = add_ndvi_slope_task(add_ndvi_task(eopatch))
 
-            The NDVI is a sinusoid over 0-pi over the temporal dimension, while bands is an array with values equal to
-            the temporal index
-        """
-        # Timestamps
-        timestamp = perdelta(date(2018, 3, 1), date(2018, 3, 11), timedelta(days=1))
-        # EOPatch
-        eopatch = EOPatch(timestamp=list(timestamp))
-        # Shape of arrays
-        t, h, w, c = 10, 3, 3, 2
-        # NDVI is a sinusoid where max slope is at index 1 and min slope at index 8
-        ndvi_shape = (t, h, w, 1)
-        bands_shape = (t, h, w, c)
-        xx = np.zeros(ndvi_shape, np.float32)
-        x = np.linspace(0, np.pi, t)
-        xx[:, :, :, :] = x[:, None, None, None]
-        # Bands are arrays with values equal to the temporal index
-        bands = np.ones(bands_shape)*np.arange(t)[:, None, None, None]
-        # Add features to eopatch
-        eopatch.add_feature(FeatureType.DATA, 'NDVI', np.sin(xx))
-        eopatch.add_feature(FeatureType.DATA, 'BANDS', bands)
-        eopatch.add_feature(FeatureType.MASK, 'IS_DATA', np.ones(ndvi_shape, bool))
-        # Tasks
-        add_ndvi = AddMaxMinTemporalIndicesTask(mask_data=False)
-        add_bands = AddMaxMinTemporalIndicesTask(data_feature='BANDS',
-                                                 data_index=1,
-                                                 amax_data_feature='ARGMAX_B1',
-                                                 amin_data_feature='ARGMIN_B1',
-                                                 mask_data=False)
-        add_ndvi_slope = AddMaxMinNDVISlopeIndicesTask(mask_data=False)
-        add_stf = AddSpatioTemporalFeaturesTask(argmax_red='ARGMAX_B1', data_feature='BANDS', indices=[0, 1])
-        # Run tasks
-        new_eopatch = add_stf(add_ndvi_slope(add_bands(add_ndvi(eopatch))))
-        # Asserts
-        self.assertTrue(new_eopatch.data_timeless['STF'].shape == (h, w, c*5))
-        self.assertTrue(np.array_equal(new_eopatch.data_timeless['STF'][:, :, 0:c], 4*np.ones((h, w, c))))
-        self.assertTrue(np.array_equal(new_eopatch.data_timeless['STF'][:, :, c:2*c], 9*np.ones((h, w, c))))
-        self.assertTrue(np.array_equal(new_eopatch.data_timeless['STF'][:, :, 2*c:3*c], np.ones((h, w, c))))
-        self.assertTrue(np.array_equal(new_eopatch.data_timeless['STF'][:, :, 3*c:4*c], 8*np.ones((h, w, c))))
-        self.assertTrue(np.array_equal(new_eopatch.data_timeless['STF'][:, :, 4*c:5*c], 9*np.ones((h, w, c))))
+    assert_array_equal(new_eopatch.data_timeless['ARGMIN_NDVI'], (t - 1) * np.ones((h, w, 1)))
+    assert_array_equal(new_eopatch.data_timeless['ARGMAX_NDVI'], (t // 2 - 1) * np.ones((h, w, 1)))
+    assert_array_equal(new_eopatch.data_timeless['ARGMIN_NDVI_SLOPE'], (t - 2) * np.ones((h, w, 1)))
+    assert_array_equal(new_eopatch.data_timeless['ARGMAX_NDVI_SLOPE'], np.ones((h, w, 1)))
+
+    add_ndvi_task = AddMaxMinTemporalIndicesTask(mask_data=True)
+    add_ndvi_slope_task = AddMaxMinNDVISlopeIndicesTask(mask_data=True)
+
+    new_eopatch = add_ndvi_slope_task(add_ndvi_task(eopatch))
+
+    assert_array_equal(new_eopatch.data_timeless['ARGMIN_NDVI'], 0 * np.ones((h, w, 1)))
+    assert_array_equal(new_eopatch.data_timeless['ARGMAX_NDVI'], (t // 2) * np.ones((h, w, 1)))
+    assert_array_equal(new_eopatch.data_timeless['ARGMIN_NDVI_SLOPE'], (t - 3) * np.ones((h, w, 1)))
+    assert_array_equal(new_eopatch.data_timeless['ARGMAX_NDVI_SLOPE'], 2 * np.ones((h, w, 1)))
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_stf_task():
+    timestamp = [date(2018, 3, 1) + timedelta(days=x) for x in range(11)]
+    eopatch = EOPatch(timestamp=list(timestamp))
+
+    t, h, w, c = 10, 3, 3, 2
+
+    # NDVI is a sinusoid where max slope is at index 1 and min slope at index 8
+    ndvi_shape = (t, h, w, 1)
+    bands_shape = (t, h, w, c)
+    xx = np.zeros(ndvi_shape, np.float32)
+    x = np.linspace(0, np.pi, t)
+    xx[:, :, :, :] = x[:, None, None, None]
+
+    bands = np.ones(bands_shape)*np.arange(t)[:, None, None, None]
+
+    eopatch[FeatureType.DATA, 'NDVI'] = np.sin(xx)
+    eopatch[FeatureType.DATA, 'BANDS'] = bands
+    eopatch[FeatureType.MASK, 'IS_DATA'] = np.ones(ndvi_shape, bool)
+
+    add_ndvi = AddMaxMinTemporalIndicesTask(mask_data=False)
+    add_bands = AddMaxMinTemporalIndicesTask(
+        data_feature='BANDS', data_index=1, amax_data_feature='ARGMAX_B1', amin_data_feature='ARGMIN_B1',
+        mask_data=False
+    )
+    add_ndvi_slope = AddMaxMinNDVISlopeIndicesTask(mask_data=False)
+    add_stf = AddSpatioTemporalFeaturesTask(argmax_red='ARGMAX_B1', data_feature='BANDS', indices=[0, 1])
+
+    new_eopatch = add_stf(add_ndvi_slope(add_bands(add_ndvi(eopatch))))
+    result = new_eopatch.data_timeless['STF']
+
+    assert result.shape == (h, w, c*5)
+    assert_array_equal(result[:, :, 0:c], 4*np.ones((h, w, c)))
+    assert_array_equal(result[:, :, c:2*c], 9*np.ones((h, w, c)))
+    assert_array_equal(result[:, :, 2*c:3*c], np.ones((h, w, c)))
+    assert_array_equal(result[:, :, 3*c:4*c], 8*np.ones((h, w, c)))
+    assert_array_equal(result[:, :, 4*c:5*c], 9*np.ones((h, w, c)))

--- a/features/eolearn/tests/test_temporal_features.py
+++ b/features/eolearn/tests/test_temporal_features.py
@@ -8,11 +8,10 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import pytest
+from datetime import date, timedelta
+
 import numpy as np
 from numpy.testing import assert_array_equal
-
-from datetime import date, timedelta
 
 from eolearn.core import EOPatch, FeatureType
 from eolearn.features import AddMaxMinNDVISlopeIndicesTask, AddMaxMinTemporalIndicesTask,\

--- a/geometry/eolearn/geometry/superpixel.py
+++ b/geometry/eolearn/geometry/superpixel.py
@@ -93,7 +93,9 @@ class SlicSegmentation(SuperpixelSegmentation):
     def __init__(self, feature, superpixel_feature, **kwargs):
         """ Arguments are passed to `SuperpixelSegmentation` task
         """
-        super().__init__(feature, superpixel_feature, segmentation_object=skimage.segmentation.slic, **kwargs)
+        super().__init__(
+            feature, superpixel_feature, segmentation_object=skimage.segmentation.slic, start_label=0, **kwargs
+        )
 
     def _create_superpixel_mask(self, data):
         """ Method which performs the segmentation
@@ -131,8 +133,8 @@ class MarkSegmentationBoundaries(EOTask):
         feature_type, feature_name = next(self.feature_checker(eopatch))
         segmentation_mask = eopatch[feature_type][feature_name][..., 0]
 
-        bounds_mask = skimage.segmentation.mark_boundaries(np.zeros(segmentation_mask.shape[:2], dtype=np.uint8),
-                                                           segmentation_mask, **self.params)
+        bounds_mask = skimage.segmentation.mark_boundaries(
+            np.zeros(segmentation_mask.shape[:2], dtype=np.uint8), segmentation_mask, **self.params)
 
         bounds_mask = bounds_mask[..., :1].astype(np.uint8)
         eopatch[self.new_feature[0]][self.new_feature[1]] = bounds_mask

--- a/geometry/eolearn/tests/conftest.py
+++ b/geometry/eolearn/tests/conftest.py
@@ -8,11 +8,11 @@ import pytest
 from eolearn.core import EOPatch
 
 
-@pytest.fixture(scope='session', name='test_eopatch_path')
-def test_eopatch_path_fixture():
-    return os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', 'example_data', 'TestEOPatch')
+TEST_EOPATCH_PATH = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', 'example_data', 'TestEOPatch'
+)
 
 
 @pytest.fixture(name='test_eopatch')
-def test_eopatch(test_eopatch_path):
-    return EOPatch.load(test_eopatch_path, lazy_loading=True)
+def test_eopatch_fixture():
+    return EOPatch.load(TEST_EOPATCH_PATH, lazy_loading=True)

--- a/geometry/eolearn/tests/conftest.py
+++ b/geometry/eolearn/tests/conftest.py
@@ -8,9 +8,8 @@ import pytest
 from eolearn.core import EOPatch
 
 
-TEST_EOPATCH_PATH = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', 'example_data', 'TestEOPatch'
-)
+EXAMPLE_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', 'example_data')
+TEST_EOPATCH_PATH = os.path.join(EXAMPLE_DATA_PATH, 'TestEOPatch')
 
 
 @pytest.fixture(name='test_eopatch')

--- a/geometry/eolearn/tests/conftest.py
+++ b/geometry/eolearn/tests/conftest.py
@@ -1,0 +1,18 @@
+"""
+Module with global fixtures
+"""
+import os
+
+import pytest
+
+from eolearn.core import EOPatch
+
+
+@pytest.fixture(scope='session', name='test_eopatch_path')
+def test_eopatch_path_fixture():
+    return os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', 'example_data', 'TestEOPatch')
+
+
+@pytest.fixture(name='test_eopatch')
+def test_eopatch(test_eopatch_path):
+    return EOPatch.load(test_eopatch_path, lazy_loading=True)

--- a/geometry/eolearn/tests/pytest.ini
+++ b/geometry/eolearn/tests/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+log_cli = FALSE
+log_cli_level = INFO
+filterwarnings = ignore::DeprecationWarning

--- a/geometry/eolearn/tests/pytest.ini
+++ b/geometry/eolearn/tests/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-log_cli = FALSE
-log_cli_level = INFO
-filterwarnings = ignore::DeprecationWarning

--- a/geometry/eolearn/tests/test_morphology.py
+++ b/geometry/eolearn/tests/test_morphology.py
@@ -9,6 +9,7 @@ file in the root directory of this source tree.
 """
 import pytest
 import numpy as np
+from numpy.testing import assert_array_equal
 
 from eolearn.core import FeatureType
 from eolearn.geometry import ErosionTask
@@ -62,4 +63,4 @@ def test_erosion_partial(test_eopatch):
         elif label in specific_labels:
             assert np.sum(mask_after == label) <= np.sum(mask_before == label), 'Error in the erosion process'
         else:
-            assert np.array_equal(mask_after == label, mask_before == label), 'Error in the erosion process'
+            assert_array_equal(mask_after == label, mask_before == label, err_msg='Error in the erosion process')

--- a/geometry/eolearn/tests/test_morphology.py
+++ b/geometry/eolearn/tests/test_morphology.py
@@ -7,75 +7,59 @@ Copyright (c) 2017-2019 Blaž Sovdat, Nejc Vesel, Jovan Višnjić, Anže Zupanc,
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-
-import unittest
-import os
-
+import pytest
 import numpy as np
 
-from eolearn.core import EOPatch, FeatureType
+from eolearn.core import FeatureType
 from eolearn.geometry import ErosionTask
 
 
-class TestErosion(unittest.TestCase):
-
-    TEST_PATCH_FILENAME = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../example_data',
-                                       'TestEOPatch')
-
-    @classmethod
-    def setUpClass(cls):
-        cls.classes = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
-    def test_erosion_value_error(self):
-        self.assertRaises(ValueError, ErosionTask, (FeatureType.MASK_TIMELESS, 'LULC', 'TEST'), disk_radius=None)
-        self.assertRaises(ValueError, ErosionTask, (FeatureType.MASK_TIMELESS, 'LULC', 'TEST'), disk_radius=0)
-        self.assertRaises(ValueError, ErosionTask, (FeatureType.MASK_TIMELESS, 'LULC', 'TEST'), disk_radius='a')
-
-    def test_erosion_full(self):
-        eopatch = EOPatch.load(self.TEST_PATCH_FILENAME, lazy_loading=True)
-        mask_before = eopatch.mask_timeless['LULC'].copy()
-
-        erosion_task = ErosionTask((FeatureType.MASK_TIMELESS, 'LULC', 'LULC_ERODED'), 1)
-        eopatch = erosion_task.execute(eopatch)
-
-        mask_after = eopatch.mask_timeless['LULC_ERODED'].copy()
-
-        self.assertFalse(np.all(mask_before == mask_after))
-
-        for label in self.classes:
-            if label == 0:
-                self.assertGreaterEqual(np.sum(mask_after == label), np.sum(mask_before == label),
-                                        msg="error in the erosion process")
-            else:
-                self.assertLessEqual(np.sum(mask_after == label), np.sum(mask_before == label),
-                                     msg="error in the erosion process")
-
-    def test_erosion_partial(self):
-        eopatch = EOPatch.load(self.TEST_PATCH_FILENAME, lazy_loading=True)
-        mask_before = eopatch.mask_timeless['LULC'].copy()
-
-        # skip forest and artificial surface
-        specific_labels = [0, 1, 3, 4]
-        erosion_task = ErosionTask(mask_feature=(FeatureType.MASK_TIMELESS, 'LULC', 'LULC_ERODED'),
-                                   disk_radius=1,
-                                   erode_labels=specific_labels)
-        eopatch = erosion_task.execute(eopatch)
-
-        mask_after = eopatch.mask_timeless['LULC_ERODED'].copy()
-
-        self.assertFalse(np.all(mask_before == mask_after))
-
-        for label in self.classes:
-            if label == 0:
-                self.assertGreaterEqual(np.sum(mask_after == label), np.sum(mask_before == label),
-                                        msg="error in the erosion process")
-            elif label in specific_labels:
-                self.assertLessEqual(np.sum(mask_after == label), np.sum(mask_before == label),
-                                     msg="error in the erosion process")
-            else:
-                self.assertTrue(np.array_equal(mask_after == label, mask_before == label),
-                                msg="error in the erosion process")
+CLASSES = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 
 
-if __name__ == '__main__':
-    unittest.main()
+@pytest.mark.parametrize('invalid_input', [None, 0, 'a'])
+def test_erosion_value_error(invalid_input):
+    with pytest.raises(ValueError):
+        ErosionTask((FeatureType.MASK_TIMELESS, 'LULC', 'TEST'), disk_radius=invalid_input)
+
+
+def test_erosion_full(test_eopatch):
+    mask_before = test_eopatch.mask_timeless['LULC'].copy()
+
+    erosion_task = ErosionTask((FeatureType.MASK_TIMELESS, 'LULC', 'LULC_ERODED'), 1)
+    eopatch = erosion_task.execute(test_eopatch)
+
+    mask_after = eopatch.mask_timeless['LULC_ERODED'].copy()
+
+    assert not np.all(mask_before == mask_after)
+
+    for label in CLASSES:
+        if label == 0:
+            assert np.sum(mask_after == label) >= np.sum(mask_before == label), 'Error in the erosion process'
+        else:
+            assert np.sum(mask_after == label) <= np.sum(mask_before == label), 'Error in the erosion process'
+
+
+def test_erosion_partial(test_eopatch):
+    mask_before = test_eopatch.mask_timeless['LULC'].copy()
+
+    # skip forest and artificial surface
+    specific_labels = [0, 1, 3, 4]
+    erosion_task = ErosionTask(
+        mask_feature=(FeatureType.MASK_TIMELESS, 'LULC', 'LULC_ERODED'),
+        disk_radius=1,
+        erode_labels=specific_labels
+    )
+    eopatch = erosion_task.execute(test_eopatch)
+
+    mask_after = eopatch.mask_timeless['LULC_ERODED'].copy()
+
+    assert not np.all(mask_before == mask_after)
+
+    for label in CLASSES:
+        if label == 0:
+            assert np.sum(mask_after == label) >= np.sum(mask_before == label), 'Error in the erosion process'
+        elif label in specific_labels:
+            assert np.sum(mask_after == label) <= np.sum(mask_before == label), 'Error in the erosion process'
+        else:
+            assert np.array_equal(mask_after == label, mask_before == label), 'Error in the erosion process'

--- a/geometry/eolearn/tests/test_sampling.py
+++ b/geometry/eolearn/tests/test_sampling.py
@@ -8,7 +8,7 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import unittest
+import pytest
 
 from eolearn.core import EOPatch, FeatureType
 from eolearn.geometry import PointSampler, PointRasterSampler, PointSamplingTask
@@ -16,80 +16,91 @@ from eolearn.geometry import PointSampler, PointRasterSampler, PointSamplingTask
 import numpy as np
 
 
-class TestSampling(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        cls.raster_size = (100, 100)
-        cls.n_samples = 100
-        cls.raster = np.zeros(cls.raster_size, dtype=np.uint8)
-        cls.raster[40:60, 40:60] = 1
-
-    def test_point_sampler(self):
-        ps = PointSampler(self.raster)
-        self.assertEqual(ps.area(), np.prod(self.raster_size), msg="incorrect total area")
-        self.assertAlmostEqual(ps.area(cc_index=0), 400, msg="incorrect area for label 1")
-        self.assertAlmostEqual(ps.area(cc_index=1), 9600, msg="incorrect area for label 0")
-        self.assertTrue(ps.geometries[0]['polygon'].envelope.bounds == (40, 40, 60, 60), msg="incorrect polygon bounds")
-        self.assertTrue(ps.geometries[1]['polygon'].envelope.bounds == (0, 0, 100, 100), msg="incorrect polygon bounds")
-        del ps
-        ps = PointSampler(self.raster, no_data_value=0)
-        self.assertEqual(ps.area(), 400, msg="incorrect total area")
-        self.assertEqual(len(ps), 1, msg="incorrect handling of no data values")
-        del ps
-        ps = PointSampler(self.raster, ignore_labels=[1])
-        self.assertEqual(ps.area(), 9600, msg="incorrect total area")
-        self.assertEqual(len(ps), 1, msg="incorrect handling of no data values")
-        del ps
-
-    def test_point_raster_sampler(self):
-        ps = PointRasterSampler([0, 1])
-        # test if it raises ndim error
-        with self.assertRaises(ValueError):
-            ps.sample(np.ones((1000,)))
-            ps.sample(np.ones((1000, 1000, 3)))
-
-        rows, cols = ps.sample(self.raster, n_samples=self.n_samples)
-        labels = self.raster[rows, cols]
-        self.assertEqual(len(labels), self.n_samples, msg="incorrect number of samples")
-        self.assertEqual(len(rows), self.n_samples, msg="incorrect number of samples")
-        self.assertEqual(len(cols), self.n_samples, msg="incorrect number of samples")
-        # test number of sample is proportional to class frequency
-        self.assertEqual(np.sum(labels == 1), int(self.n_samples*(400/np.prod(self.raster_size))),
-                         msg="incorrect sampling distribution")
-        self.assertEqual(np.sum(labels == 0), int(self.n_samples*(9600/np.prod(self.raster_size))),
-                         msg="incorrect sampling distribution")
-        # test sampling is correct
-        self.assertEqual((labels == self.raster[rows, cols]).all(), True, msg="incorrect sampling")
-        del ps
-        # test even sampling of classes
-        ps = PointRasterSampler([0, 1], even_sampling=True)
-        rows, cols = ps.sample(self.raster, n_samples=self.n_samples)
-        labels = self.raster[rows, cols]
-        self.assertEqual(np.sum(labels == 1), self.n_samples//2, msg="incorrect sampling distribution")
-        self.assertEqual(np.sum(labels == 0), self.n_samples//2, msg="incorrect sampling distribution")
-        self.assertEqual((labels == self.raster[rows, cols]).all(), True, msg="incorrect sampling")
-
-    def test_point_sampling_task(self):
-        # test PointSamplingTask
-        t, h, w, d = 10, 100, 100, 5
-        eop = EOPatch()
-        eop.data['bands'] = np.arange(t*h*w*d).reshape(t, h, w, d)
-        eop.mask_timeless['raster'] = self.raster.reshape(self.raster_size + (1,))
-
-        task = PointSamplingTask(n_samples=self.n_samples, ref_mask_feature='raster', ref_labels=[0, 1],
-                                 sample_features=[(FeatureType.DATA, 'bands', 'SAMPLED_DATA'),
-                                                  (FeatureType.MASK_TIMELESS, 'raster', 'SAMPLED_LABELS')],
-                                 even_sampling=True)
-        task.execute(eop)
-        # assert features, labels and sampled rows and cols are added to eopatch
-        self.assertIn('SAMPLED_LABELS', eop.mask_timeless, msg="labels not added to eopatch")
-        self.assertIn('SAMPLED_DATA', eop.data, msg="features not added to eopatch")
-        # check validity of sampling
-        self.assertTupleEqual(eop.data['SAMPLED_DATA'].shape, (t, self.n_samples, 1, d), msg="incorrect features size")
-        self.assertTupleEqual(eop.mask_timeless['SAMPLED_LABELS'].shape, (self.n_samples, 1, 1),
-                              msg="incorrect number of samples")
+N_SAMPLES = 100
 
 
-if __name__ == '__main__':
-    unittest.main()
+@pytest.fixture(name='raster')
+def raster_fixture():
+    raster_size = (100, 100)
+    raster = np.zeros(raster_size, dtype=np.uint8)
+    raster[40:60, 40:60] = 1
+    return raster
+
+
+def test_point_sampler(raster):
+    ps = PointSampler(raster)
+    assert ps.area() == np.prod(raster.shape), 'Incorrect total area'
+    assert ps.area(cc_index=0) == pytest.approx(400), 'Incorrect area for label 1'
+    assert ps.area(cc_index=1) == pytest.approx(9600), 'Incorrect area for label 0'
+    assert ps.geometries[0]['polygon'].envelope.bounds == (40, 40, 60, 60), 'Incorrect polygon bounds'
+    assert ps.geometries[1]['polygon'].envelope.bounds == (0, 0, 100, 100), 'Incorrect polygon bounds'
+    del ps
+
+    ps = PointSampler(raster, no_data_value=0)
+    assert ps.area() == 400, 'Incorrect total area'
+    assert len(ps) == 1, 'Incorrect handling of no data values'
+    del ps
+
+    ps = PointSampler(raster, ignore_labels=[1])
+    assert ps.area() == 9600, 'Incorrect total area'
+    assert len(ps) == 1, 'Incorrect handling of no data values'
+    del ps
+
+
+def test_point_raster_sampler(raster):
+    ps = PointRasterSampler([0, 1])
+    # test if it raises ndim error
+    with pytest.raises(ValueError):
+        ps.sample(np.ones((1000,)))
+        ps.sample(np.ones((1000, 1000, 3)))
+
+    rows, cols = ps.sample(raster, n_samples=N_SAMPLES)
+    labels = raster[rows, cols]
+
+    assert len(labels) == N_SAMPLES, 'Incorrect number of samples'
+    assert len(rows) == N_SAMPLES, 'Incorrect number of samples'
+    assert len(cols) == N_SAMPLES, 'Incorrect number of samples'
+
+    # test number of sample is proportional to class frequency
+    assert np.sum(labels == 1) == int(N_SAMPLES * (400 / np.prod(raster.shape))), 'Incorrect sampling distribution'
+    assert np.sum(labels == 0) == int(N_SAMPLES * (9600 / np.prod(raster.shape))), 'Incorrect sampling distribution'
+
+    # test sampling is correct
+    assert (labels == raster[rows, cols]).all(), 'Incorrect sampling'
+    del ps
+
+    # test even sampling of classes
+    ps = PointRasterSampler([0, 1], even_sampling=True)
+    rows, cols = ps.sample(raster, n_samples=N_SAMPLES)
+    labels = raster[rows, cols]
+
+    assert np.sum(labels == 1) == N_SAMPLES // 2, 'Incorrect sampling distribution'
+    assert np.sum(labels == 0) == N_SAMPLES // 2, 'Incorrect sampling distribution'
+    assert (labels == raster[rows, cols]).all(), 'Incorrect sampling'
+
+
+def test_point_sampling_task(raster):
+    # test PointSamplingTask
+    t, h, w, d = 10, *raster.shape, 5
+    eop = EOPatch()
+    eop.data['bands'] = np.arange(t * h * w * d).reshape(t, h, w, d)
+    eop.mask_timeless['raster'] = raster.reshape(raster.shape + (1,))
+
+    task = PointSamplingTask(
+        n_samples=N_SAMPLES,
+        ref_mask_feature='raster',
+        ref_labels=[0, 1],
+        sample_features=[
+            (FeatureType.DATA, 'bands', 'SAMPLED_DATA'),
+            (FeatureType.MASK_TIMELESS, 'raster', 'SAMPLED_LABELS')
+        ],
+        even_sampling=True
+    )
+
+    task.execute(eop)
+    # assert features, labels and sampled rows and cols are added to eopatch
+    assert 'SAMPLED_LABELS' in eop.mask_timeless, 'Labels not added to eopatch'
+    assert 'SAMPLED_DATA' in eop.data, 'Features not added to eopatch'
+    # check validity of sampling
+    assert eop.data['SAMPLED_DATA'].shape == (t, N_SAMPLES, 1, d), 'Incorrect features size'
+    assert eop.mask_timeless['SAMPLED_LABELS'].shape == (N_SAMPLES, 1, 1), 'Incorrect number of samples'

--- a/geometry/eolearn/tests/test_superpixel.py
+++ b/geometry/eolearn/tests/test_superpixel.py
@@ -7,13 +7,10 @@ Copyright (c) 2017-2019 Blaž Sovdat, Nejc Vesel, Jovan Višnjić, Anže Zupanc,
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-
-import dataclasses
-
 import numpy as np
 import pytest
 
-from eolearn.core import FeatureType, EOTask
+from eolearn.core import FeatureType
 from eolearn.geometry import SuperpixelSegmentation, FelzenszwalbSegmentation, SlicSegmentation
 
 

--- a/geometry/eolearn/tests/test_superpixel.py
+++ b/geometry/eolearn/tests/test_superpixel.py
@@ -20,67 +20,49 @@ from eolearn.geometry import SuperpixelSegmentation, FelzenszwalbSegmentation, S
 SUPERPIXEL_FEATURE = FeatureType.MASK_TIMELESS, 'SP_FEATURE'
 
 
-@dataclasses.dataclass(frozen=True)
-class SuperpixelTestCase:
-    """Class for keeping specifics of each test case."""
-    name: str
-    task: EOTask
-    mask_mean: float
-    mask_median: int
-    mask_max: int
-    mask_min: int = 0
-
-
-TEST_CASES = (
-    SuperpixelTestCase(
-        name='base superpixel segmentation',
-        task=SuperpixelSegmentation(
+@pytest.mark.parametrize('task, expected_min, expected_max, expected_mean, expected_median', (
+    [
+        SuperpixelSegmentation(
             (FeatureType.DATA, 'BANDS-S2-L1C'), SUPERPIXEL_FEATURE, scale=100, sigma=0.5, min_size=100
         ),
-        mask_max=25, mask_mean=10.6809, mask_median=11
-    ),
-    SuperpixelTestCase(
-        name='Felzenszwalb segmentation',
-        task=FelzenszwalbSegmentation(
+        0, 25, 10.6809, 11
+    ],
+    [
+        FelzenszwalbSegmentation(
             (FeatureType.DATA_TIMELESS, 'MAX_NDVI'), SUPERPIXEL_FEATURE, scale=21, sigma=1.0, min_size=52
         ),
-        mask_max=22, mask_mean=8.5302, mask_median=7
-        ),
-    SuperpixelTestCase(
-        name='Felzenszwalb segmentation on mask',
-        task=FelzenszwalbSegmentation(
-            (FeatureType.MASK, 'CLM'), SUPERPIXEL_FEATURE, scale=1, sigma=0, min_size=15
-        ),
-        mask_max=171, mask_mean=86.46267, mask_median=90
-        ),
-    SuperpixelTestCase(
-        name='SLIC segmentation',
-        task=SlicSegmentation(
+        0, 22, 8.5302, 7
+    ],
+    [
+        FelzenszwalbSegmentation((FeatureType.MASK, 'CLM'), SUPERPIXEL_FEATURE, scale=1, sigma=0, min_size=15),
+        0, 171, 86.46267, 90
+    ],
+    [
+        SlicSegmentation(
             (FeatureType.DATA, 'CLP'), SUPERPIXEL_FEATURE, n_segments=55, compactness=25.0, max_iter=20, sigma=0.8
         ),
-        mask_max=48, mask_mean=24.6072, mask_median=25
-        ),
-    SuperpixelTestCase(
-        name='SLIC segmentation on mask',
-        task=SlicSegmentation(
+        0, 48, 24.6072, 25
+    ],
+    [
+        SlicSegmentation(
             (FeatureType.MASK_TIMELESS, 'RANDOM_UINT8'), SUPERPIXEL_FEATURE,
             n_segments=231, compactness=15.0, max_iter=7, sigma=0.2
         ),
-        mask_max=195, mask_mean=100.1844, mask_median=101
-        ),
+        0, 195, 100.1844, 101
+    ],
 )
 
 
-@pytest.mark.parametrize('test_case', TEST_CASES)
-def test_superpixel(test_eopatch, test_case):
-    test_case.task.execute(test_eopatch)
+)
+def test_superpixel(test_eopatch, task, expected_min, expected_max, expected_mean, expected_median):
+    task.execute(test_eopatch)
     result = test_eopatch[SUPERPIXEL_FEATURE]
 
     assert result.dtype == np.int64, "Expected int64 dtype for result"
 
     delta = 1e-3
 
-    assert np.amin(result) == pytest.approx(test_case.mask_min, delta), 'Minimum values do not match.'
-    assert np.amax(result) == pytest.approx(test_case.mask_max, delta), 'Maxmum values do not match.'
-    assert np.mean(result) == pytest.approx(test_case.mask_mean, delta), 'Mean values do not match.'
-    assert np.median(result) == pytest.approx(test_case.mask_median, delta), 'Median values do not match.'
+    assert np.amin(result) == pytest.approx(expected_min, delta), 'Minimum values do not match.'
+    assert np.amax(result) == pytest.approx(expected_max, delta), 'Maxmum values do not match.'
+    assert np.mean(result) == pytest.approx(expected_mean, delta), 'Mean values do not match.'
+    assert np.median(result) == pytest.approx(expected_median, delta), 'Median values do not match.'

--- a/geometry/eolearn/tests/test_superpixel.py
+++ b/geometry/eolearn/tests/test_superpixel.py
@@ -8,101 +8,79 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import unittest
-import os
+import dataclasses
 
 import numpy as np
+import pytest
 
-from eolearn.core import EOPatch, FeatureType
+from eolearn.core import FeatureType, EOTask
 from eolearn.geometry import SuperpixelSegmentation, FelzenszwalbSegmentation, SlicSegmentation
 
 
-class TestSuperpixelSegmentation(unittest.TestCase):
-
-    class TestCase:
-        """
-        Container for each test case
-        """
-        TEST_PATCH_FILENAME = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../example_data',
-                                           'TestEOPatch')
-        SUPERPIXEL_FEATURE = FeatureType.MASK_TIMELESS, 'SP_FEATURE'
-
-        def __init__(self, name, task, mask_min=0, mask_max=0, mask_mean=0, mask_median=0):
-            self.name = name
-            self.task = task
-            self.mask_min = mask_min
-            self.mask_max = mask_max
-            self.mask_mean = mask_mean
-            self.mask_median = mask_median
-
-            self.result = None
-
-        def execute(self):
-            eopatch = EOPatch.load(self.TEST_PATCH_FILENAME)
-
-            eopatch = self.task.execute(eopatch)
-
-            self.result = eopatch[self.SUPERPIXEL_FEATURE[0]][self.SUPERPIXEL_FEATURE[1]]
-
-    @classmethod
-    def setUpClass(cls):
-        # Segmentation also works with nan values, although it is not tested
-        cls.test_cases = [
-            cls.TestCase('base superpixel segmentation',
-                         SuperpixelSegmentation((FeatureType.DATA, 'BANDS-S2-L1C'), cls.TestCase.SUPERPIXEL_FEATURE,
-                                                scale=100, sigma=0.5, min_size=100),
-                         mask_min=0, mask_max=25, mask_mean=10.6809, mask_median=11),
-            cls.TestCase('Felzenszwalb segmentation',
-                         FelzenszwalbSegmentation((FeatureType.DATA_TIMELESS, 'MAX_NDVI'),
-                                                  cls.TestCase.SUPERPIXEL_FEATURE, scale=21, sigma=1.0, min_size=52),
-                         mask_min=0, mask_max=22, mask_mean=8.5302, mask_median=7),
-            cls.TestCase('Felzenszwalb segmentation on mask',
-                         FelzenszwalbSegmentation((FeatureType.MASK, 'CLM'), cls.TestCase.SUPERPIXEL_FEATURE,
-                                                  scale=1, sigma=0, min_size=15),
-                         mask_min=0, mask_max=171, mask_mean=86.46267, mask_median=90),
-            cls.TestCase('SLIC segmentation',
-                         SlicSegmentation((FeatureType.DATA, 'CLP'), cls.TestCase.SUPERPIXEL_FEATURE,
-                                          n_segments=55, compactness=25.0, max_iter=20, sigma=0.8),
-                         mask_min=0, mask_max=48, mask_mean=24.6072, mask_median=25),
-            cls.TestCase('SLIC segmentation on mask',
-                         SlicSegmentation((FeatureType.MASK_TIMELESS, 'RANDOM_UINT8'), cls.TestCase.SUPERPIXEL_FEATURE,
-                                          n_segments=231, compactness=15.0, max_iter=7, sigma=0.2),
-                         mask_min=0, mask_max=195, mask_mean=100.1844, mask_median=101),
-        ]
-
-        for test_case in cls.test_cases:
-            test_case.execute()
-
-    def test_output_type(self):
-        for test_case in self.test_cases:
-            with self.subTest(msg='Test case {}'.format(test_case.name)):
-                self.assertTrue(test_case.result.dtype == np.int64, "Expected int64 dtype")
-
-    def test_stats(self):
-        for test_case in self.test_cases:
-            delta = 1e-3
-            data = test_case.result
-
-            min_val = np.amin(data)
-            with self.subTest(msg='Test case {}'.format(test_case.name)):
-                self.assertAlmostEqual(test_case.mask_min, min_val, delta=delta,
-                                       msg="Expected min {}, got {}".format(test_case.mask_min, min_val))
-
-            max_val = np.amax(data)
-            with self.subTest(msg='Test case {}'.format(test_case.name)):
-                self.assertAlmostEqual(test_case.mask_max, max_val, delta=delta,
-                                       msg="Expected max {}, got {}".format(test_case.mask_max, max_val))
-
-            mean_val = np.mean(data)
-            with self.subTest(msg='Test case {}'.format(test_case.name)):
-                self.assertAlmostEqual(test_case.mask_mean, mean_val, delta=delta,
-                                       msg="Expected mean {}, got {}".format(test_case.mask_mean, mean_val))
-
-            median_val = np.median(data)
-            with self.subTest(msg='Test case {}'.format(test_case.name)):
-                self.assertAlmostEqual(test_case.mask_median, median_val, delta=delta,
-                                       msg="Expected median {}, got {}".format(test_case.mask_median, median_val))
+SUPERPIXEL_FEATURE = FeatureType.MASK_TIMELESS, 'SP_FEATURE'
 
 
-if __name__ == '__main__':
-    unittest.main()
+@dataclasses.dataclass(frozen=True)
+class SuperpixelTestCase:
+    """Class for keeping specifics of each test case."""
+    name: str
+    task: EOTask
+    mask_mean: float
+    mask_median: int
+    mask_max: int
+    mask_min: int = 0
+
+
+TEST_CASES = (
+    SuperpixelTestCase(
+        name='base superpixel segmentation',
+        task=SuperpixelSegmentation(
+            (FeatureType.DATA, 'BANDS-S2-L1C'), SUPERPIXEL_FEATURE, scale=100, sigma=0.5, min_size=100
+        ),
+        mask_max=25, mask_mean=10.6809, mask_median=11
+    ),
+    SuperpixelTestCase(
+        name='Felzenszwalb segmentation',
+        task=FelzenszwalbSegmentation(
+            (FeatureType.DATA_TIMELESS, 'MAX_NDVI'), SUPERPIXEL_FEATURE, scale=21, sigma=1.0, min_size=52
+        ),
+        mask_max=22, mask_mean=8.5302, mask_median=7
+        ),
+    SuperpixelTestCase(
+        name='Felzenszwalb segmentation on mask',
+        task=FelzenszwalbSegmentation(
+            (FeatureType.MASK, 'CLM'), SUPERPIXEL_FEATURE, scale=1, sigma=0, min_size=15
+        ),
+        mask_max=171, mask_mean=86.46267, mask_median=90
+        ),
+    SuperpixelTestCase(
+        name='SLIC segmentation',
+        task=SlicSegmentation(
+            (FeatureType.DATA, 'CLP'), SUPERPIXEL_FEATURE, n_segments=55, compactness=25.0, max_iter=20, sigma=0.8
+        ),
+        mask_max=48, mask_mean=24.6072, mask_median=25
+        ),
+    SuperpixelTestCase(
+        name='SLIC segmentation on mask',
+        task=SlicSegmentation(
+            (FeatureType.MASK_TIMELESS, 'RANDOM_UINT8'), SUPERPIXEL_FEATURE,
+            n_segments=231, compactness=15.0, max_iter=7, sigma=0.2
+        ),
+        mask_max=195, mask_mean=100.1844, mask_median=101
+        ),
+)
+
+
+@pytest.mark.parametrize('test_case', TEST_CASES)
+def test_superpixel(test_eopatch, test_case):
+    test_case.task.execute(test_eopatch)
+    result = test_eopatch[SUPERPIXEL_FEATURE]
+
+    assert result.dtype == np.int64, "Expected int64 dtype for result"
+
+    delta = 1e-3
+
+    assert np.amin(result) == pytest.approx(test_case.mask_min, delta), 'Minimum values do not match.'
+    assert np.amax(result) == pytest.approx(test_case.mask_max, delta), 'Maxmum values do not match.'
+    assert np.mean(result) == pytest.approx(test_case.mask_mean, delta), 'Mean values do not match.'
+    assert np.median(result) == pytest.approx(test_case.mask_median, delta), 'Median values do not match.'

--- a/geometry/eolearn/tests/test_transformations.py
+++ b/geometry/eolearn/tests/test_transformations.py
@@ -8,9 +8,8 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import os
 import dataclasses
-import typing
+from typing import Any
 
 import pytest
 import numpy as np
@@ -19,13 +18,11 @@ from eolearn.core import EOTask, EOPatch, FeatureType
 from eolearn.geometry import VectorToRaster, RasterToVector
 from shapely.geometry import Polygon
 
+from conftest import TEST_EOPATCH_PATH
 
 VECTOR_FEATURE = FeatureType.VECTOR_TIMELESS, 'LULC'
 RASTER_FEATURE = FeatureType.MASK_TIMELESS, 'RASTERIZED_LULC'
 
-TEST_EOPATCH_PATH = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', 'example_data', 'TestEOPatch'
-)
 CUSTOM_DATAFRAME = EOPatch.load(TEST_EOPATCH_PATH, lazy_loading=True)[VECTOR_FEATURE]
 CUSTOM_DATAFRAME = CUSTOM_DATAFRAME[(CUSTOM_DATAFRAME['AREA'] < 10 ** 3)]
 
@@ -185,8 +182,8 @@ def test_polygon_overlap(test_eopatch):
 class RasterToVectorTestCase:
     name: str
     task: EOTask
-    feature: typing.Any
-    vector_feature: typing.Any
+    feature: Any
+    vector_feature: Any
     data_len: int
     test_reverse: bool = False
 

--- a/geometry/eolearn/tests/test_transformations.py
+++ b/geometry/eolearn/tests/test_transformations.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import pytest
 import numpy as np
+from numpy.testing import assert_array_equal
 
 from eolearn.core import EOTask, EOPatch, FeatureType
 from eolearn.geometry import VectorToRaster, RasterToVector
@@ -219,5 +220,5 @@ def test_raster_to_vector_result(test_case, test_eopatch):
         )
 
         eop_rerasterized = vector2raster_task(eop_vectorized)
-        assert np.array_equal(eop_rerasterized[new_feature], eop_rerasterized[old_feature]), \
-            'Old and new raster features should be the same'
+        assert_array_equal(eop_rerasterized[new_feature], eop_rerasterized[old_feature],
+                           err_msg='Old and new raster features should be the same')

--- a/geometry/eolearn/tests/test_transformations.py
+++ b/geometry/eolearn/tests/test_transformations.py
@@ -8,290 +8,219 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import unittest
 import os
+import dataclasses
+import typing
 
+import pytest
 import numpy as np
 
-from eolearn.core import EOPatch, FeatureType
+from eolearn.core import EOTask, EOPatch, FeatureType
 from eolearn.geometry import VectorToRaster, RasterToVector
 from shapely.geometry import Polygon
 
 
-class TestVectorToRaster(unittest.TestCase):
-    """ Testing transformation vector -> raster
-    """
-    class TestCase:
-        """
-        Container for each test case
-        """
-        TEST_PATCH_FILENAME = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../example_data',
-                                           'TestEOPatch')
+VECTOR_FEATURE = FeatureType.VECTOR_TIMELESS, 'LULC'
+RASTER_FEATURE = FeatureType.MASK_TIMELESS, 'RASTERIZED_LULC'
 
-        def __init__(self, name, task, img_min=0, img_max=0, img_mean=0, img_median=0, img_dtype=None, img_shape=None):
-            self.name = name
-            self.task = task
-            self.img_min = img_min
-            self.img_max = img_max
-            self.img_mean = img_mean
-            self.img_median = img_median
-            self.img_dtype = img_dtype
-            self.img_shape = img_shape
-
-            self.result = None
-
-        def execute(self):
-            eopatch = EOPatch.load(self.TEST_PATCH_FILENAME)
-            self.result = self.task.execute(eopatch)
-            self.result = self.task.execute(self.result)
-
-    @classmethod
-    def setUpClass(cls):
-        cls.vector_feature = FeatureType.VECTOR_TIMELESS, 'LULC'
-        cls.raster_feature = FeatureType.MASK_TIMELESS, 'RASTERIZED_LULC'
-
-        custom_dataframe = EOPatch.load(cls.TestCase.TEST_PATCH_FILENAME).vector_timeless['LULC']
-        custom_dataframe = custom_dataframe[(custom_dataframe['AREA'] < 10 ** 3)]
-
-        reprojected_dataframe = custom_dataframe.to_crs(epsg=3857)
-
-        cls.test_cases = [
-            cls.TestCase('basic test',
-                         VectorToRaster(cls.vector_feature, cls.raster_feature, values_column='LULC_ID',
-                                        raster_shape=(FeatureType.DATA, 'BANDS-S2-L1C'), no_data_value=20),
-                         img_min=0, img_max=8, img_mean=2.33267, img_median=2, img_dtype=np.uint8,
-                         img_shape=(101, 100, 1)),
-            cls.TestCase('single value filter, fixed shape',
-                         VectorToRaster(cls.vector_feature, cls.raster_feature, values=8, values_column='LULC_ID',
-                                        raster_shape=(50, 50), no_data_value=20, write_to_existing=True,
-                                        raster_dtype=np.int32),
-                         img_min=8, img_max=20, img_mean=19.76, img_median=20, img_dtype=np.int32,
-                         img_shape=(50, 50, 1)),
-            cls.TestCase('multiple values filter, resolution, all touched',
-                         VectorToRaster(cls.vector_feature, cls.raster_feature, values=[1, 5], values_column='LULC_ID',
-                                        raster_resolution='60m', no_data_value=13, raster_dtype=np.uint16,
-                                        all_touched=True, write_to_existing=False),
-                         img_min=1, img_max=13, img_mean=12.7093, img_median=13, img_dtype=np.uint16,
-                         img_shape=(17, 17, 1)),
-            cls.TestCase('deprecated parameters, single value, custom resolution',
-                         VectorToRaster(vector_input=custom_dataframe, raster_feature=cls.raster_feature, values=14,
-                                        raster_resolution=(32, 15), no_data_value=-1, raster_dtype=np.int32),
-                         img_min=-1, img_max=14, img_mean=-0.8411, img_median=-1, img_dtype=np.int32,
-                         img_shape=(67, 31, 1)),
-            cls.TestCase('empty vector data test',
-                         VectorToRaster(vector_input=custom_dataframe[
-                                            (custom_dataframe.LULC_NAME == 'some_none_existent_name')],
-                                        raster_feature=cls.raster_feature,
-                                        values_column='LULC_ID',
-                                        raster_shape=(FeatureType.DATA, 'BANDS-S2-L1C'), no_data_value=0),
-                         img_min=0, img_max=0, img_mean=0, img_median=0, img_dtype=np.uint8,
-                         img_shape=(101, 100, 1)),
-            cls.TestCase('negative polygon buffering',
-                         VectorToRaster(vector_input=custom_dataframe,
-                                        raster_feature=cls.raster_feature,
-                                        values_column='LULC_ID',
-                                        buffer=-2,
-                                        raster_shape=(FeatureType.DATA, 'BANDS-S2-L1C'), no_data_value=0),
-                         img_min=0, img_max=8, img_mean=0.0229, img_median=0, img_dtype=np.uint8,
-                         img_shape=(101, 100, 1)),
-            cls.TestCase('positive polygon buffering',
-                         VectorToRaster(vector_input=custom_dataframe,
-                                        raster_feature=cls.raster_feature,
-                                        values_column='LULC_ID',
-                                        buffer=2,
-                                        raster_shape=(FeatureType.DATA, 'BANDS-S2-L1C'), no_data_value=0),
-                         img_min=0, img_max=8, img_mean=0.0664, img_median=0, img_dtype=np.uint8,
-                         img_shape=(101, 100, 1)),
-            cls.TestCase('different crs',
-                         VectorToRaster(vector_input=reprojected_dataframe,
-                                        raster_feature=cls.raster_feature,
-                                        values_column='LULC_ID',
-                                        raster_shape=(FeatureType.DATA, 'BANDS-S2-L1C'), no_data_value=0),
-                         img_min=0, img_max=8, img_mean=0.042079, img_median=0, img_dtype=np.uint8,
-                         img_shape=(101, 100, 1)),
-        ]
-
-        for test_case in cls.test_cases:
-            test_case.execute()
-
-    def test_result(self):
-        for test_case in self.test_cases:
-            delta = 1e-3
-            data = test_case.result[self.raster_feature[0]][self.raster_feature[1]]
-
-            min_val = np.amin(data)
-            with self.subTest(msg='Test case {}'.format(test_case.name)):
-                self.assertAlmostEqual(test_case.img_min, min_val, delta=delta,
-                                       msg="Expected min {}, got {}".format(test_case.img_min, min_val))
-
-            max_val = np.amax(data)
-            with self.subTest(msg='Test case {}'.format(test_case.name)):
-                self.assertAlmostEqual(test_case.img_max, max_val, delta=delta,
-                                       msg="Expected max {}, got {}".format(test_case.img_max, max_val))
-
-            mean_val = np.mean(data)
-            with self.subTest(msg='Test case {}'.format(test_case.name)):
-                self.assertAlmostEqual(test_case.img_mean, mean_val, delta=delta,
-                                       msg="Expected mean {}, got {}".format(test_case.img_mean, mean_val))
-
-            median_val = np.median(data)
-            with self.subTest(msg='Test case {}'.format(test_case.name)):
-                self.assertAlmostEqual(test_case.img_median, median_val, delta=delta,
-                                       msg="Expected median {}, got {}".format(test_case.img_median, median_val))
-
-            with self.subTest(msg='Test case {}'.format(test_case.name)):
-                self.assertTrue(test_case.img_dtype == data.dtype,
-                                msg="Expected dtype {}, got {}".format(test_case.img_dtype, data.dtype))
-
-            with self.subTest(msg='Test case {}'.format(test_case.name)):
-                self.assertEqual(test_case.img_shape, data.shape,
-                                 msg="Expected shape {}, got {}".format(test_case.img_shape, data.shape))
-
-    def test_polygon_overlap(self):
-        patch_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../example_data', 'TestEOPatch')
-        patch = EOPatch.load(patch_path)
-
-        # create two test bboxes to overlap existing classes
-        bounds = patch.vector_timeless['LULC'].total_bounds
-        test_bounds1 = bounds[0] + 500, bounds[1] + 1000, bounds[2] - 1450, bounds[3] - 1650
-        test_bounds2 = bounds[0] + 300, bounds[1] + 1400, bounds[2] - 1750, bounds[3] - 1300
-
-        dframe = patch.vector_timeless['LULC'][0:50]
-
-        # override 0th row with a test polygon of class 10
-        test_row = dframe.index[0]
-        dframe.at[test_row, 'LULC_ID'] = 10
-        dframe.at[test_row, 'geometry'] = Polygon.from_bounds(*test_bounds1)
-
-        # override the last row with a test polygon of class 5
-        test_row = dframe.index[-1]
-        dframe.at[test_row, 'LULC_ID'] = 5
-        dframe.at[test_row, 'geometry'] = Polygon.from_bounds(*test_bounds2)
-
-        patch.vector_timeless['TEST'] = dframe
-
-        shape_feature = FeatureType.DATA, 'BANDS-S2-L1C'
-
-        # no overlap
-        patch = VectorToRaster(dframe[1:-1], (FeatureType.MASK_TIMELESS, 'OVERLAP_0'),
-                               values_column='LULC_ID', raster_shape=shape_feature, overlap_value=5)(patch)
-
-        # overlap without taking intersection into account
-        patch = VectorToRaster(dframe, (FeatureType.MASK_TIMELESS, 'OVERLAP_1'),
-                               values_column='LULC_ID', raster_shape=shape_feature, overlap_value=None)(patch)
-
-        # overlap without setting intersections to 0
-        patch = VectorToRaster(dframe, (FeatureType.MASK_TIMELESS, 'OVERLAP_2'),
-                               values_column='LULC_ID', raster_shape=shape_feature, overlap_value=0)(patch)
-
-        # overlap without setting intersections to class 7
-        patch = VectorToRaster(dframe, (FeatureType.MASK_TIMELESS, 'OVERLAP_3'),
-                               values_column='LULC_ID', raster_shape=shape_feature, overlap_value=7)(patch)
-
-        # separately render bboxes for comparisons in asserts
-        patch = VectorToRaster(dframe[:1], (FeatureType.MASK_TIMELESS, 'TEST_BBOX1'),
-                               values_column='LULC_ID', raster_shape=shape_feature)(patch)
-        patch = VectorToRaster(dframe[-1:], (FeatureType.MASK_TIMELESS, 'TEST_BBOX2'),
-                               values_column='LULC_ID', raster_shape=shape_feature)(patch)
-
-        bbox1 = patch.mask_timeless['TEST_BBOX1']
-        bbox2 = patch.mask_timeless['TEST_BBOX2']
-
-        overlap0 = patch.mask_timeless['OVERLAP_0']
-        overlap1 = patch.mask_timeless['OVERLAP_1']
-        overlap2 = patch.mask_timeless['OVERLAP_2']
-
-        # 4 gets partially covered by 5
-        self.assertTrue(np.count_nonzero(overlap0 == 4) > np.count_nonzero(overlap1 == 4))
-        # 2 doesn't get covered, stays the same
-        self.assertTrue(np.count_nonzero(overlap0 == 2) == np.count_nonzero(overlap1 == 2))
-        # 10 is bbox2 and it gets covered by other classes
-        self.assertTrue(np.count_nonzero(bbox1) > np.count_nonzero(overlap1 == 10))
-        # 5 is bbox1 and it is rendered on top of all others, so it doesn't get covered
-        self.assertTrue(np.count_nonzero(bbox2) == np.count_nonzero(overlap1 == 5))
-
-        # all classes have their parts intersected, so the sum should reduce
-        self.assertTrue(np.count_nonzero(bbox1) > np.count_nonzero(overlap2 == 10))
-        self.assertTrue(np.count_nonzero(bbox2) > np.count_nonzero(overlap2 == 5))
-        self.assertTrue(np.count_nonzero(overlap0 == 4) > np.count_nonzero(overlap2 == 4))
-        # 2 gets covered completely
-        self.assertTrue(np.count_nonzero(overlap2 == 2) == 0)
+TEST_EOPATCH_PATH = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', 'example_data', 'TestEOPatch'
+)
+CUSTOM_DATAFRAME = EOPatch.load(TEST_EOPATCH_PATH, lazy_loading=True)[VECTOR_FEATURE]
+CUSTOM_DATAFRAME = CUSTOM_DATAFRAME[(CUSTOM_DATAFRAME['AREA'] < 10 ** 3)]
 
 
-class TestRasterToVector(unittest.TestCase):
-    """ Testing transformation raster -> vector
-    """
-    class TestCase:
-        """
-        Container for each test case
-        """
-        TEST_PATCH_FILENAME = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../example_data',
-                                           'TestEOPatch')
-
-        def __init__(self, name, task, feature, data_len, test_reverse=False):
-            self.name = name
-            self.task = task
-            self.feature = feature
-            self.data_len = data_len
-            self.test_reverse = test_reverse
-
-            self.result = None
-
-        @property
-        def vector_feature(self):
-            feature_type = FeatureType.VECTOR_TIMELESS if self.feature[0].is_timeless() else FeatureType.VECTOR
-            return feature_type, self.feature[-1]
-
-        def execute(self):
-            eopatch = EOPatch.load(self.TEST_PATCH_FILENAME)
-            self.result = self.task.execute(eopatch)
-
-    @classmethod
-    def setUpClass(cls):
-        feature1 = FeatureType.MASK_TIMELESS, 'LULC', 'NEW_LULC'
-        feature2 = FeatureType.MASK, 'CLM'
-
-        cls.test_cases = [
-            cls.TestCase('reverse test',
-                         RasterToVector(feature1), feature=feature1, data_len=126, test_reverse=True),
-            cls.TestCase('parameters test',
-                         RasterToVector(feature2, values=[1, 2], values_column='IS_CLOUD', raster_dtype=np.int16,
-                                        connectivity=8),
-                         feature=feature2, data_len=54),
-        ]
-
-        for test_case in cls.test_cases:
-            test_case.execute()
-
-    def test_result(self):
-        for test_case in self.test_cases:
-
-            ft, fn = test_case.vector_feature
-            data = test_case.result[ft][fn]
-
-            data_len = len(data.index)
-            with self.subTest(msg='Test case {}'.format(test_case.name)):
-                self.assertEqual(test_case.data_len, data_len,
-                                 msg="Expected number of shapes {}, got {}".format(test_case.data_len, data_len))
-
-    def test_transformation_back(self):
-        for test_case in self.test_cases:
-            if test_case.test_reverse:
-                with self.subTest(msg='Test case {}'.format(test_case.name)):
-
-                    new_raster_feature = test_case.feature[0], '{}_NEW'.format(test_case.feature[1])
-                    old_raster_feature = test_case.feature[:2]
-                    vector2raster_task = VectorToRaster(test_case.vector_feature, new_raster_feature,
-                                                        values_column=test_case.task.values_column,
-                                                        raster_shape=old_raster_feature)
-
-                    eop = vector2raster_task(test_case.result)
-
-                    new_raster = eop[new_raster_feature[0]][new_raster_feature[1]]
-                    old_raster = eop[old_raster_feature[0]][old_raster_feature[1]]
-                    self.assertTrue(np.array_equal(new_raster, old_raster),
-                                    msg='Old and new raster features should be the same')
+@dataclasses.dataclass(frozen=True)
+class VectorToRasterTestCase:
+    name: str
+    task: EOTask
+    img_shape: tuple
+    img_mean: float
+    img_median: int
+    img_max: int
+    img_min: int = 0
+    img_dtype: type = np.uint8
 
 
-if __name__ == '__main__':
-    unittest.main()
+VECTOR_TO_RASTER_TEST_CASES = (
+    VectorToRasterTestCase(
+        name='basic test',
+        task=VectorToRaster(
+            VECTOR_FEATURE, RASTER_FEATURE, values_column='LULC_ID',
+            raster_shape=(FeatureType.DATA, 'BANDS-S2-L1C'), no_data_value=20
+        ),
+        img_max=8, img_mean=2.33267, img_median=2, img_shape=(101, 100, 1)),
+    VectorToRasterTestCase(
+        name='single value filter, fixed shape',
+        task=VectorToRaster(
+            VECTOR_FEATURE, RASTER_FEATURE, values=8, values_column='LULC_ID',
+            raster_shape=(50, 50), no_data_value=20, write_to_existing=True, raster_dtype=np.int32
+        ),
+        img_min=8, img_max=20, img_mean=19.76, img_median=20, img_dtype=np.int32, img_shape=(50, 50, 1)),
+    VectorToRasterTestCase(
+        name='multiple values filter, resolution, all touched',
+        task=VectorToRaster(
+            VECTOR_FEATURE, RASTER_FEATURE, values=[1, 5], values_column='LULC_ID',
+            raster_resolution='60m', no_data_value=13, raster_dtype=np.uint16, all_touched=True,
+            write_to_existing=False
+        ),
+        img_min=1, img_max=13, img_mean=12.7093, img_median=13, img_dtype=np.uint16, img_shape=(17, 17, 1)),
+    VectorToRasterTestCase(
+        name='deprecated parameters, single value, custom resolution',
+        task=VectorToRaster(
+            vector_input=CUSTOM_DATAFRAME, raster_feature=RASTER_FEATURE, values=14,
+            raster_resolution=(32, 15), no_data_value=-1, raster_dtype=np.int32
+        ),
+        img_min=-1, img_max=14, img_mean=-0.8411, img_median=-1, img_dtype=np.int32, img_shape=(67, 31, 1)),
+    VectorToRasterTestCase(
+        name='empty vector data test',
+        task=VectorToRaster(
+            vector_input=CUSTOM_DATAFRAME[(CUSTOM_DATAFRAME.LULC_NAME == 'some_none_existent_name')],
+            raster_feature=RASTER_FEATURE, values_column='LULC_ID',
+            raster_shape=(FeatureType.DATA, 'BANDS-S2-L1C'), no_data_value=0
+        ),
+        img_max=0, img_mean=0, img_median=0, img_shape=(101, 100, 1)),
+    VectorToRasterTestCase(
+        name='negative polygon buffering',
+        task=VectorToRaster(
+            vector_input=CUSTOM_DATAFRAME, raster_feature=RASTER_FEATURE, values_column='LULC_ID', buffer=-2,
+            raster_shape=(FeatureType.DATA, 'BANDS-S2-L1C'), no_data_value=0
+        ),
+        img_max=8, img_mean=0.0229, img_median=0, img_shape=(101, 100, 1)),
+    VectorToRasterTestCase(
+        name='positive polygon buffering',
+        task=VectorToRaster(
+            vector_input=CUSTOM_DATAFRAME, raster_feature=RASTER_FEATURE, values_column='LULC_ID', buffer=2,
+            raster_shape=(FeatureType.DATA, 'BANDS-S2-L1C'), no_data_value=0
+        ),
+        img_max=8, img_mean=0.0664, img_median=0, img_shape=(101, 100, 1)),
+    VectorToRasterTestCase(
+        name='different crs',
+        task=VectorToRaster(
+            vector_input=CUSTOM_DATAFRAME.to_crs(epsg=3857), raster_feature=RASTER_FEATURE, values_column='LULC_ID',
+            raster_shape=(FeatureType.DATA, 'BANDS-S2-L1C'), no_data_value=0
+        ),
+        img_max=8, img_mean=0.042079, img_median=0, img_shape=(101, 100, 1)),
+)
+
+
+@pytest.mark.parametrize('test_case', VECTOR_TO_RASTER_TEST_CASES)
+def test_vector_to_raster_result(test_case, test_eopatch):
+    result = test_case.task(test_eopatch)[RASTER_FEATURE]
+    delta = 1e-3
+
+    assert np.amin(result) == pytest.approx(test_case.img_min, abs=delta), 'Minimum values do not match.'
+    assert np.amax(result) == pytest.approx(test_case.img_max, abs=delta), 'Maximum values do not match.'
+    assert np.mean(result) == pytest.approx(test_case.img_mean, abs=delta), 'Mean values do not match.'
+    assert np.median(result) == pytest.approx(test_case.img_median, abs=delta), 'Median values do not match.'
+    assert result.dtype == test_case.img_dtype, 'Wrong dtype of result.'
+    assert result.shape == test_case.img_shape, 'Result is of wrong shape.'
+
+
+def test_polygon_overlap(test_eopatch):
+
+    # create two test bboxes to overlap existing classes
+    bounds = test_eopatch[VECTOR_FEATURE].total_bounds
+    test_bounds1 = bounds[0] + 500, bounds[1] + 1000, bounds[2] - 1450, bounds[3] - 1650
+    test_bounds2 = bounds[0] + 300, bounds[1] + 1400, bounds[2] - 1750, bounds[3] - 1300
+
+    dframe = test_eopatch[VECTOR_FEATURE][0:50]
+
+    # override 0th row with a test polygon of class 10
+    test_row = dframe.index[0]
+    dframe.at[test_row, 'LULC_ID'] = 10
+    dframe.at[test_row, 'geometry'] = Polygon.from_bounds(*test_bounds1)
+
+    # override the last row with a test polygon of class 5
+    test_row = dframe.index[-1]
+    dframe.at[test_row, 'LULC_ID'] = 5
+    dframe.at[test_row, 'geometry'] = Polygon.from_bounds(*test_bounds2)
+
+    test_eopatch.vector_timeless['TEST'] = dframe
+
+    kwargs = {'raster_shape': (FeatureType.DATA, 'BANDS-S2-L1C'), 'values_column': 'LULC_ID'}
+    eop = test_eopatch
+
+    # no overlap
+    eop = VectorToRaster(dframe[1:-1], (FeatureType.MASK_TIMELESS, 'OVERLAP_0'), overlap_value=5, **kwargs)(eop)
+
+    # overlap without taking intersection into account
+    eop = VectorToRaster(dframe, (FeatureType.MASK_TIMELESS, 'OVERLAP_1'), overlap_value=None, **kwargs)(eop)
+
+    # overlap by setting intersections to 0
+    eop = VectorToRaster(dframe, (FeatureType.MASK_TIMELESS, 'OVERLAP_2'), overlap_value=0, **kwargs)(eop)
+
+    # overlap by setting intersections to class 7
+    eop = VectorToRaster(dframe, (FeatureType.MASK_TIMELESS, 'OVERLAP_3'), overlap_value=7, **kwargs)(eop)
+
+    # separately render bboxes for comparisons in asserts
+    eop = VectorToRaster(dframe[:1], (FeatureType.MASK_TIMELESS, 'TEST_BBOX1'), **kwargs)(eop)
+    eop = VectorToRaster(dframe[-1:], (FeatureType.MASK_TIMELESS, 'TEST_BBOX2'), **kwargs)(eop)
+
+    bbox1 = eop.mask_timeless['TEST_BBOX1']
+    bbox2 = eop.mask_timeless['TEST_BBOX2']
+
+    overlap0 = eop.mask_timeless['OVERLAP_0']
+    overlap1 = eop.mask_timeless['OVERLAP_1']
+    overlap2 = eop.mask_timeless['OVERLAP_2']
+
+    # 4 gets partially covered by 5
+    assert np.count_nonzero(overlap0 == 4) > np.count_nonzero(overlap1 == 4)
+    # 2 doesn't get covered, stays the same
+    assert np.count_nonzero(overlap0 == 2) == np.count_nonzero(overlap1 == 2)
+    # 10 is bbox2 and it gets covered by other classes
+    assert np.count_nonzero(bbox1) > np.count_nonzero(overlap1 == 10)
+    # 5 is bbox1 and it is rendered on top of all others, so it doesn't get covered
+    assert np.count_nonzero(bbox2) == np.count_nonzero(overlap1 == 5)
+
+    # all classes have their parts intersected, so the sum should reduce
+    assert np.count_nonzero(bbox1) > np.count_nonzero(overlap2 == 10)
+    assert np.count_nonzero(bbox2) > np.count_nonzero(overlap2 == 5)
+    assert np.count_nonzero(overlap0 == 4) > np.count_nonzero(overlap2 == 4)
+    # 2 gets covered completely
+    assert np.count_nonzero(overlap2 == 2) == 0
+
+
+@dataclasses.dataclass(frozen=True)
+class RasterToVectorTestCase:
+    name: str
+    task: EOTask
+    feature: typing.Any
+    vector_feature: typing.Any
+    data_len: int
+    test_reverse: bool = False
+
+
+RASTER_TO_VECTOR_TEST_CASES = (
+    # feature2 = FeatureType.MASK, 'CLM'
+    RasterToVectorTestCase(
+        name='reverse test', task=RasterToVector((FeatureType.MASK_TIMELESS, 'LULC', 'NEW_LULC')),
+        feature=(FeatureType.MASK_TIMELESS, 'LULC'), vector_feature=(FeatureType.VECTOR_TIMELESS, 'NEW_LULC'),
+        data_len=126, test_reverse=True
+    ),
+    RasterToVectorTestCase(
+        name='parameters test',
+        task=RasterToVector(
+            (FeatureType.MASK, 'CLM'), values=[1, 2], values_column='IS_CLOUD', raster_dtype=np.int16, connectivity=8
+        ),
+        feature=(FeatureType.MASK, 'CLM'), vector_feature=(FeatureType.VECTOR, 'CLM'), data_len=54
+    ),
+)
+
+
+@pytest.mark.parametrize('test_case', RASTER_TO_VECTOR_TEST_CASES)
+def test_raster_to_vector_result(test_case, test_eopatch):
+    eop_vectorized = test_case.task(test_eopatch)
+    assert test_case.data_len == len(eop_vectorized[test_case.vector_feature].index), 'Got wrong number of shapes.'
+
+    if test_case.test_reverse:
+        old_feature = test_case.feature
+        new_feature = old_feature[0], f'{old_feature[1]}_NEW'
+
+        vector2raster_task = VectorToRaster(
+            test_case.vector_feature, new_feature, values_column=test_case.task.values_column, raster_shape=old_feature
+        )
+
+        eop_rerasterized = vector2raster_task(eop_vectorized)
+        assert np.array_equal(eop_rerasterized[new_feature], eop_rerasterized[old_feature]), \
+            'Old and new raster features should be the same'

--- a/io/eolearn/tests/conftest.py
+++ b/io/eolearn/tests/conftest.py
@@ -8,6 +8,16 @@ from botocore.exceptions import ClientError, NoCredentialsError
 import pytest
 
 from sentinelhub import SHConfig
+from eolearn.core import EOPatch
+
+TEST_EOPATCH_PATH = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', 'example_data', 'TestEOPatch'
+)
+
+
+@pytest.fixture(name='test_eopatch')
+def test_eopatch_fixture():
+    return EOPatch.load(TEST_EOPATCH_PATH, lazy_loading=True)
 
 
 @pytest.fixture(name='config')

--- a/io/eolearn/tests/conftest.py
+++ b/io/eolearn/tests/conftest.py
@@ -10,14 +10,18 @@ import pytest
 from sentinelhub import SHConfig
 from eolearn.core import EOPatch
 
-TEST_EOPATCH_PATH = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', 'example_data', 'TestEOPatch'
-)
+EXAMPLE_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', 'example_data')
+TEST_EOPATCH_PATH = os.path.join(EXAMPLE_DATA_PATH, 'TestEOPatch')
 
 
 @pytest.fixture(name='test_eopatch')
 def test_eopatch_fixture():
     return EOPatch.load(TEST_EOPATCH_PATH, lazy_loading=True)
+
+
+@pytest.fixture(name='example_data_path')
+def example_data_path_fixture():
+    return EXAMPLE_DATA_PATH
 
 
 @pytest.fixture(name='config')

--- a/io/eolearn/tests/test_local_io.py
+++ b/io/eolearn/tests/test_local_io.py
@@ -14,318 +14,286 @@ import datetime
 import logging
 import os
 import tempfile
-import unittest
-from unittest.mock import patch
+import dataclasses
+from typing import Optional, Union
 
 import boto3
 import numpy as np
 from fs.errors import ResourceNotFound
 from moto import mock_s3
+import pytest
 
 from eolearn.core import EOPatch, FeatureType
 from eolearn.io import ExportToTiff, ImportFromTiff
 from sentinelhub import read_data
 from sentinelhub.time_utils import serialize_time
 
+from conftest import TEST_EOPATCH_PATH
+
 logging.basicConfig(level=logging.DEBUG)
 
 
-@mock_s3
-def _create_s3_bucket(bucket_name):
-    s3resource = boto3.resource('s3', region_name='eu-central-1')
-    bucket = s3resource.Bucket(bucket_name)
-
-    if bucket.creation_date:  # If bucket already exists
-        for key in bucket.objects.all():
-            key.delete()
-        bucket.delete()
-
-    s3resource.create_bucket(Bucket=bucket_name,
-                             CreateBucketConfiguration={'LocationConstraint': 'eu-central-1'})
+BUCKET_NAME = 'mocked-test-bucket'
+PATH_ON_BUCKET = f's3://{BUCKET_NAME}/some-folder'
 
 
-class TestExportAndImportTiff(unittest.TestCase):
-    """ Testing if export and then import of the data preserves the data
-    """
+@pytest.fixture(autouse=True)
+def create_s3_bucket_fixture():
+    with mock_s3():
+        s3resource = boto3.resource('s3', region_name='eu-central-1')
+        s3resource.create_bucket(Bucket=BUCKET_NAME, CreateBucketConfiguration={'LocationConstraint': 'eu-central-1'})
+        yield
 
-    class TestCase:
+
+@dataclasses.dataclass()
+class TiffTestCase:
+    name: str
+    feature_type: FeatureType
+    data: np.ndarray
+    bands: Optional[Union[tuple, list]] = None
+    times: Optional[Union[tuple, list]] = None
+    expected_times: Optional[Union[tuple, list]] = None
+
+    def __post_init__(self):
+        if self.expected_times is None:
+            self.expected_times = self.times
+
+    def get_expected(self):
+        """ Returns expected data at the end of export-import process
         """
-        Container for each test case
-        """
-
-        def __init__(self, name, feature_type, data, bands=None, times=None, expected_times=None):
-            self.name = name
-            self.feature_type = feature_type
-            self.data = data
-            self.bands = bands
-            self.times = times
-            self.expected_times = expected_times
-
-            if self.expected_times is None:
-                self.expected_times = self.times
-
-        def get_expected(self):
-            """ Returns expected data at the end of export-import process
-            """
-            expected = self.data.copy()
-
-            if isinstance(self.expected_times, tuple):
-                expected = expected[self.expected_times[0]: self.expected_times[1] + 1, ...]
-            elif isinstance(self.expected_times, list):
-                expected = expected[self.expected_times, ...]
-
-            if isinstance(self.bands, tuple):
-                expected = expected[..., self.bands[0]: self.bands[1] + 1]
-            elif isinstance(self.bands, list):
-                expected = expected[..., self.bands]
-
-            if expected.dtype == np.int64:
-                expected = expected.astype(np.int32)
-
-            return expected
-
-        def get_expected_timestamp_size(self):
-            if self.feature_type.is_timeless():
-                return None
-            return self.get_expected().shape[0]
-
-    @classmethod
-    def setUpClass(cls):
-
-        cls.eopatch = EOPatch.load(os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                                '../../../example_data/TestEOPatch'))
-
-        dates = cls.eopatch.timestamp
-        scalar_array = np.arange(10 * 6, dtype=np.float32).reshape(10, 6)
-        mask_array = np.arange(5*3*2*1, dtype=np.uint16).reshape(5, 3, 2, 1)
-        data_timeless_array = np.arange(3*2*5, dtype=np.float64).reshape(3, 2, 5)
-        data_array = np.arange(10 * 3 * 2 * 6, dtype=np.float32).reshape(10, 3, 2, 6)
-
-        cls.test_cases = [
-            cls.TestCase('scalar_timeless', FeatureType.SCALAR_TIMELESS, np.arange(3)),
-            cls.TestCase('scalar_timeless_list', FeatureType.SCALAR_TIMELESS, np.arange(5), bands=[3, 0, 2]),
-            cls.TestCase('scalar_timeless_tuple', FeatureType.SCALAR_TIMELESS, np.arange(6), bands=(1, 4)),
-            cls.TestCase('scalar_band_single_time_single', FeatureType.SCALAR, scalar_array, bands=[3], times=[7]),
-            cls.TestCase('scalar_band_list_time_list', FeatureType.SCALAR, scalar_array,
-                         bands=[2, 4, 1, 0], times=[1, 7, 0, 2, 3]),
-            cls.TestCase('scalar_band_tuple_time_tuple', FeatureType.SCALAR, scalar_array, bands=(1, 4), times=(2, 8)),
-            cls.TestCase('mask_timeless', FeatureType.MASK_TIMELESS, np.arange(3*3*1).reshape(3, 3, 1)),
-            cls.TestCase('mask_single', FeatureType.MASK, mask_array, times=[4]),
-            cls.TestCase('mask_list', FeatureType.MASK, mask_array, times=[4, 2]),
-            cls.TestCase('mask_tuple_int', FeatureType.MASK, mask_array, times=(2, 4)),
-            cls.TestCase('mask_tuple_datetime', FeatureType.MASK, mask_array, times=(dates[2], dates[4]),
-                         expected_times=(2, 4)),
-            cls.TestCase('mask_tuple_string', FeatureType.MASK, mask_array,
-                         times=(serialize_time(dates[2]), serialize_time(dates[4])),
-                         expected_times=(2, 4)),
-            cls.TestCase('data_timeless_band_list', FeatureType.DATA_TIMELESS, data_timeless_array, bands=[2, 4, 1, 0]),
-            cls.TestCase('data_timeless_band_tuple', FeatureType.DATA_TIMELESS, data_timeless_array, bands=(1, 4)),
-            cls.TestCase('data_band_list_time_list', FeatureType.DATA, data_array,
-                         bands=[2, 4, 1, 0], times=[1, 7, 0, 2, 3]),
-            cls.TestCase('data_band_tuple_time_tuple', FeatureType.DATA, data_array, bands=(1, 4), times=(2, 8)),
-            cls.TestCase('data_normal', FeatureType.DATA, data_array),
-        ]
-
-    def test_export_import(self):
-        for test_case in self.test_cases:
-            with self.subTest(msg='Test case {}'.format(test_case.name)):
-
-                self.eopatch[test_case.feature_type][test_case.name] = test_case.data
-
-                with tempfile.TemporaryDirectory() as tmp_dir_name:
-                    tmp_file_name = 'temp_file.tiff'
-                    tmp_file_name_reproject = 'temp_file_4326.tiff'
-                    feature = test_case.feature_type, test_case.name
-
-                    export_task = ExportToTiff(feature, folder=tmp_dir_name,
-                                               band_indices=test_case.bands, date_indices=test_case.times)
-                    export_task.execute(self.eopatch, filename=tmp_file_name)
-
-                    export_task = ExportToTiff(feature, folder=tmp_dir_name,
-                                               band_indices=test_case.bands, date_indices=test_case.times,
-                                               crs='EPSG:4326', compress='lzw')
-                    export_task.execute(self.eopatch, filename=tmp_file_name_reproject)
-
-                    import_task = ImportFromTiff(feature, folder=tmp_dir_name,
-                                                 timestamp_size=test_case.get_expected_timestamp_size())
-
-                    expected_raster = test_case.get_expected()
-
-                    new_eop = import_task.execute(filename=tmp_file_name)
-                    old_eop = import_task.execute(self.eopatch, filename=tmp_file_name)
+        expected = self.data.copy()
+
+        if isinstance(self.expected_times, tuple):
+            expected = expected[self.expected_times[0]: self.expected_times[1] + 1, ...]
+        elif isinstance(self.expected_times, list):
+            expected = expected[self.expected_times, ...]
+
+        if isinstance(self.bands, tuple):
+            expected = expected[..., self.bands[0]: self.bands[1] + 1]
+        elif isinstance(self.bands, list):
+            expected = expected[..., self.bands]
+
+        if expected.dtype == np.int64:
+            expected = expected.astype(np.int32)
+
+        return expected
+
+    def get_expected_timestamp_size(self):
+        if self.feature_type.is_timeless():
+            return None
+        return self.get_expected().shape[0]
+
+
+DATES = EOPatch.load(TEST_EOPATCH_PATH, lazy_loading=True).timestamp
+SCALAR_ARRAY = np.arange(10 * 6, dtype=np.float32).reshape(10, 6)
+MASK_ARRAY = np.arange(5*3*2*1, dtype=np.uint16).reshape(5, 3, 2, 1)
+DATA_TIMELESS_ARRAY = np.arange(3*2*5, dtype=np.float64).reshape(3, 2, 5)
+DATA_ARRAY = np.arange(10 * 3 * 2 * 6, dtype=np.float32).reshape(10, 3, 2, 6)
+
+
+TIFF_TEST_CASES = [
+    TiffTestCase('scalar_timeless', FeatureType.SCALAR_TIMELESS, np.arange(3)),
+    TiffTestCase('scalar_timeless_list', FeatureType.SCALAR_TIMELESS, np.arange(5), bands=[3, 0, 2]),
+    TiffTestCase('scalar_timeless_tuple', FeatureType.SCALAR_TIMELESS, np.arange(6), bands=(1, 4)),
+    TiffTestCase('scalar_band_single_time_single', FeatureType.SCALAR, SCALAR_ARRAY, bands=[3], times=[7]),
+    TiffTestCase('scalar_band_list_time_list', FeatureType.SCALAR, SCALAR_ARRAY,
+                 bands=[2, 4, 1, 0], times=[1, 7, 0, 2, 3]),
+    TiffTestCase('scalar_band_tuple_time_tuple', FeatureType.SCALAR, SCALAR_ARRAY, bands=(1, 4), times=(2, 8)),
+    TiffTestCase('mask_timeless', FeatureType.MASK_TIMELESS, np.arange(3*3*1).reshape(3, 3, 1)),
+    TiffTestCase('mask_single', FeatureType.MASK, MASK_ARRAY, times=[4]),
+    TiffTestCase('mask_list', FeatureType.MASK, MASK_ARRAY, times=[4, 2]),
+    TiffTestCase('mask_tuple_int', FeatureType.MASK, MASK_ARRAY, times=(2, 4)),
+    TiffTestCase('mask_tuple_datetime', FeatureType.MASK, MASK_ARRAY, times=(DATES[2], DATES[4]),
+                 expected_times=(2, 4)),
+    TiffTestCase('mask_tuple_string', FeatureType.MASK, MASK_ARRAY, times=(serialize_time(DATES[2]),
+                 serialize_time(DATES[4])), expected_times=(2, 4)),
+    TiffTestCase('data_timeless_band_list', FeatureType.DATA_TIMELESS, DATA_TIMELESS_ARRAY, bands=[2, 4, 1, 0]),
+    TiffTestCase('data_timeless_band_tuple', FeatureType.DATA_TIMELESS, DATA_TIMELESS_ARRAY, bands=(1, 4)),
+    TiffTestCase('data_band_list_time_list', FeatureType.DATA, DATA_ARRAY, bands=[2, 4, 1, 0], times=[1, 7, 0, 2, 3]),
+    TiffTestCase('data_band_tuple_time_tuple', FeatureType.DATA, DATA_ARRAY, bands=(1, 4), times=(2, 8)),
+    TiffTestCase('data_normal', FeatureType.DATA, DATA_ARRAY),
+]
+
+
+@pytest.mark.parametrize('test_case', TIFF_TEST_CASES)
+def test_export_import(test_case, test_eopatch):
+
+    test_eopatch[test_case.feature_type][test_case.name] = test_case.data
+
+    with tempfile.TemporaryDirectory() as tmp_dir_name:
+        tmp_file_name = 'temp_file.tiff'
+        tmp_file_name_reproject = 'temp_file_4326.tiff'
+        feature = test_case.feature_type, test_case.name
+
+        export_task = ExportToTiff(
+            feature, folder=tmp_dir_name, band_indices=test_case.bands, date_indices=test_case.times
+        )
+        export_task(test_eopatch, filename=tmp_file_name)
+
+        export_task = ExportToTiff(
+            feature, folder=tmp_dir_name, band_indices=test_case.bands, date_indices=test_case.times,
+            crs='EPSG:4326', compress='lzw'
+        )
+        export_task(test_eopatch, filename=tmp_file_name_reproject)
+
+        import_task = ImportFromTiff(
+            feature, folder=tmp_dir_name, timestamp_size=test_case.get_expected_timestamp_size()
+        )
 
-                    self.assertTrue(np.array_equal(expected_raster, new_eop[test_case.feature_type][test_case.name]),
-                                    msg='Tiff imported into new EOPatch is not the same as expected')
-                    self.assertTrue(np.array_equal(expected_raster, old_eop[test_case.feature_type][test_case.name]),
-                                    msg='Tiff imported into old EOPatch is not the same as expected')
-                    self.assertEqual(expected_raster.dtype, new_eop[test_case.feature_type][test_case.name].dtype,
-                                     msg='Tiff imported into new EOPatch has different dtype as expected')
+        expected_raster = test_case.get_expected()
 
-    def test_export2tiff_wrong_format(self):
-        data = np.arange(10*3*2*6, dtype=float).reshape(10, 3, 2, 6)
+        new_eop = import_task(filename=tmp_file_name)
+        old_eop = import_task(test_eopatch, filename=tmp_file_name)
 
-        self.eopatch.data['data'] = data
+        assert np.array_equal(expected_raster, new_eop[test_case.feature_type][test_case.name]), \
+            'Tiff imported into new EOPatch is not the same as expected'
+        assert np.array_equal(expected_raster, old_eop[test_case.feature_type][test_case.name]), \
+            'Tiff imported into old EOPatch is not the same as expected'
+        assert expected_raster.dtype == new_eop[test_case.feature_type][test_case.name].dtype, \
+            'Tiff imported into new EOPatch has different dtype as expected'
 
-        for bands, times in [([2, 'string', 1, 0], [1, 7, 0, 2, 3]),
-                             ([2, 3, 1, 0], [1, 7, 'string', 2, 3])]:
-            with tempfile.TemporaryDirectory() as tmp_dir_name, self.assertRaises(ValueError):
-                tmp_file_name = 'temp_file.tiff'
-                task = ExportToTiff((FeatureType.DATA, 'data'), folder=tmp_dir_name,
-                                    band_indices=bands, date_indices=times, image_dtype=data.dtype)
-                task.execute(self.eopatch, filename=tmp_file_name)
 
-    @patch('logging.Logger.warning')
-    def test_export2tiff_wrong_feature(self, mocked_logger):
+@pytest.mark.parametrize(
+    'bands, times', [([2, 'string', 1, 0], [1, 7, 0, 2, 3]), ([2, 3, 1, 0], [1, 7, 'string', 2, 3])]
+)
+def test_export2tiff_wrong_format(bands, times, test_eopatch):
+    test_eopatch.data['data'] = np.arange(10*3*2*6, dtype=float).reshape(10, 3, 2, 6)
 
-        with tempfile.TemporaryDirectory() as tmp_dir_name:
-            tmp_file_name = 'temp_file.tiff'
-            feature = FeatureType.MASK_TIMELESS, 'feature-not-present'
+    with tempfile.TemporaryDirectory() as tmp_dir_name, pytest.raises(ValueError):
+        tmp_file_name = 'temp_file.tiff'
+        task = ExportToTiff(
+            (FeatureType.DATA, 'data'), folder=tmp_dir_name, band_indices=bands, date_indices=times, image_dtype=float
+        )
+        task.execute(test_eopatch, filename=tmp_file_name)
 
-            export_task = ExportToTiff(feature, folder=tmp_dir_name, fail_on_missing=False)
-            export_task.execute(self.eopatch, filename=tmp_file_name)
-            assert mocked_logger.call_count == 1
-            val_err_tup, _ = mocked_logger.call_args
-            val_err, = val_err_tup
-            assert str(val_err) == 'Feature feature-not-present of type FeatureType.MASK_TIMELESS ' \
-                                   'was not found in EOPatch'
 
-            with self.assertRaises(ValueError):
-                export_task_fail = ExportToTiff(feature, folder=tmp_dir_name, fail_on_missing=True)
-                export_task_fail.execute(self.eopatch, filename=tmp_file_name)
+def test_export2tiff_wrong_feature(mocker, test_eopatch):
+    mocker.patch('logging.Logger.warning')
 
-    def test_export2tiff_separate_timestamps(self):
-        test_case = self.test_cases[-1]
-        eopatch = copy.deepcopy(self.eopatch)
-        eopatch[test_case.feature_type][test_case.name] = test_case.data
-        eopatch.timestamp = self.eopatch.timestamp[:test_case.data.shape[0]]
+    with tempfile.TemporaryDirectory() as tmp_dir_name:
+        tmp_file_name = 'temp_file.tiff'
+        feature = FeatureType.MASK_TIMELESS, 'feature-not-present'
 
-        with tempfile.TemporaryDirectory() as tmp_dir_name:
-            tmp_file_name = 'temp_file_*'
-            tmp_file_name_reproject = 'temp_file_4326_%Y%m%d.tif'
-            feature = test_case.feature_type, test_case.name
+        export_task = ExportToTiff(feature, folder=tmp_dir_name, fail_on_missing=False)
+        export_task(test_eopatch, filename=tmp_file_name)
 
-            export_task = ExportToTiff(feature,
-                                       band_indices=test_case.bands, date_indices=test_case.times)
-            full_path = os.path.join(tmp_dir_name, tmp_file_name)
-            export_task.execute(eopatch, filename=full_path)
+        assert logging.Logger.warning.call_count == 1
 
-            for timestamp in eopatch.timestamp:
-                expected_path = os.path.join(tmp_dir_name, timestamp.strftime('temp_file_%Y%m%dT%H%M%S.tif'))
-                self.assertTrue(os.path.exists(expected_path), f'Path {expected_path} does not exist')
+        (val_err,), _ = logging.Logger.warning.call_args
+        assert str(val_err) == 'Feature feature-not-present of type FeatureType.MASK_TIMELESS was not found in EOPatch'
 
-            full_path = os.path.join(tmp_dir_name, tmp_file_name_reproject)
-            export_task = ExportToTiff(feature, folder=full_path,
-                                       band_indices=test_case.bands, date_indices=test_case.times,
-                                       crs='EPSG:4326', compress='lzw')
-            export_task.execute(eopatch)
+        with pytest.raises(ValueError):
+            failing_export_task = ExportToTiff(feature, folder=tmp_dir_name, fail_on_missing=True)
+            failing_export_task(test_eopatch, filename=tmp_file_name)
 
-            for timestamp in eopatch.timestamp:
-                expected_path = os.path.join(tmp_dir_name, timestamp.strftime(tmp_file_name_reproject))
-                self.assertTrue(os.path.exists(expected_path), f'Path {expected_path} does not exist')
 
+def test_export2tiff_separate_timestamps(test_eopatch):
+    test_case = TIFF_TEST_CASES[-1]
+    eopatch = copy.deepcopy(test_eopatch)
+    eopatch[test_case.feature_type][test_case.name] = test_case.data
+    eopatch.timestamp = test_eopatch.timestamp[:test_case.data.shape[0]]
 
-class TestImportTiff(unittest.TestCase):
+    with tempfile.TemporaryDirectory() as tmp_dir_name:
+        tmp_file_name = 'temp_file_*'
+        tmp_file_name_reproject = 'temp_file_4326_%Y%m%d.tif'
+        feature = test_case.feature_type, test_case.name
 
-    @classmethod
-    def setUpClass(cls):
-        cls.eopatch = EOPatch.load(os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                                '../../../example_data/TestEOPatch'))
+        export_task = ExportToTiff(feature, band_indices=test_case.bands, date_indices=test_case.times)
+        full_path = os.path.join(tmp_dir_name, tmp_file_name)
+        export_task(eopatch, filename=full_path)
 
-    def test_import_tiff_subset(self):
-        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../example_data/import-tiff-test1.tiff')
+        for timestamp in eopatch.timestamp:
+            expected_path = os.path.join(tmp_dir_name, timestamp.strftime('temp_file_%Y%m%dT%H%M%S.tif'))
+            assert os.path.exists(expected_path), f'Path {expected_path} does not exist'
 
-        mask_feature = FeatureType.MASK_TIMELESS, 'TEST_TIF'
-        mask_type, mask_name = mask_feature
+        full_path = os.path.join(tmp_dir_name, tmp_file_name_reproject)
+        export_task = ExportToTiff(
+            feature, folder=full_path, band_indices=test_case.bands, date_indices=test_case.times, crs='EPSG:4326',
+            compress='lzw'
+        )
+        export_task(eopatch)
 
-        task = ImportFromTiff(mask_feature, path)
-        task.execute(self.eopatch)
+        for timestamp in eopatch.timestamp:
+            expected_path = os.path.join(tmp_dir_name, timestamp.strftime(tmp_file_name_reproject))
+            assert os.path.exists(expected_path), f'Path {expected_path} does not exist'
 
-        tiff_img = read_data(path)
 
-        self.assertTrue(np.array_equal(tiff_img[20: 53, 21: 54], self.eopatch[mask_type][mask_name][..., 0]),
-                        msg='Imported tiff data should be the same as original')
+def test_import_tiff_subset(test_eopatch):
+    path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../example_data/import-tiff-test1.tiff')
+    mask_feature = FeatureType.MASK_TIMELESS, 'TEST_TIF'
 
-    def test_import_tiff_intersecting(self):
-        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../example_data/import-tiff-test2.tiff')
+    task = ImportFromTiff(mask_feature, path)
+    task(test_eopatch)
 
-        mask_feature = FeatureType.MASK_TIMELESS, 'TEST_TIF'
-        mask_type, mask_name = mask_feature
-        no_data_value = 1.0
+    tiff_img = read_data(path)
 
-        task = ImportFromTiff(mask_feature, path, image_dtype=np.float64, no_data_value=no_data_value)
-        task.execute(self.eopatch)
+    assert np.array_equal(tiff_img[20: 53, 21: 54], test_eopatch[mask_feature][..., 0]), \
+        'Imported tiff data should be the same as original'
 
-        tiff_img = read_data(path)
 
-        self.assertTrue(np.array_equal(tiff_img[-6:, :3, :], self.eopatch[mask_type][mask_name][:6, -3:, :]),
-                        msg='Imported tiff data should be the same as original')
-        feature_dtype = self.eopatch[mask_type][mask_name].dtype
-        self.assertEqual(feature_dtype, np.float64,
-                         msg='Feature should have dtype numpy.float64 but {} found'.format(feature_dtype))
+def test_import_tiff_intersecting(test_eopatch):
+    path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../example_data/import-tiff-test2.tiff')
+    mask_feature = FeatureType.MASK_TIMELESS, 'TEST_TIF'
+    no_data_value = 1.0
 
-        self.eopatch[mask_type][mask_name][:6, -3:, :] = no_data_value
-        unique_values = list(np.unique(self.eopatch[mask_type][mask_name][:6, -3:, :]))
-        self.assertEqual(unique_values, [no_data_value],
-                         msg='No data values should all be equal to {}'.format(no_data_value))
+    task = ImportFromTiff(mask_feature, path, image_dtype=np.float64, no_data_value=no_data_value)
+    task(test_eopatch)
 
+    tiff_img = read_data(path)
 
-@mock_s3
-class TestS3ExportAndImport(unittest.TestCase):
+    assert np.array_equal(tiff_img[-6:, :3, :], test_eopatch[mask_feature][:6, -3:, :]), \
+        'Imported tiff data should be the same as original'
+    feature_dtype = test_eopatch[mask_feature].dtype
+    assert feature_dtype == np.float64, f'Feature should have dtype numpy.float64 but {feature_dtype} found'
 
-    @classmethod
-    def setUpClass(cls):
-        bucket_name = 'mocked-test-bucket'
-        _create_s3_bucket(bucket_name)
+    test_eopatch[mask_feature][:6, -3:, :] = no_data_value
+    unique_values = list(np.unique(test_eopatch[mask_feature][:6, -3:, :]))
+    assert unique_values == [no_data_value], f'No data values should all be equal to {no_data_value}'
 
-        cls.eopatch = EOPatch.load(os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                                '../../../example_data/TestEOPatch'))
-        cls.path = f's3://{bucket_name}/some-folder'
 
-    def test_timeless_feature(self):
-        feature = FeatureType.DATA_TIMELESS, 'DEM'
-        filename = 'relative-path/my-filename.tiff'
+def test_timeless_feature(test_eopatch):
+    feature = FeatureType.DATA_TIMELESS, 'DEM'
+    filename = 'relative-path/my-filename.tiff'
 
-        export_task = ExportToTiff(feature, folder=self.path)
-        import_task = ImportFromTiff(feature, folder=self.path)
+    export_task = ExportToTiff(feature, folder=PATH_ON_BUCKET)
+    import_task = ImportFromTiff(feature, folder=PATH_ON_BUCKET)
 
-        export_task.execute(self.eopatch, filename=filename)
-        new_eopatch = import_task.execute(self.eopatch, filename=filename)
+    export_task.execute(test_eopatch, filename=filename)
+    new_eopatch = import_task.execute(test_eopatch, filename=filename)
 
-        self.assertTrue(np.array_equal(new_eopatch[feature], self.eopatch[feature]))
+    assert np.array_equal(new_eopatch[feature], test_eopatch[feature])
 
-    def test_time_dependent_feature(self):
-        feature = FeatureType.DATA, 'NDVI'
-        filename_export = 'relative-path/*.tiff'
-        filename_import = [f'relative-path/{timestamp.strftime("%Y%m%dT%H%M%S")}.tiff'
-                           for timestamp in self.eopatch.timestamp]
 
-        export_task = ExportToTiff(feature, folder=self.path)
-        import_task = ImportFromTiff(feature, folder=self.path, timestamp_size=68)
+def test_time_dependent_feature(test_eopatch):
+    feature = FeatureType.DATA, 'NDVI'
+    filename_export = 'relative-path/*.tiff'
+    filename_import = [f'relative-path/{timestamp.strftime("%Y%m%dT%H%M%S")}.tiff'
+                       for timestamp in test_eopatch.timestamp]
 
-        export_task.execute(self.eopatch, filename=filename_export)
-        new_eopatch = import_task.execute(filename=filename_import)
+    export_task = ExportToTiff(feature, folder=PATH_ON_BUCKET)
+    import_task = ImportFromTiff(feature, folder=PATH_ON_BUCKET, timestamp_size=68)
 
-        self.assertTrue(np.array_equal(new_eopatch[feature], self.eopatch[feature]))
+    export_task(test_eopatch, filename=filename_export)
+    new_eopatch = import_task(filename=filename_import)
 
-        self.eopatch.timestamp[-1] = datetime.datetime(2020, 10, 10)
-        filename_import = [f'relative-path/{timestamp.strftime("%Y%m%dT%H%M%S")}.tiff'
-                           for timestamp in self.eopatch.timestamp]
+    assert np.array_equal(new_eopatch[feature], test_eopatch[feature])
 
-        with self.assertRaises(ResourceNotFound):
-            import_task.execute(filename=filename_import)
+    test_eopatch.timestamp[-1] = datetime.datetime(2020, 10, 10)
+    filename_import = [f'relative-path/{timestamp.strftime("%Y%m%dT%H%M%S")}.tiff'
+                       for timestamp in test_eopatch.timestamp]
 
-    def test_time_dependent_feature_with_timestamps(self):
-        feature = FeatureType.DATA, 'NDVI'
-        filename = 'relative-path/%Y%m%dT%H%M%S.tiff'
+    with pytest.raises(ResourceNotFound):
+        import_task(filename=filename_import)
 
-        export_task = ExportToTiff(feature, folder=self.path)
-        import_task = ImportFromTiff(feature, folder=self.path)
 
-        export_task.execute(self.eopatch, filename=filename)
-        new_eopatch = import_task.execute(self.eopatch, filename=filename)
+def test_time_dependent_feature_with_timestamps(test_eopatch):
+    feature = FeatureType.DATA, 'NDVI'
+    filename = 'relative-path/%Y%m%dT%H%M%S.tiff'
 
-        self.assertTrue(np.array_equal(new_eopatch[feature], self.eopatch[feature]))
+    export_task = ExportToTiff(feature, folder=PATH_ON_BUCKET)
+    import_task = ImportFromTiff(feature, folder=PATH_ON_BUCKET)
 
+    export_task.execute(test_eopatch, filename=filename)
+    new_eopatch = import_task(test_eopatch, filename=filename)
 
-if __name__ == '__main__':
-    unittest.main()
+    assert np.array_equal(new_eopatch[feature], test_eopatch[feature])

--- a/io/eolearn/tests/test_local_io.py
+++ b/io/eolearn/tests/test_local_io.py
@@ -46,7 +46,7 @@ def create_s3_bucket_fixture():
         yield
 
 
-@dataclasses.dataclass()
+@dataclasses.dataclass
 class TiffTestCase:
     name: str
     feature_type: FeatureType
@@ -220,8 +220,8 @@ def test_export2tiff_separate_timestamps(test_eopatch):
             assert os.path.exists(expected_path), f'Path {expected_path} does not exist'
 
 
-def test_import_tiff_subset(test_eopatch):
-    path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../example_data/import-tiff-test1.tiff')
+def test_import_tiff_subset(test_eopatch, example_data_path):
+    path = os.path.join(example_data_path, 'import-tiff-test1.tiff')
     mask_feature = FeatureType.MASK_TIMELESS, 'TEST_TIF'
 
     task = ImportFromTiff(mask_feature, path)
@@ -233,8 +233,8 @@ def test_import_tiff_subset(test_eopatch):
                        err_msg='Imported tiff data should be the same as original')
 
 
-def test_import_tiff_intersecting(test_eopatch):
-    path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../example_data/import-tiff-test2.tiff')
+def test_import_tiff_intersecting(test_eopatch, example_data_path):
+    path = os.path.join(example_data_path, 'import-tiff-test2.tiff')
     mask_feature = FeatureType.MASK_TIMELESS, 'TEST_TIF'
     no_data_value = 1.0
 

--- a/io/eolearn/tests/test_local_io.py
+++ b/io/eolearn/tests/test_local_io.py
@@ -153,9 +153,10 @@ def test_export_import(test_case, test_eopatch):
             'Tiff imported into new EOPatch has different dtype as expected'
 
 
-@pytest.mark.parametrize(
-    'bands, times', [([2, 'string', 1, 0], [1, 7, 0, 2, 3]), ([2, 3, 1, 0], [1, 7, 'string', 2, 3])]
-)
+@pytest.mark.parametrize('bands, times', [
+    ([2, 'string', 1, 0], [1, 7, 0, 2, 3]),
+    ([2, 3, 1, 0], [1, 7, 'string', 2, 3])
+])
 def test_export2tiff_wrong_format(bands, times, test_eopatch):
     test_eopatch.data['data'] = np.arange(10*3*2*6, dtype=float).reshape(10, 3, 2, 6)
 

--- a/io/eolearn/tests/test_local_io.py
+++ b/io/eolearn/tests/test_local_io.py
@@ -19,6 +19,7 @@ from typing import Optional, Union
 
 import boto3
 import numpy as np
+from numpy.testing import assert_array_equal
 from fs.errors import ResourceNotFound
 from moto import mock_s3
 import pytest
@@ -145,10 +146,10 @@ def test_export_import(test_case, test_eopatch):
         new_eop = import_task(filename=tmp_file_name)
         old_eop = import_task(test_eopatch, filename=tmp_file_name)
 
-        assert np.array_equal(expected_raster, new_eop[test_case.feature_type][test_case.name]), \
-            'Tiff imported into new EOPatch is not the same as expected'
-        assert np.array_equal(expected_raster, old_eop[test_case.feature_type][test_case.name]), \
-            'Tiff imported into old EOPatch is not the same as expected'
+        assert_array_equal(expected_raster, new_eop[test_case.feature_type][test_case.name],
+                           err_msg='Tiff imported into new EOPatch is not the same as expected')
+        assert_array_equal(expected_raster, old_eop[test_case.feature_type][test_case.name],
+                           err_msg='Tiff imported into old EOPatch is not the same as expected')
         assert expected_raster.dtype == new_eop[test_case.feature_type][test_case.name].dtype, \
             'Tiff imported into new EOPatch has different dtype as expected'
 
@@ -228,8 +229,8 @@ def test_import_tiff_subset(test_eopatch):
 
     tiff_img = read_data(path)
 
-    assert np.array_equal(tiff_img[20: 53, 21: 54], test_eopatch[mask_feature][..., 0]), \
-        'Imported tiff data should be the same as original'
+    assert_array_equal(tiff_img[20: 53, 21: 54], test_eopatch[mask_feature][..., 0],
+                       err_msg='Imported tiff data should be the same as original')
 
 
 def test_import_tiff_intersecting(test_eopatch):
@@ -242,8 +243,8 @@ def test_import_tiff_intersecting(test_eopatch):
 
     tiff_img = read_data(path)
 
-    assert np.array_equal(tiff_img[-6:, :3, :], test_eopatch[mask_feature][:6, -3:, :]), \
-        'Imported tiff data should be the same as original'
+    assert_array_equal(tiff_img[-6:, :3, :], test_eopatch[mask_feature][:6, -3:, :],
+                       err_msg='Imported tiff data should be the same as original')
     feature_dtype = test_eopatch[mask_feature].dtype
     assert feature_dtype == np.float64, f'Feature should have dtype numpy.float64 but {feature_dtype} found'
 
@@ -262,7 +263,7 @@ def test_timeless_feature(test_eopatch):
     export_task.execute(test_eopatch, filename=filename)
     new_eopatch = import_task.execute(test_eopatch, filename=filename)
 
-    assert np.array_equal(new_eopatch[feature], test_eopatch[feature])
+    assert_array_equal(new_eopatch[feature], test_eopatch[feature])
 
 
 def test_time_dependent_feature(test_eopatch):
@@ -277,7 +278,7 @@ def test_time_dependent_feature(test_eopatch):
     export_task(test_eopatch, filename=filename_export)
     new_eopatch = import_task(filename=filename_import)
 
-    assert np.array_equal(new_eopatch[feature], test_eopatch[feature])
+    assert_array_equal(new_eopatch[feature], test_eopatch[feature])
 
     test_eopatch.timestamp[-1] = datetime.datetime(2020, 10, 10)
     filename_import = [f'relative-path/{timestamp.strftime("%Y%m%dT%H%M%S")}.tiff'
@@ -297,4 +298,4 @@ def test_time_dependent_feature_with_timestamps(test_eopatch):
     export_task.execute(test_eopatch, filename=filename)
     new_eopatch = import_task(test_eopatch, filename=filename)
 
-    assert np.array_equal(new_eopatch[feature], test_eopatch[feature])
+    assert_array_equal(new_eopatch[feature], test_eopatch[feature])

--- a/io/eolearn/tests/test_meteoblue.py
+++ b/io/eolearn/tests/test_meteoblue.py
@@ -16,7 +16,7 @@ import pytest
 import numpy as np
 from sentinelhub import BBox, CRS
 if sys.version_info >= (3, 7):
-    from meteoblue_dataset_sdk.Dataset_pb2 import DatasetApiProtobuf
+    from meteoblue_dataset_sdk.protobuf.dataset_pb2 import DatasetApiProtobuf
 
 from eolearn.core import FeatureType, EOPatch
 from eolearn.io import MeteoblueVectorTask, MeteoblueRasterTask

--- a/io/eolearn/tests/test_sentinelhub_process.py
+++ b/io/eolearn/tests/test_sentinelhub_process.py
@@ -29,7 +29,7 @@ def cache_folder_fixture():
     shutil.rmtree(cache_folder)
 
 
-@dataclasses.dataclass()
+@dataclasses.dataclass
 class IoTestCase:
     name: str
     task: EOTask
@@ -53,7 +53,7 @@ def calculate_stats(array):
     return stats
 
 
-class TestProcessingIO():
+class TestProcessingIO:
     """ Test cases for SentinelHubInputTask
     """
     size = (99, 101)
@@ -63,7 +63,7 @@ class TestProcessingIO():
     time_difference = dt.timedelta(minutes=60)
     max_threads = 3
 
-    def test_S2L1C_float32_uint16(self, cache_folder):
+    def test_s2l1c_float32_uint16(self, cache_folder):
         task = SentinelHubInputTask(
             bands_feature=(FeatureType.DATA, 'BANDS'),
             additional_data=[(FeatureType.MASK, 'dataMask')],
@@ -360,7 +360,7 @@ class TestProcessingIO():
         assert array.shape == (20, height, width, 3)
 
 
-class TestSentinelHubInputTaskDataCollections():
+class TestSentinelHubInputTaskDataCollections:
     """ Integration tests for all supported data collections
     """
 

--- a/mask/eolearn/tests/conftest.py
+++ b/mask/eolearn/tests/conftest.py
@@ -1,0 +1,18 @@
+"""
+Module with global fixtures
+"""
+import os
+
+import pytest
+
+from eolearn.core import EOPatch
+
+
+TEST_EOPATCH_PATH = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', 'example_data', 'TestEOPatch'
+)
+
+
+@pytest.fixture(name='test_eopatch')
+def test_eopatch_fixture():
+    return EOPatch.load(TEST_EOPATCH_PATH, lazy_loading=True)

--- a/mask/eolearn/tests/conftest.py
+++ b/mask/eolearn/tests/conftest.py
@@ -8,9 +8,8 @@ import pytest
 from eolearn.core import EOPatch
 
 
-TEST_EOPATCH_PATH = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', 'example_data', 'TestEOPatch'
-)
+EXAMPLE_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', '..', 'example_data')
+TEST_EOPATCH_PATH = os.path.join(EXAMPLE_DATA_PATH, 'TestEOPatch')
 
 
 @pytest.fixture(name='test_eopatch')

--- a/mask/eolearn/tests/test_cloud_mask.py
+++ b/mask/eolearn/tests/test_cloud_mask.py
@@ -8,86 +8,68 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import os
-import unittest
-
+import pytest
+from pytest import approx
 import numpy as np
+
 from eolearn.core import EOPatch, FeatureType
 from eolearn.mask import CloudMaskTask
+from conftest import TEST_EOPATCH_PATH
 
 
-class TestCloudMaskTask(unittest.TestCase):
-    TEST_PATCH_FILENAME = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../example_data',
-                                       'TestEOPatch')
-
-    FEATURES_TO_LOAD = {
-        FeatureType.DATA: ['BANDS-S2-L1C', 'CLP_S2C', 'CLP_MULTI'],
-        FeatureType.MASK: ['IS_DATA', 'CLM_S2C', 'CLM_MULTI', 'CLM_INTERSSIM'],
-        FeatureType.LABEL: ['IS_CLOUDLESS'],
-        FeatureType.META_INFO: ...,
-        FeatureType.TIMESTAMP: ...,
-        FeatureType.BBOX: ...
-    }
-
-    @classmethod
-    def setUpClass(cls):
-        cls.eop = EOPatch.load(cls.TEST_PATCH_FILENAME, features=cls.FEATURES_TO_LOAD)
-        cls.eop.rename_feature(FeatureType.DATA, 'BANDS-S2-L1C', 'ALL_DATA')
-
-    def test_raises_errors(self):
-        add_tcm = CloudMaskTask(data_feature='bands')
-        self.assertRaises(ValueError, add_tcm, self.eop)
-
-    def _check_shape(self, output, data):
-        """Checks that shape of data and output match."""
-
-        self.assertTrue(output.ndim == 4)
-        self.assertTrue(output.shape[:-1] == data.shape[:-1])
-        self.assertTrue(output.shape[-1] == 1)
-
-    def test_mono_temporal_cloud_detection(self):
-        add_tcm = CloudMaskTask(data_feature='ALL_DATA',
-                                all_bands=True,
-                                is_data_feature='IS_DATA',
-                                mono_features=('CLP_TEST', 'CLM_TEST'),
-                                mask_feature=None,
-                                average_over=4,
-                                dilation_size=2,
-                                mono_threshold=0.4)
-        eop_clm = add_tcm(self.eop)
-
-        self.assertTrue(np.array_equal(eop_clm.mask['CLM_TEST'], eop_clm.mask['CLM_S2C']))
-        self.assertTrue(np.array_equal(eop_clm.data['CLP_TEST'], eop_clm.data['CLP_S2C']))
-
-    def test_multi_temporal_cloud_detection_downscaled(self):
-        add_tcm = CloudMaskTask(data_feature='ALL_DATA',
-                                processing_resolution=120,
-                                mono_features=('CLP_TEST', 'CLM_TEST'),
-                                multi_features=('CLP_MULTI_TEST', 'CLM_MULTI_TEST'),
-                                mask_feature='CLM_INTERSSIM_TEST',
-                                average_over=8,
-                                dilation_size=4)
-        eop_clm = add_tcm(self.eop)
-
-        # Check shape and type
-        self._check_shape(eop_clm.mask['CLM_TEST'], eop_clm.data['ALL_DATA'])
-        self._check_shape(eop_clm.data['CLP_TEST'], eop_clm.data['ALL_DATA'])
-        self.assertTrue(eop_clm.mask['CLM_TEST'].dtype == bool)
-        self.assertTrue(eop_clm.data['CLP_TEST'].dtype == np.float32)
-
-        # Compare mean cloud coverage with provided reference
-        self.assertAlmostEqual(np.mean(eop_clm.mask['CLM_TEST']), np.mean(eop_clm.mask['CLM_S2C']), places=1)
-        self.assertAlmostEqual(np.mean(eop_clm.data['CLP_TEST']), np.mean(eop_clm.data['CLP_S2C']), places=1)
-
-        # Check if most of the same times are flagged as cloudless
-        cloudless = np.mean(eop_clm.mask['CLM_TEST'], axis=(1, 2, 3)) == 0
-        self.assertTrue(np.mean(cloudless == eop_clm.label['IS_CLOUDLESS'][:, 0]) > 0.94)
-
-        # Check multi-temporal results and final mask
-        self.assertTrue(np.array_equal(eop_clm.data['CLP_MULTI_TEST'], eop_clm.data['CLP_MULTI']))
-        self.assertTrue(np.array_equal(eop_clm.mask['CLM_MULTI_TEST'], eop_clm.mask['CLM_MULTI']))
-        self.assertTrue(np.array_equal(eop_clm.mask['CLM_INTERSSIM_TEST'], eop_clm.mask['CLM_INTERSSIM']))
+def test_raises_errors(test_eopatch):
+    add_tcm = CloudMaskTask(data_feature='bands')
+    with pytest.raises(ValueError):
+        add_tcm(test_eopatch)
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_mono_temporal_cloud_detection(test_eopatch):
+    add_tcm = CloudMaskTask(
+        data_feature='BANDS-S2-L1C',
+        all_bands=True,
+        is_data_feature='IS_DATA',
+        mono_features=('CLP_TEST', 'CLM_TEST'),
+        mask_feature=None,
+        average_over=4,
+        dilation_size=2,
+        mono_threshold=0.4
+    )
+    eop_clm = add_tcm(test_eopatch)
+
+    assert np.array_equal(eop_clm.mask['CLM_TEST'], eop_clm.mask['CLM_S2C'])
+    assert np.array_equal(eop_clm.data['CLP_TEST'], eop_clm.data['CLP_S2C'])
+
+
+def test_multi_temporal_cloud_detection_downscaled(test_eopatch):
+
+    add_tcm = CloudMaskTask(
+        data_feature='BANDS-S2-L1C',
+        processing_resolution=120,
+        mono_features=('CLP_TEST', 'CLM_TEST'),
+        multi_features=('CLP_MULTI_TEST', 'CLM_MULTI_TEST'),
+        mask_feature='CLM_INTERSSIM_TEST',
+        average_over=8,
+        dilation_size=4
+    )
+    eop_clm = add_tcm(test_eopatch)
+
+    # Check shape and type
+    for feature in ((FeatureType.MASK, 'CLM_TEST'), (FeatureType.DATA, 'CLP_TEST')):
+        assert eop_clm[feature].ndim == 4
+        assert eop_clm[feature].shape[:-1] == eop_clm.data['BANDS-S2-L1C'].shape[:-1]
+        assert eop_clm[feature].shape[-1] == 1
+    assert eop_clm.mask['CLM_TEST'].dtype == bool
+    assert eop_clm.data['CLP_TEST'].dtype == np.float32
+
+    # Compare mean cloud coverage with provided reference
+    assert np.mean(eop_clm.mask['CLM_TEST']) == approx(np.mean(eop_clm.mask['CLM_S2C']), abs=0.01)
+    assert np.mean(eop_clm.data['CLP_TEST']) == approx(np.mean(eop_clm.data['CLP_S2C']), abs=0.01)
+
+    # Check if most of the same times are flagged as cloudless
+    cloudless = np.mean(eop_clm.mask['CLM_TEST'], axis=(1, 2, 3)) == 0
+    assert np.mean(cloudless == eop_clm.label['IS_CLOUDLESS'][:, 0]) > 0.94
+
+    # Check multi-temporal results and final mask
+    assert np.array_equal(eop_clm.data['CLP_MULTI_TEST'], eop_clm.data['CLP_MULTI'])
+    assert np.array_equal(eop_clm.mask['CLM_MULTI_TEST'], eop_clm.mask['CLM_MULTI'])
+    assert np.array_equal(eop_clm.mask['CLM_INTERSSIM_TEST'], eop_clm.mask['CLM_INTERSSIM'])

--- a/mask/eolearn/tests/test_cloud_mask.py
+++ b/mask/eolearn/tests/test_cloud_mask.py
@@ -11,6 +11,7 @@ file in the root directory of this source tree.
 import pytest
 from pytest import approx
 import numpy as np
+from numpy.testing import assert_array_equal
 
 from eolearn.core import FeatureType
 from eolearn.mask import CloudMaskTask
@@ -35,8 +36,8 @@ def test_mono_temporal_cloud_detection(test_eopatch):
     )
     eop_clm = add_tcm(test_eopatch)
 
-    assert np.array_equal(eop_clm.mask['CLM_TEST'], eop_clm.mask['CLM_S2C'])
-    assert np.array_equal(eop_clm.data['CLP_TEST'], eop_clm.data['CLP_S2C'])
+    assert_array_equal(eop_clm.mask['CLM_TEST'], eop_clm.mask['CLM_S2C'])
+    assert_array_equal(eop_clm.data['CLP_TEST'], eop_clm.data['CLP_S2C'])
 
 
 def test_multi_temporal_cloud_detection_downscaled(test_eopatch):
@@ -69,6 +70,6 @@ def test_multi_temporal_cloud_detection_downscaled(test_eopatch):
     assert np.mean(cloudless == eop_clm.label['IS_CLOUDLESS'][:, 0]) > 0.94
 
     # Check multi-temporal results and final mask
-    assert np.array_equal(eop_clm.data['CLP_MULTI_TEST'], eop_clm.data['CLP_MULTI'])
-    assert np.array_equal(eop_clm.mask['CLM_MULTI_TEST'], eop_clm.mask['CLM_MULTI'])
-    assert np.array_equal(eop_clm.mask['CLM_INTERSSIM_TEST'], eop_clm.mask['CLM_INTERSSIM'])
+    assert_array_equal(eop_clm.data['CLP_MULTI_TEST'], eop_clm.data['CLP_MULTI'])
+    assert_array_equal(eop_clm.mask['CLM_MULTI_TEST'], eop_clm.mask['CLM_MULTI'])
+    assert_array_equal(eop_clm.mask['CLM_INTERSSIM_TEST'], eop_clm.mask['CLM_INTERSSIM'])

--- a/mask/eolearn/tests/test_cloud_mask.py
+++ b/mask/eolearn/tests/test_cloud_mask.py
@@ -12,9 +12,8 @@ import pytest
 from pytest import approx
 import numpy as np
 
-from eolearn.core import EOPatch, FeatureType
+from eolearn.core import FeatureType
 from eolearn.mask import CloudMaskTask
-from conftest import TEST_EOPATCH_PATH
 
 
 def test_raises_errors(test_eopatch):

--- a/mask/eolearn/tests/test_mask_counting.py
+++ b/mask/eolearn/tests/test_mask_counting.py
@@ -8,50 +8,44 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import unittest
+import pytest
 import numpy as np
 
 from eolearn.mask import ClassFrequencyTask
 from eolearn.core import EOPatch, FeatureType
 
-
-class TestMaskCounting(unittest.TestCase):
-    def test_class_frequency(self):
-        patch = EOPatch()
-
-        shape = (20, 5, 5, 2)
-
-        data = np.random.randint(0, 5, size=shape)
-        data[:, 0, 0, 0] = 0
-        data[:, 0, 1, 0] = 2
-
-        patch[(FeatureType.MASK, 'TEST')] = data
-
-        classes = [2, 1, 55]
-
-        in_feature = (FeatureType.MASK, 'TEST')
-        out_feature = (FeatureType.DATA_TIMELESS, 'FREQ')
-
-        self.assertRaises(ValueError, ClassFrequencyTask, in_feature, out_feature, classes=['a', 'b'])
-        self.assertRaises(ValueError, ClassFrequencyTask, in_feature, out_feature, classes=4)
-        self.assertRaises(ValueError, ClassFrequencyTask, in_feature, out_feature, classes=None)
-        self.assertRaises(ValueError, ClassFrequencyTask, in_feature, out_feature, classes=[1, 2, 3], no_data_value=2)
-
-        patch = ClassFrequencyTask(in_feature, out_feature, classes)(patch)
-
-        result = patch[out_feature]
-
-        # all zeros through the temporal dimension should result in nan
-        self.assertTrue(np.isnan(result[0, 0, 0]))
-
-        # frequency of 2 should be 1
-        self.assertEqual(result[0, 1, 0], 1)
-
-        # frequency of 55 should be 0
-        self.assertTrue(np.all(result[1:, :, -2] == 0))
-
-        self.assertTrue(result.shape == (5, 5, 6))
+IN_FEATURE = (FeatureType.MASK, 'TEST')
+OUT_FEATURE = (FeatureType.DATA_TIMELESS, 'FREQ')
 
 
-if __name__ == '__main__':
-    unittest.main()
+@pytest.mark.parametrize('classes, no_data_value', (
+    (['a', 'b'], 0), (4, 0), (None, 0), ([1, 2, 3], 2)
+))
+def test_value_error(classes, no_data_value):
+    with pytest.raises(ValueError):
+        ClassFrequencyTask(IN_FEATURE, OUT_FEATURE, classes=classes, no_data_value=no_data_value)
+
+
+def test_class_frequency():
+    shape = (20, 5, 5, 2)
+
+    data = np.random.randint(0, 5, size=shape)
+    data[:, 0, 0, 0] = 0
+    data[:, 0, 1, 0] = 2
+
+    eopatch = EOPatch()
+    eopatch[IN_FEATURE] = data
+
+    eopatch = ClassFrequencyTask(IN_FEATURE, OUT_FEATURE, [2, 1, 55])(eopatch)
+    result = eopatch[OUT_FEATURE]
+
+    # all zeros through the temporal dimension should result in nan
+    assert np.isnan(result[0, 0, 0])
+
+    # frequency of 2 should be 1
+    assert result[0, 1, 0] == 1
+
+    # frequency of 55 should be 0
+    assert np.all(result[1:, :, -2] == 0)
+
+    assert result.shape == (5, 5, 6)

--- a/mask/eolearn/tests/test_masking.py
+++ b/mask/eolearn/tests/test_masking.py
@@ -6,9 +6,6 @@ Copyright (c) 2017-2020 Jernej Puc, Nejc Vesel, Jovan Višnjić, Anže Zupanc, L
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-import copy
-import os
-
 import pytest
 import numpy as np
 

--- a/mask/eolearn/tests/test_masking.py
+++ b/mask/eolearn/tests/test_masking.py
@@ -8,79 +8,67 @@ file in the root directory of this source tree.
 """
 import copy
 import os
-import unittest
 
+import pytest
 import numpy as np
 
-from eolearn.core import EOPatch, FeatureType
+from eolearn.core import FeatureType
 from eolearn.mask import MaskFeature
 
 
-class TestMaskFeature(unittest.TestCase):
-
-    TEST_PATCH_FILENAME = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../example_data',
-                                       'TestEOPatch')
-
-    @classmethod
-    def setUpClass(cls):
-        cls.eop = EOPatch.load(cls.TEST_PATCH_FILENAME)
-
-        cls.bands_feature = FeatureType.DATA, 'BANDS-S2-L1C'
-        cls.ndvi_feature = FeatureType.DATA, 'NDVI'
-        cls.cloud_mask_feature = FeatureType.MASK, 'CLM'
-        cls.lulc_feature = FeatureType.MASK_TIMELESS, 'LULC'
-
-    def test_bands_with_clm(self):
-        eop = copy.copy(self.eop)
-        new_feature = FeatureType.DATA, 'BANDS-S2-L1C_MASKED'
-
-        mask_task = MaskFeature(self.bands_feature, self.cloud_mask_feature, mask_values=[True], no_data_value=-1)
-        eop = mask_task(eop)
-
-        masked_count = np.count_nonzero(eop[new_feature] == -1)
-        clm_count = np.count_nonzero(eop[self.cloud_mask_feature])
-        bands_num = eop[self.bands_feature].shape[-1]
-        self.assertEqual(masked_count, clm_count * bands_num)
-
-    def test_ndvi_with_clm(self):
-        eop = copy.copy(self.eop)
-        new_feature = FeatureType.DATA, 'NDVI_MASKED'
-
-        mask_task = MaskFeature(self.ndvi_feature, self.cloud_mask_feature, mask_values=[True])
-        eop = mask_task(eop)
-
-        masked_count = np.count_nonzero(np.isnan(eop[new_feature]))
-        clm_count = np.count_nonzero(eop[self.cloud_mask_feature])
-        self.assertEqual(masked_count, clm_count)
-
-    def test_clm_with_lulc(self):
-        eop = copy.copy(self.eop)
-        new_feature = FeatureType.MASK, 'CLM_MASKED'
-
-        mask_task = MaskFeature(self.cloud_mask_feature, self.lulc_feature, mask_values=[2], no_data_value=255)
-        eop = mask_task(eop)
-
-        masked_count = np.count_nonzero(eop[new_feature] == 255)
-        lulc_count = np.count_nonzero(eop[self.lulc_feature] == 2)
-        bands_num = eop[self.cloud_mask_feature].shape[-1]
-        time_num = eop[self.cloud_mask_feature].shape[0]
-        self.assertEqual(masked_count, lulc_count * time_num * bands_num)
-
-    def test_lulc_with_lulc(self):
-        eop = copy.copy(self.eop)
-        new_feature = FeatureType.MASK_TIMELESS, 'LULC_MASKED'
-
-        mask_task = MaskFeature(self.lulc_feature, self.lulc_feature, mask_values=[1], no_data_value=100)
-        eop = mask_task(eop)
-
-        masked_count = np.count_nonzero(eop[new_feature] == 100)
-        lulc_count = np.count_nonzero(eop[self.lulc_feature] == 1)
-        self.assertEqual(masked_count, lulc_count)
-
-    def test_wrong_arguments(self):
-        with self.assertRaises(ValueError):
-            MaskFeature(self.bands_feature, self.cloud_mask_feature, mask_values=10)
+BANDS_FEATURE = FeatureType.DATA, 'BANDS-S2-L1C'
+NDVI_FEATURE = FeatureType.DATA, 'NDVI'
+CLOUD_MASK_FEATURE = FeatureType.MASK, 'CLM'
+LULC_FEATURE = FeatureType.MASK_TIMELESS, 'LULC'
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_bands_with_clm(test_eopatch):
+    new_feature = FeatureType.DATA, 'BANDS-S2-L1C_MASKED'
+
+    mask_task = MaskFeature(BANDS_FEATURE, CLOUD_MASK_FEATURE, mask_values=[True], no_data_value=-1)
+    eop = mask_task(test_eopatch)
+
+    masked_count = np.count_nonzero(eop[new_feature] == -1)
+    clm_count = np.count_nonzero(eop[CLOUD_MASK_FEATURE])
+    bands_num = eop[BANDS_FEATURE].shape[-1]
+    assert masked_count == clm_count * bands_num
+
+
+def test_ndvi_with_clm(test_eopatch):
+    new_feature = FeatureType.DATA, 'NDVI_MASKED'
+
+    mask_task = MaskFeature(NDVI_FEATURE, CLOUD_MASK_FEATURE, mask_values=[True])
+    eop = mask_task(test_eopatch)
+
+    masked_count = np.count_nonzero(np.isnan(eop[new_feature]))
+    clm_count = np.count_nonzero(eop[CLOUD_MASK_FEATURE])
+    assert masked_count == clm_count
+
+
+def test_clm_with_lulc(test_eopatch):
+    new_feature = FeatureType.MASK, 'CLM_MASKED'
+
+    mask_task = MaskFeature(CLOUD_MASK_FEATURE, LULC_FEATURE, mask_values=[2], no_data_value=255)
+    eop = mask_task(test_eopatch)
+
+    masked_count = np.count_nonzero(eop[new_feature] == 255)
+    lulc_count = np.count_nonzero(eop[LULC_FEATURE] == 2)
+    bands_num = eop[CLOUD_MASK_FEATURE].shape[-1]
+    time_num = eop[CLOUD_MASK_FEATURE].shape[0]
+    assert masked_count == lulc_count * time_num * bands_num
+
+
+def test_lulc_with_lulc(test_eopatch):
+    new_feature = FeatureType.MASK_TIMELESS, 'LULC_MASKED'
+
+    mask_task = MaskFeature(LULC_FEATURE, LULC_FEATURE, mask_values=[1], no_data_value=100)
+    eop = mask_task(test_eopatch)
+
+    masked_count = np.count_nonzero(eop[new_feature] == 100)
+    lulc_count = np.count_nonzero(eop[LULC_FEATURE] == 1)
+    assert masked_count == lulc_count
+
+
+def test_wrong_arguments():
+    with pytest.raises(ValueError):
+        MaskFeature(BANDS_FEATURE, CLOUD_MASK_FEATURE, mask_values=10)

--- a/mask/eolearn/tests/test_snow_mask.py
+++ b/mask/eolearn/tests/test_snow_mask.py
@@ -7,11 +7,9 @@ Copyright (c) 2017-2019 Jovan Višnjić, Anže Zupanc, Lojze Žust (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-
-import os
-
 import pytest
 import numpy as np
+
 from eolearn.core import FeatureType
 from eolearn.mask import SnowMask, TheiaSnowMask
 
@@ -31,11 +29,17 @@ def test_raises_errors(params, test_eopatch):
 
 
 @pytest.mark.parametrize('task, result', [
-    (SnowMask((FeatureType.DATA, 'BANDS-S2-L1C'), [2, 3, 7, 11], mask_name='TEST_SNOW_MASK'),
-     (50468, 1405)),
-    (TheiaSnowMask((FeatureType.DATA, 'BANDS-S2-L1C'), [2, 3, 11], (FeatureType.MASK, 'CLM'),
-                   (FeatureType.DATA_TIMELESS, 'DEM'), b10_index=10, mask_name='TEST_THEIA_SNOW_MASK'),
-     (60682, 10088))
+    (
+        SnowMask((FeatureType.DATA, 'BANDS-S2-L1C'), [2, 3, 7, 11], mask_name='TEST_SNOW_MASK'),
+        (50468, 1405)
+    ),
+    (
+        TheiaSnowMask(
+            (FeatureType.DATA, 'BANDS-S2-L1C'), [2, 3, 11], (FeatureType.MASK, 'CLM'),
+            (FeatureType.DATA_TIMELESS, 'DEM'), b10_index=10, mask_name='TEST_THEIA_SNOW_MASK'
+        ),
+        (60682, 10088)
+    ),
 ])
 def test_snow_coverage(task, result, test_eopatch):
     resulting_eopatch = task(test_eopatch)

--- a/mask/eolearn/tests/test_snow_mask.py
+++ b/mask/eolearn/tests/test_snow_mask.py
@@ -9,77 +9,44 @@ file in the root directory of this source tree.
 """
 
 import os
-import unittest
 
+import pytest
 import numpy as np
-from eolearn.core import EOPatch, FeatureType
+from eolearn.core import FeatureType
 from eolearn.mask import SnowMask, TheiaSnowMask
 
 
-class TestSnowMaskingTasks(unittest.TestCase):
-
-    TEST_PATCH_FILENAME = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../example_data',
-                                       'TestEOPatch')
-
-    FEATURES_TO_LOAD = [
-        (FeatureType.DATA, 'BANDS-S2-L1C'),
-        (FeatureType.MASK, 'CLM'),
-        (FeatureType.DATA_TIMELESS, 'DEM'),
-        FeatureType.META_INFO,
-        FeatureType.TIMESTAMP,
-        FeatureType.BBOX
-    ]
-
-    @classmethod
-    def setUpClass(cls):
-        cls.eop = EOPatch.load(cls.TEST_PATCH_FILENAME, features=cls.FEATURES_TO_LOAD)
-
-    def test_raises_errors(self):
-        test_params = [dict(dem_params=(100, 100, 100)),
-                       dict(red_params=45),
-                       dict(ndsi_params=(0.2, 3))]
-        for test_param in test_params:
-            with self.subTest(msg='Test case {}'.format(test_param.keys())):
-                with self.assertRaises(ValueError):
-                    theia_mask = TheiaSnowMask((FeatureType.DATA, 'BANDS-S2-L1C'),
-                                               [2, 3, 11],
-                                               (FeatureType.MASK, 'CLM'),
-                                               (FeatureType.DATA_TIMELESS, 'DEM'),
-                                               **test_param)
-                    theia_mask(self.eop)
-
-    def _check_shape(self, output, data):
-        """Checks that shape of data and output match."""
-        self.assertTrue(output.ndim == 4)
-        self.assertTrue(output.shape[:-1] == data.shape[:-1])
-        self.assertTrue(output.shape[-1] == 1)
-
-    def test_snow_coverage(self):
-        snow_mask = SnowMask((FeatureType.DATA, 'BANDS-S2-L1C'),
-                             [2, 3, 7, 11],
-                             mask_name='TEST_SNOW_MASK')
-        theia_snow_mask = TheiaSnowMask((FeatureType.DATA, 'BANDS-S2-L1C'),
-                                        [2, 3, 11],
-                                        (FeatureType.MASK, 'CLM'),
-                                        (FeatureType.DATA_TIMELESS, 'DEM'),
-                                        b10_index=10,
-                                        mask_name='TEST_THEIA_SNOW_MASK')
-
-        test_results = [(50468, 1405), (60682, 10088)]
-
-        for task, results in zip([snow_mask, theia_snow_mask], test_results):
-            eop = task(self.eop)
-
-            # Check shape and type
-            self._check_shape(eop.mask[task.mask_feature[1]], self.eop.data['BANDS-S2-L1C'])
-            self.assertTrue(eop.mask[task.mask_feature[1]].dtype == bool)
-
-            snow_pixels = np.sum(eop.mask[task.mask_feature[1]], axis=(1, 2, 3))
-            self.assertEqual(np.sum(snow_pixels), results[0],
-                             'Sum of snowy pixels does not match for task {}'.format(task.mask_feature[1]))
-            self.assertEqual(snow_pixels[-4], results[1],
-                             'Snowy pixels on specified frame does not match for task {}'.format(task.mask_feature[1]))
+@pytest.mark.parametrize('params', [
+    {'dem_params': (100, 100, 100)},
+    {'red_params': 45},
+    {'ndsi_params': (0.2, 3)}
+])
+def test_raises_errors(params, test_eopatch):
+    with pytest.raises(ValueError):
+        theia_mask = TheiaSnowMask(
+            (FeatureType.DATA, 'BANDS-S2-L1C'), [2, 3, 11], (FeatureType.MASK, 'CLM'),
+            (FeatureType.DATA_TIMELESS, 'DEM'), **params
+        )
+        theia_mask(test_eopatch)
 
 
-if __name__ == '__main__':
-    unittest.main()
+@pytest.mark.parametrize('task, result', [
+    (SnowMask((FeatureType.DATA, 'BANDS-S2-L1C'), [2, 3, 7, 11], mask_name='TEST_SNOW_MASK'),
+     (50468, 1405)),
+    (TheiaSnowMask((FeatureType.DATA, 'BANDS-S2-L1C'), [2, 3, 11], (FeatureType.MASK, 'CLM'),
+                   (FeatureType.DATA_TIMELESS, 'DEM'), b10_index=10, mask_name='TEST_THEIA_SNOW_MASK'),
+     (60682, 10088))
+])
+def test_snow_coverage(task, result, test_eopatch):
+    resulting_eopatch = task(test_eopatch)
+    output = resulting_eopatch[task.mask_feature]
+
+    assert output.ndim == 4
+    assert output.shape[:-1] == test_eopatch.data['BANDS-S2-L1C'].shape[:-1]
+    assert output.shape[-1] == 1
+
+    assert output.dtype == bool
+
+    snow_pixels = np.sum(output, axis=(1, 2, 3))
+    assert np.sum(snow_pixels) == result[0], 'Sum of snowy pixels does not match'
+    assert snow_pixels[-4] == result[1], 'Snowy pixels on specified frame do not match'

--- a/ml_tools/eolearn/ml_tools/train_test_split.py
+++ b/ml_tools/eolearn/ml_tools/train_test_split.py
@@ -64,7 +64,7 @@ class TrainTestSplitTask(EOTask):
         :type feature: (FeatureType, feature_name, new_name)
         :param bins: Cumulative probabilities of all value classes or a single float, representing a fraction.
         :type bins: a float or list of floats
-        :param split_type: Valye split type, either 'per_pixel', 'per_class' or 'per_value'.
+        :param split_type: Value split type, either 'per_pixel', 'per_class' or 'per_value'.
         :type split_type: str
         :param ignore_values: A list of values to ignore and not assign them to any subsets.
         :type ignore_values: a list of integers

--- a/ml_tools/eolearn/tests/test_classifier.py
+++ b/ml_tools/eolearn/tests/test_classifier.py
@@ -12,6 +12,7 @@ import logging
 
 import pytest
 import numpy as np
+from numpy.testing import assert_array_equal
 
 from eolearn.ml_tools import ImagePatchClassifier, ImagePixelClassifier, ImagePixel2PatchClassifier
 
@@ -98,9 +99,9 @@ def test_pixel_classifier():
     data_predicted = image_classifier.image_predict(data)
     data_prob_predicted = image_classifier.image_predict_proba(data)
 
-    assert np.array_equal(data_predicted, np.max(values)*np.ones((20, 40, 40), dtype=np.uint8))
-    assert np.array_equal(data_prob_predicted[..., 0], np.max(values) * np.ones((20, 40, 40), dtype=np.uint8))
-    assert np.array_equal(data_prob_predicted[..., 1], np.min(values) * np.ones((20, 40, 40), dtype=np.uint8))
+    assert_array_equal(data_predicted, np.max(values)*np.ones((20, 40, 40), dtype=np.uint8))
+    assert_array_equal(data_prob_predicted[..., 0], np.max(values) * np.ones((20, 40, 40), dtype=np.uint8))
+    assert_array_equal(data_prob_predicted[..., 1], np.min(values) * np.ones((20, 40, 40), dtype=np.uint8))
 
 
 def test_patch_classifier():
@@ -113,6 +114,6 @@ def test_patch_classifier():
     data_predicted = image_classifier.image_predict(data)
     data_prob_predicted = image_classifier.image_predict_proba(data)
 
-    assert np.array_equal(data_predicted, np.max(values)*np.ones((20, 40, 40), dtype=np.uint8))
-    assert np.array_equal(data_prob_predicted[..., 0], np.max(values) * np.ones((20, 40, 40), dtype=np.uint8))
-    assert np.array_equal(data_prob_predicted[..., 1], np.min(values) * np.ones((20, 40, 40), dtype=np.uint8))
+    assert_array_equal(data_predicted, np.max(values)*np.ones((20, 40, 40), dtype=np.uint8))
+    assert_array_equal(data_prob_predicted[..., 0], np.max(values) * np.ones((20, 40, 40), dtype=np.uint8))
+    assert_array_equal(data_prob_predicted[..., 1], np.min(values) * np.ones((20, 40, 40), dtype=np.uint8))

--- a/ml_tools/eolearn/tests/test_classifier.py
+++ b/ml_tools/eolearn/tests/test_classifier.py
@@ -8,8 +8,9 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import unittest
 import logging
+
+import pytest
 import numpy as np
 
 from eolearn.ml_tools import ImagePatchClassifier, ImagePixelClassifier, ImagePixel2PatchClassifier
@@ -62,60 +63,56 @@ class DummyPatchClassifier:
     def predict(self, data):
         if data.shape[1:3] == self.receptive_field:
             return np.asarray([self._predict(example) for example in data], dtype=int)
-        else:
-            raise ValueError('Dummy Classifier: input of incorrect shape')
+        raise ValueError('Dummy Classifier: input of incorrect shape')
 
     def predict_proba(self, data):
         if data.shape[1:3] == self.receptive_field:
             return np.asarray([self._predict_proba(example) for example in data], dtype=float)
-        else:
-            raise ValueError('Dummy Classifier: input of incorrect shape')
+        raise ValueError('Dummy Classifier: input of incorrect shape')
 
 
-class TestImageClassifier(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        cls.receptive_field = (2, 2)
-        cls.bad_classifier = BadClassifier()
-        cls.pixel_classifier = DummyPixelClassifier()
-        cls.patch_classifier = DummyPatchClassifier(receptive_field=cls.receptive_field)
-
-    def test_initialisation(self):
-        # Test class raises exceptions if classifier does not implement image_predict and image_predict_proba
-        with self.assertRaises(ValueError):
-            ImagePatchClassifier(self.bad_classifier, self.receptive_field)
-            ImagePixelClassifier(self.bad_classifier)
-            ImagePixel2PatchClassifier(self.bad_classifier, (4, 4))
-
-    def test_pixel_classifier(self):
-        # Test a dummy pixel classifier example
-        image_classifier = ImagePixelClassifier(self.pixel_classifier)
-        data = np.ones((20, 40, 40, 3), dtype=np.uint8)
-        values = np.random.randint(0, 100, (3,), dtype=np.uint8)
-        data *= values[None, None, None, :]
-        data_predicted = image_classifier.image_predict(data)
-        data_prob_predicted = image_classifier.image_predict_proba(data)
-        self.assertTrue(np.array_equal(data_predicted, np.max(values)*np.ones((20, 40, 40), dtype=np.uint8)))
-        self.assertTrue(np.array_equal(data_prob_predicted[..., 0],
-                                       np.max(values)*np.ones((20, 40, 40), dtype=np.uint8)))
-        self.assertTrue(np.array_equal(data_prob_predicted[..., 1],
-                                       np.min(values)*np.ones((20, 40, 40), dtype=np.uint8)))
-
-    def test_patch_classifier(self):
-        # Test a dummy patch classifier example
-        image_classifier = ImagePatchClassifier(self.patch_classifier, self.receptive_field)
-        data = np.ones((20, 40, 40, 3), dtype=np.uint8)
-        values = np.random.randint(0, 100, (3,), dtype=np.uint8)
-        data *= values[None, None, None, :]
-        data_predicted = image_classifier.image_predict(data)
-        data_prob_predicted = image_classifier.image_predict_proba(data)
-        self.assertTrue(np.array_equal(data_predicted, np.max(values)*np.ones((20, 40, 40), dtype=np.uint8)))
-        self.assertTrue(np.array_equal(data_prob_predicted[..., 0],
-                                       np.max(values)*np.ones((20, 40, 40), dtype=np.uint8)))
-        self.assertTrue(np.array_equal(data_prob_predicted[..., 1],
-                                       np.min(values)*np.ones((20, 40, 40), dtype=np.uint8)))
+RECEPTIVE_FIELD = (2, 2)
+BAD_CLASSIFIER = BadClassifier()
+PIXEL_CLASSIFIER = DummyPixelClassifier()
+PATCH_CLASSIFIER = DummyPatchClassifier(receptive_field=RECEPTIVE_FIELD)
 
 
-if __name__ == '__main__':
-    unittest.main()
+@pytest.mark.parametrize('classifier_class, faulty_params', [
+    (ImagePatchClassifier, (BAD_CLASSIFIER, RECEPTIVE_FIELD)),
+    (ImagePixelClassifier, (BAD_CLASSIFIER,)),
+    (ImagePixel2PatchClassifier, (BAD_CLASSIFIER, (4, 4))),
+])
+def test_initialisation(classifier_class, faulty_params):
+    # Test class raises exceptions if classifier does not implement image_predict and image_predict_proba
+    with pytest.raises(ValueError):
+        classifier_class(*faulty_params)
+
+
+def test_pixel_classifier():
+    # Test a dummy pixel classifier example
+    image_classifier = ImagePixelClassifier(PIXEL_CLASSIFIER)
+    data = np.ones((20, 40, 40, 3), dtype=np.uint8)
+    values = np.random.randint(0, 100, (3,), dtype=np.uint8)
+    data *= values[None, None, None, :]
+
+    data_predicted = image_classifier.image_predict(data)
+    data_prob_predicted = image_classifier.image_predict_proba(data)
+
+    assert np.array_equal(data_predicted, np.max(values)*np.ones((20, 40, 40), dtype=np.uint8))
+    assert np.array_equal(data_prob_predicted[..., 0], np.max(values) * np.ones((20, 40, 40), dtype=np.uint8))
+    assert np.array_equal(data_prob_predicted[..., 1], np.min(values) * np.ones((20, 40, 40), dtype=np.uint8))
+
+
+def test_patch_classifier():
+    # Test a dummy patch classifier example
+    image_classifier = ImagePatchClassifier(PATCH_CLASSIFIER, RECEPTIVE_FIELD)
+    data = np.ones((20, 40, 40, 3), dtype=np.uint8)
+    values = np.random.randint(0, 100, (3,), dtype=np.uint8)
+    data *= values[None, None, None, :]
+
+    data_predicted = image_classifier.image_predict(data)
+    data_prob_predicted = image_classifier.image_predict_proba(data)
+
+    assert np.array_equal(data_predicted, np.max(values)*np.ones((20, 40, 40), dtype=np.uint8))
+    assert np.array_equal(data_prob_predicted[..., 0], np.max(values) * np.ones((20, 40, 40), dtype=np.uint8))
+    assert np.array_equal(data_prob_predicted[..., 1], np.min(values) * np.ones((20, 40, 40), dtype=np.uint8))

--- a/ml_tools/eolearn/tests/test_train_split.py
+++ b/ml_tools/eolearn/tests/test_train_split.py
@@ -10,6 +10,7 @@ file in the root directory of this source tree.
 
 import pytest
 import numpy as np
+from numpy.testing import assert_array_equal
 
 from eolearn.core import FeatureType, EOPatch
 from eolearn.ml_tools import TrainTestSplitTask
@@ -66,7 +67,7 @@ def test_train_split():
     patch = TrainTestSplitTask((*INPUT_MASK_FEATURE, NEW_FEATURE_NAME), bins, split_type='per_class')(patch, seed=1)
     result_seed_equal = patch[NEW_MASK_FEATURE]
     assert set(np.unique(result_seed2)) <= expected_unique
-    assert np.array_equal(result_seed1, result_seed_equal)
+    assert_array_equal(result_seed1, result_seed_equal)
 
     # test ignore_values=[2]
 
@@ -101,8 +102,8 @@ def test_train_split_per_pixel():
     class_percentages = np.round(counts / input_data.size, 1)
     expected_unique = list(range(1, len(bins) + 2))
 
-    assert np.array_equal(unique, expected_unique)
-    assert np.array_equal(class_percentages, [0.2, 0.4, 0.4])
+    assert_array_equal(unique, expected_unique)
+    assert_array_equal(class_percentages, [0.2, 0.4, 0.4])
 
 
 def test_train_split_per_value():
@@ -135,4 +136,4 @@ def test_train_split_per_value():
     for uniq in unique:
         folds1 = otuput1[input1 == uniq]
         folds2 = otuput2[input2 == uniq]
-        assert np.array_equal(np.unique(folds1), np.unique(folds2))
+        assert_array_equal(np.unique(folds1), np.unique(folds2))

--- a/ml_tools/eolearn/tests/test_train_split.py
+++ b/ml_tools/eolearn/tests/test_train_split.py
@@ -8,136 +8,131 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import unittest
+import pytest
 import numpy as np
 
 from eolearn.core import FeatureType, EOPatch
 from eolearn.ml_tools import TrainTestSplitTask
 
-
-class TestTrainSet(unittest.TestCase):
-
-    def test_train_split(self):
-        new_name = 'TEST_TRAIN_MASK'
-
-        input_mask_feature = (FeatureType.MASK_TIMELESS, 'TEST')
-        new_mask_feature = (FeatureType.MASK_TIMELESS, new_name)
-
-        self.assertRaises(ValueError, TrainTestSplitTask, input_mask_feature, None)
-        self.assertRaises(ValueError, TrainTestSplitTask, input_mask_feature, 1.5)
-        self.assertRaises(ValueError, TrainTestSplitTask, input_mask_feature, [0.5, 0.3, 0.7])
-        self.assertRaises(ValueError, TrainTestSplitTask, input_mask_feature, [0.5, 0.3, 0.7], split_type=None)
-        self.assertRaises(ValueError, TrainTestSplitTask, input_mask_feature, [0.5, 0.3, 0.7], split_type='nonsense')
-
-        shape = (1000, 1000, 3)
-        data = np.random.randint(10, size=shape, dtype=int)
-
-        indices = [(0, 2, 0, 2), (0, 2, 2, 4), (2, 4, 0, 2), (2, 4, 2, 4), (0, 4, 4, 8), (4, 8, 0, 4), (4, 8, 4, 8)]
-        for index, (i_1, i_2, j_1, j_2) in enumerate(indices, 1):
-            data[i_1:i_2, j_1:j_2, :] = index * 11
-
-        patch = EOPatch()
-        patch[input_mask_feature] = data
-
-        bins = [0.2, 0.5, 0.8]
-        expected_unique = set(range(1, len(bins) + 2))
-
-        patch = TrainTestSplitTask((*input_mask_feature, new_name), bins, split_type='per_class')(patch, seed=1)
-        self.assertTrue(set(np.unique(patch[new_mask_feature])) <= expected_unique)
-
-        result_seed1 = np.copy(patch[new_mask_feature])
-        unique = (np.unique(result_seed1[i_1:i_2, j_1:j_2, :], return_counts=True) for i_1, i_2, j_1, j_2 in indices)
-        expected = [(i_2 - i_1) * (j_2 - j_1) * shape[-1] for i_1, i_2, j_1, j_2 in indices]
-
-        for (unique_values, unique_counts), expected_count in zip(unique, expected):
-            self.assertTrue(len(unique_values) == 1)
-            self.assertTrue(len(unique_counts) == 1)
-            self.assertTrue(unique_counts[0] == expected_count)
-
-        # seed=2 should produce different result than seed=1
-        patch = TrainTestSplitTask((*input_mask_feature, new_name), bins, split_type='per_class')(patch, seed=2)
-        result_seed2 = np.copy(patch[new_mask_feature])
-        self.assertTrue(set(np.unique(result_seed2)) <= expected_unique)
-        self.assertFalse(np.array_equal(result_seed1, result_seed2))
-
-        # test with seed 1 should produce the same result as before
-        patch = TrainTestSplitTask((*input_mask_feature, new_name), bins, split_type='per_class')(patch, seed=1)
-        result_seed_equal = patch[new_mask_feature]
-        self.assertTrue(set(np.unique(result_seed2)) <= expected_unique)
-        self.assertTrue(np.array_equal(result_seed1, result_seed_equal))
-
-        # test ignore_values=[2]
-
-        bins = [0.2, 0.5, 0.7, 0.8]
-        expected_unique = set(range(0, len(bins) + 2))
-
-        data = np.random.randint(10, size=shape)
-        patch[(FeatureType.MASK_TIMELESS, 'TEST')] = data
-
-        split_task = TrainTestSplitTask((FeatureType.MASK_TIMELESS, 'TEST', 'BINS'), bins, split_type='per_class',
-                                        ignore_values=[2])
-
-        patch = split_task(patch, seed=542)
-
-        self.assertTrue(set(np.unique(patch[(FeatureType.MASK_TIMELESS, 'BINS')])) <= expected_unique)
-        self.assertTrue(np.all(patch[(FeatureType.MASK_TIMELESS, 'BINS')][data == 2] == 0))
-
-    def test_train_split_per_pixel(self):
-        new_name = 'TEST_TRAIN_MASK'
-        input_mask_feature = (FeatureType.MASK_TIMELESS, 'TEST')
-
-        shape = (1000, 1000, 3)
-
-        input_data = np.random.randint(10, size=shape, dtype=int)
-        patch = EOPatch()
-        patch[input_mask_feature] = input_data
-
-        bins = [0.2, 0.6]
-        patch = TrainTestSplitTask((*input_mask_feature, new_name), bins, split_type='per_pixel')(patch, seed=1)
-
-        output_data = patch[(FeatureType.MASK_TIMELESS, new_name)]
-        unique, counts = np.unique(output_data, return_counts=True)
-        class_percentages = np.round(counts / input_data.size, 1)
-        expected_unique = list(range(1, len(bins) + 2))
-
-        self.assertTrue(np.array_equal(unique, expected_unique))
-        self.assertTrue(np.array_equal(class_percentages, [0.2, 0.4, 0.4]))
-
-    def test_train_split_per_value(self):
-        """ Test if class ids get assigned to the same subclasses in multiple eopatches
-        """
-        new_name = 'TEST_TRAIN_MASK'
-        input_mask_feature = (FeatureType.MASK_TIMELESS, 'TEST')
-
-        shape = (1000, 1000, 3)
-
-        input1 = np.random.randint(10, size=shape, dtype=int)
-        input2 = np.random.randint(10, size=shape, dtype=int)
-
-        patch1 = EOPatch()
-        patch1[input_mask_feature] = input1
-
-        patch2 = EOPatch()
-        patch2[input_mask_feature] = input2
-
-        bins = [0.2, 0.6]
-
-        split_task = TrainTestSplitTask((*input_mask_feature, new_name), bins, split_type='per_value')
-
-        # seeds should get ignored when splitting 'per_value'
-        patch1 = split_task(patch1, seed=1)
-        patch2 = split_task(patch2, seed=1)
-
-        otuput1 = patch1[(FeatureType.MASK_TIMELESS, new_name)]
-        otuput2 = patch2[(FeatureType.MASK_TIMELESS, new_name)]
-
-        unique = set(np.unique(input1)) | set(np.unique(input2))
-
-        for uniq in unique:
-            folds1 = otuput1[input1 == uniq]
-            folds2 = otuput2[input2 == uniq]
-            self.assertTrue(np.array_equal(np.unique(folds1), np.unique(folds2)))
+NEW_FEATURE_NAME = 'TEST_TRAIN_MASK'
+INPUT_MASK_FEATURE = (FeatureType.MASK_TIMELESS, 'TEST')
+NEW_MASK_FEATURE = (FeatureType.MASK_TIMELESS, NEW_FEATURE_NAME)
 
 
-if __name__ == '__main__':
-    unittest.main()
+@pytest.mark.parametrize('bad_arg, bad_kwargs', [
+    (None, {}), (1.5, {}),
+    ([0.5, 0.3], {}),
+    ([0.5], {'split_type': None}),
+    ([0.5, 0.7], {'split_type': 'nonsense'}),
+])
+def test_bad_args(bad_arg, bad_kwargs):
+    with pytest.raises(ValueError):
+        TrainTestSplitTask(INPUT_MASK_FEATURE, bad_arg, **bad_kwargs)
+
+
+def test_train_split():
+    shape = (1000, 1000, 3)
+    data = np.random.randint(10, size=shape, dtype=int)
+
+    indices = [(0, 2, 0, 2), (0, 2, 2, 4), (2, 4, 0, 2), (2, 4, 2, 4), (0, 4, 4, 8), (4, 8, 0, 4), (4, 8, 4, 8)]
+    for index, (i_1, i_2, j_1, j_2) in enumerate(indices, 1):
+        data[i_1:i_2, j_1:j_2, :] = index * 11
+
+    patch = EOPatch()
+    patch[INPUT_MASK_FEATURE] = data
+
+    bins = [0.2, 0.5, 0.8]
+    expected_unique = set(range(1, len(bins) + 2))
+
+    patch = TrainTestSplitTask((*INPUT_MASK_FEATURE, NEW_FEATURE_NAME), bins, split_type='per_class')(patch, seed=1)
+    assert set(np.unique(patch[NEW_MASK_FEATURE])) <= expected_unique
+
+    result_seed1 = np.copy(patch[NEW_MASK_FEATURE])
+    unique = (np.unique(result_seed1[i_1:i_2, j_1:j_2, :], return_counts=True) for i_1, i_2, j_1, j_2 in indices)
+    expected = [(i_2 - i_1) * (j_2 - j_1) * shape[-1] for i_1, i_2, j_1, j_2 in indices]
+
+    for (unique_values, unique_counts), expected_count in zip(unique, expected):
+        assert len(unique_values) == 1
+        assert len(unique_counts) == 1
+        assert unique_counts[0] == expected_count
+
+    # seed=2 should produce different result than seed=1
+    patch = TrainTestSplitTask((*INPUT_MASK_FEATURE, NEW_FEATURE_NAME), bins, split_type='per_class')(patch, seed=2)
+    result_seed2 = np.copy(patch[NEW_MASK_FEATURE])
+    assert set(np.unique(result_seed2)) <= expected_unique
+    assert not np.array_equal(result_seed1, result_seed2)
+
+    # test with seed 1 should produce the same result as before
+    patch = TrainTestSplitTask((*INPUT_MASK_FEATURE, NEW_FEATURE_NAME), bins, split_type='per_class')(patch, seed=1)
+    result_seed_equal = patch[NEW_MASK_FEATURE]
+    assert set(np.unique(result_seed2)) <= expected_unique
+    assert np.array_equal(result_seed1, result_seed_equal)
+
+    # test ignore_values=[2]
+
+    bins = [0.2, 0.5, 0.7, 0.8]
+    expected_unique = set(range(0, len(bins) + 2))
+
+    data = np.random.randint(10, size=shape)
+    patch[INPUT_MASK_FEATURE] = data
+
+    split_task = TrainTestSplitTask(
+        (FeatureType.MASK_TIMELESS, 'TEST', 'BINS'), bins, split_type='per_class', ignore_values=[2]
+    )
+
+    patch = split_task(patch, seed=542)
+
+    assert set(np.unique(patch[(FeatureType.MASK_TIMELESS, 'BINS')])) <= expected_unique
+    assert np.all(patch[(FeatureType.MASK_TIMELESS, 'BINS')][data == 2] == 0)
+
+
+def test_train_split_per_pixel():
+    shape = (1000, 1000, 3)
+
+    input_data = np.random.randint(10, size=shape, dtype=int)
+    patch = EOPatch()
+    patch[INPUT_MASK_FEATURE] = input_data
+
+    bins = [0.2, 0.6]
+    patch = TrainTestSplitTask((*INPUT_MASK_FEATURE, NEW_FEATURE_NAME), bins, split_type='per_pixel')(patch, seed=1)
+
+    output_data = patch[NEW_MASK_FEATURE]
+    unique, counts = np.unique(output_data, return_counts=True)
+    class_percentages = np.round(counts / input_data.size, 1)
+    expected_unique = list(range(1, len(bins) + 2))
+
+    assert np.array_equal(unique, expected_unique)
+    assert np.array_equal(class_percentages, [0.2, 0.4, 0.4])
+
+
+def test_train_split_per_value():
+    """ Test if class ids get assigned to the same subclasses in multiple eopatches
+    """
+    shape = (1000, 1000, 3)
+
+    input1 = np.random.randint(10, size=shape, dtype=int)
+    input2 = np.random.randint(10, size=shape, dtype=int)
+
+    patch1 = EOPatch()
+    patch1[INPUT_MASK_FEATURE] = input1
+
+    patch2 = EOPatch()
+    patch2[INPUT_MASK_FEATURE] = input2
+
+    bins = [0.2, 0.6]
+
+    split_task = TrainTestSplitTask((*INPUT_MASK_FEATURE, NEW_FEATURE_NAME), bins, split_type='per_value')
+
+    # seeds should get ignored when splitting 'per_value'
+    patch1 = split_task(patch1, seed=1)
+    patch2 = split_task(patch2, seed=1)
+
+    otuput1 = patch1[NEW_MASK_FEATURE]
+    otuput2 = patch2[NEW_MASK_FEATURE]
+
+    unique = set(np.unique(input1)) | set(np.unique(input2))
+
+    for uniq in unique:
+        folds1 = otuput1[input1 == uniq]
+        folds2 = otuput2[input2 == uniq]
+        assert np.array_equal(np.unique(folds1), np.unique(folds2))

--- a/visualization/eolearn/tests/test_eoexecutor_visualization.py
+++ b/visualization/eolearn/tests/test_eoexecutor_visualization.py
@@ -12,8 +12,6 @@ import os
 import logging
 import tempfile
 
-import pytest
-
 from eolearn.core import EOTask, EOWorkflow, Dependency, EOExecutor
 
 

--- a/visualization/eolearn/tests/test_eoexecutor_visualization.py
+++ b/visualization/eolearn/tests/test_eoexecutor_visualization.py
@@ -8,10 +8,11 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import unittest
 import os
 import logging
 import tempfile
+
+import pytest
 
 from eolearn.core import EOTask, EOWorkflow, Dependency, EOExecutor
 
@@ -31,30 +32,22 @@ class ExampleTask(EOTask):
             raise Exception
 
 
-class TestEOExecutor(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        task = ExampleTask()
-        cls.workflow = EOWorkflow([(task, []),
-                                   Dependency(task=ExampleTask(), inputs=[task, task])])
-
-        cls.execution_args = [
-            {task: {'arg1': 1}},
-            {},
-            {task: {'arg1': 3, 'arg3': 10}},
-            {task: {'arg1': None}}
-        ]
-
-    def test_report_creation(self):
-        with tempfile.TemporaryDirectory() as tmp_dir_name:
-            executor = EOExecutor(self.workflow, self.execution_args, logs_folder=tmp_dir_name, save_logs=True,
-                                  execution_names=['ex 1', 2, 0.4, None])
-            executor.run(workers=10)
-            executor.make_report()
-
-            self.assertTrue(os.path.exists(executor.get_report_filename()), 'Execution report was not created')
+TASK = ExampleTask()
+WORKFLOW = EOWorkflow([(TASK, []), Dependency(task=ExampleTask(), inputs=[TASK, TASK])])
+EXECUTION_ARGS = [
+    {TASK: {'arg1': 1}},
+    {},
+    {TASK: {'arg1': 3, 'arg3': 10}},
+    {TASK: {'arg1': None}}
+]
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_report_creation():
+    with tempfile.TemporaryDirectory() as tmp_dir_name:
+        executor = EOExecutor(
+            WORKFLOW, EXECUTION_ARGS, logs_folder=tmp_dir_name, save_logs=True, execution_names=['ex 1', 2, 0.4, None]
+        )
+        executor.run(workers=10)
+        executor.make_report()
+
+        assert os.path.exists(executor.get_report_filename()), 'Execution report was not created'

--- a/visualization/eolearn/tests/test_eoworkflow_visualization.py
+++ b/visualization/eolearn/tests/test_eoworkflow_visualization.py
@@ -10,7 +10,7 @@ file in the root directory of this source tree.
 import pytest
 from graphviz import Digraph
 
-from eolearn.core import EOTask, EOWorkflow, Dependency, WorkflowResults, LinearWorkflow
+from eolearn.core import EOTask, EOWorkflow, Dependency
 
 
 class FooTask(EOTask):

--- a/visualization/eolearn/tests/test_eoworkflow_visualization.py
+++ b/visualization/eolearn/tests/test_eoworkflow_visualization.py
@@ -7,8 +7,7 @@ Copyright (c) 2017-2019 Blaž Sovdat, Nejc Vesel, Jovan Višnjić, Anže Zupanc,
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-import unittest
-
+import pytest
 from graphviz import Digraph
 
 from eolearn.core import EOTask, EOWorkflow, Dependency, WorkflowResults, LinearWorkflow
@@ -19,26 +18,22 @@ class FooTask(EOTask):
         return eopatch
 
 
-class TestGraph(unittest.TestCase):
+@pytest.fixture(name='workflow')
+def workflow_fixture():
+    task1, task2, task3 = FooTask(), FooTask(), FooTask()
 
-    def setUp(self):
-        task1 = FooTask()
-        task2 = FooTask()
-        task3 = FooTask()
-
-        self.workflow = EOWorkflow(dependencies=[
+    workflow = EOWorkflow(
+        dependencies=[
             Dependency(task=task1, inputs=[]),
             Dependency(task=task2, inputs=[]),
             Dependency(task=task3, inputs=[task1, task2])
         ])
-
-    def test_graph_nodes_and_edges(self):
-        dot = self.workflow.get_dot()
-        self.assertTrue(isinstance(dot, Digraph))
-
-        digraph = self.workflow.dependency_graph()
-        self.assertTrue(isinstance(digraph, Digraph))
+    return workflow
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_graph_nodes_and_edges(workflow):
+    dot = workflow.get_dot()
+    assert isinstance(dot, Digraph)
+
+    digraph = workflow.dependency_graph()
+    assert isinstance(digraph, Digraph)


### PR DESCRIPTION
I updated all the remaining tests that were using `unittest` to use `pytest`. The tests for `eolearn.core` are excluded from this pull request, since they have been updated on `develop-v1.0`.

I also fixed two outdated tests (an import error in `meteoblue` and a non-updated tests for the new `sh-py` collections). There are also some minor changes to other files (if i noticed a mistake in the docstrings).

The test content is almost entirely the same.