### PR TITLE
Fix eopatch saving w.r.t. compression and lazy loading

### DIFF
--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -78,27 +78,6 @@ def remove_redundant_files(filesystem, eopatch_features, filesystem_features, cu
     files_to_remove = []
     saved_features = {(ftype, fname) for ftype, fname, _ in eopatch_features}
     for ftype, fname, path in filesystem_features:
-        if fname is ... and not ftype.is_meta():
-            continue
-
-        different_compression = path.endswith(FileFormat.GZIP.extension()) != (current_compress_level > 0)
-        if (ftype, fname) in saved_features and different_compression:
-            files_to_remove.append(path)
-
-    with concurrent.futures.ThreadPoolExecutor() as executor:
-        # The following is intentionally wrapped in a list in order to get back potential exceptions
-        list(executor.map(filesystem.remove, files_to_remove))
-
-
-def remove_old_eopatch_files(filesystem, eopatch_features, filesystem_features, current_compress_level):
-    """ Removes files that should have been overwriten but were not due to different compression levels
-    """
-    files_to_remove = []
-    saved_features = {(ftype, fname) for ftype, fname, _ in eopatch_features}
-    for ftype, fname, path in filesystem_features:
-        if fname is ... and not ftype.is_meta():
-            continue
-
         different_compression = path.endswith(FileFormat.GZIP.extension()) != (current_compress_level > 0)
         if (ftype, fname) in saved_features and different_compression:
             files_to_remove.append(path)

--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -31,7 +31,7 @@ def save_eopatch(eopatch, filesystem, patch_location, features=..., overwrite_pe
 
     if overwrite_permission is OverwritePermission.OVERWRITE_PATCH and patch_exists:
         filesystem.removetree(patch_location)
-        if patch_location != '/':
+        if patch_location != '/':  # avoid redundant filesystem.makedirs if the location is '/'
             patch_exists = False
 
     if not patch_exists:
@@ -45,20 +45,23 @@ def save_eopatch(eopatch, filesystem, patch_location, features=..., overwrite_pe
     else:
         fs_features = []
 
-    _check_case_matching(eopatch_features, fs_features)
+    _check_letter_case_collisions(eopatch_features, fs_features)
 
     if overwrite_permission is OverwritePermission.ADD_ONLY:
         _check_add_only_permission(eopatch_features, fs_features)
 
-    ftype_folder_map = {(ftype, fs.path.dirname(path)) for ftype, _, path in eopatch_features if not ftype.is_meta()}
-    for ftype, folder in ftype_folder_map:
+    ftype_folders = {fs.path.dirname(path) for ftype, _, path in eopatch_features if not ftype.is_meta()}
+    for folder in ftype_folders:
         if not filesystem.exists(folder):
             filesystem.makedirs(folder, recreate=True)
 
-    features_to_save = ((FeatureIO(filesystem, path),
-                         eopatch[(ftype, fname)],
-                         FileFormat.NPY if ftype.is_raster() else FileFormat.PICKLE,
-                         compress_level) for ftype, fname, path in eopatch_features)
+    features_to_save = []
+    for ftype, fname, path in eopatch_features:
+        feature_io = FeatureIO(filesystem, path)
+        data = eopatch[(ftype, fname)]
+        file_format = FileFormat.NPY if ftype.is_raster() else FileFormat.PICKLE
+
+        features_to_save.append((feature_io, data, file_format, compress_level))
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
         # The following is intentionally wrapped in a list in order to get back potential exceptions
@@ -82,7 +85,7 @@ def load_eopatch(eopatch, filesystem, patch_location, features=..., lazy_loading
 
 
 def walk_filesystem(filesystem, patch_location, features=...):
-    """ Recursively reads a patch_location and returns yields tuples of (feature_type, feature_name, file_path)
+    """ Recursively reads a patch_location and yields tuples of (feature_type, feature_name, file_path)
     """
     existing_features = defaultdict(dict)
     for ftype, fname, path in walk_main_folder(filesystem, patch_location):
@@ -96,20 +99,23 @@ def walk_filesystem(filesystem, patch_location, features=...):
 
         if ftype.is_meta():
             if ftype in returned_meta_features:
+                # Resolves META_INFO that is yielded multiple times by FeatureParser but is saved in one file
                 continue
             fname = ...
             returned_meta_features.add(ftype)
 
         elif ftype not in queried_features and (fname is ... or fname not in existing_features[ftype]):
+            # Need to either collect all features for ftype or there is a not-yet seen feature that could be collected
             queried_features.add(ftype)
             if ... not in existing_features[ftype]:
-                raise IOError('There are no features of type {} in saved EOPatch'.format(ftype))
+                raise IOError(f'There are no features of type {ftype} in saved EOPatch')
 
             for feature_name, path in walk_feature_type_folder(filesystem, existing_features[ftype][...]):
                 existing_features[ftype][feature_name] = path
 
         if fname not in existing_features[ftype]:
-            raise IOError('Feature {} does not exist in saved EOPatch'.format((ftype, fname)))
+            # ftype has already been fully collected, but the feature not found
+            raise IOError(f'Feature {(ftype, fname)} does not exist in saved EOPatch')
 
         if fname is ... and not ftype.is_meta():
             for feature_name, path in existing_features[ftype].items():
@@ -121,11 +127,15 @@ def walk_filesystem(filesystem, patch_location, features=...):
 
 def walk_main_folder(filesystem, folder_path):
     """ Walks the main EOPatch folders and yields tuples (feature type, feature name, path in filesystem)
+
+    The results depend on the implementation of ``filesystem.listdir``. For each folder that coincides with a feature
+    type it returns (feature type, ..., path). If files in subfolders are also listed by ``listdir`` it returns the
+    them as well, which allows `walk_filesystem` to skip such subfolders from further searches.
     """
     for path in filesystem.listdir(folder_path):
         raw_path = path.split('.')[0].strip('/')
 
-        if '/' in raw_path:
+        if '/' in raw_path:  # For cases where S3 does not have a regular folder structure
             ftype_str, fname = fs.path.split(raw_path)
         else:
             ftype_str, fname = raw_path, ...
@@ -142,13 +152,15 @@ def walk_feature_type_folder(filesystem, folder_path):
             yield path.split('.')[0], fs.path.combine(folder_path, path)
 
 
-def walk_eopatch(eopatch, patch_location, features=...):
-    """ Recursively reads a patch_location and returns yields tuples of (feature_type, feature_name, file_path)
+def walk_eopatch(eopatch, patch_location, features):
+    """ Yields tuples of (feature_type, feature_name, file_path), with file_path being the expected file path
     """
     returned_meta_features = set()
     for ftype, fname in FeatureParser(features)(eopatch):
         name_basis = fs.path.combine(patch_location, ftype.value)
         if ftype.is_meta():
+            # META_INFO features are yielded separately by FeatureParser. We only yield them once with `...`,
+            # because all META_INFO is saved together
             if eopatch[ftype] and ftype not in returned_meta_features:
                 yield ftype, ..., name_basis
                 returned_meta_features.add(ftype)
@@ -164,12 +176,11 @@ def _check_add_only_permission(eopatch_features, filesystem_features):
 
     intersection = filesystem_features.intersection(eopatch_features)
     if intersection:
-        error_msg = "Cannot save features {} with overwrite_permission=OverwritePermission.ADD_ONLY "
-        raise ValueError(error_msg.format(intersection))
+        raise ValueError(f'Cannot save features {intersection} with overwrite_permission=OverwritePermission.ADD_ONLY')
 
 
-def _check_case_matching(eopatch_features, filesystem_features):
-    """ Checks that no two features in memory or in filesystem differ only by feature name casing
+def _check_letter_case_collisions(eopatch_features, filesystem_features):
+    """ Check that eopatch features have no name clashes (ignoring case) with other eopatch features and saved features
     """
     lowercase_features = {_to_lowercase(*feature) for feature in eopatch_features}
 
@@ -180,8 +191,8 @@ def _check_case_matching(eopatch_features, filesystem_features):
 
     for ftype, fname, _ in filesystem_features:
         if (ftype, fname) not in original_features and _to_lowercase(ftype, fname) in lowercase_features:
-            raise IOError('There already exists a feature {} in filesystem that only differs in casing from the one '
-                          'that should be saved'.format((ftype, fname)))
+            raise IOError(f'There already exists a feature {(ftype, fname)} in the filesystem that only differs in '
+                          'casing from a feature that should be saved')
 
 
 def _to_lowercase(ftype, fname, *_):
@@ -191,7 +202,7 @@ def _to_lowercase(ftype, fname, *_):
 
 
 class FeatureIO:
-    """ A class handling saving and loading process of a single feature at a given location
+    """ A class that handles the saving and loading process of a single feature at a given location
     """
     def __init__(self, filesystem, path):
         """
@@ -206,10 +217,10 @@ class FeatureIO:
     def __repr__(self):
         """ A representation method
         """
-        return '{}({})'.format(self.__class__.__name__, self.path)
+        return f'{self.__class__.__name__}({self.path})'
 
     def load(self):
-        """ Method for loading a feature
+        """ Method for loading a feature from
         """
         with self.filesystem.openbin(self.path, 'r') as file_handle:
             if self.path.endswith(FileFormat.GZIP.extension()):
@@ -269,4 +280,4 @@ class FeatureIO:
         if FileFormat.NPY.extension() in path:
             return np.load(file)
 
-        raise ValueError('Unsupported data type.')
+        raise ValueError(f'Unsupported data type for file {path}.')

--- a/core/eolearn/tests/test_eodata_io.py
+++ b/core/eolearn/tests/test_eodata_io.py
@@ -238,6 +238,33 @@ class TestEOPatchIO(unittest.TestCase):
             save_task.execute(empty_eop)
             self.assertTrue(os.path.exists(full_path))
 
+    def test_cleanup_different_compression(self):
+        folder = 'foo-folder'
+        patch_folder = 'patch-folder'
+        for fs_loader in self.filesystem_loaders:
+            with fs_loader() as temp_fs:
+                temp_fs.makedir(folder)
+
+                save_compressed_task = SaveTask(folder, filesystem=temp_fs, compress_level=9, overwrite_permission=1)
+                save_noncompressed_task = SaveTask(folder, filesystem=temp_fs, compress_level=0, overwrite_permission=1)
+                bbox_path = fs.path.join(folder, patch_folder, 'bbox.pkl')
+                compressed_bbox_path = bbox_path + '.gz'
+                data_timeless_path = fs.path.join(folder, patch_folder, 'data_timeless', 'mask.npy')
+                compressed_data_timeless_path = data_timeless_path + '.gz'
+
+                save_compressed_task(self.eopatch, eopatch_folder=patch_folder)
+                save_noncompressed_task(self.eopatch, eopatch_folder=patch_folder)
+                self.assertTrue(temp_fs.exists(bbox_path))
+                self.assertTrue(temp_fs.exists(data_timeless_path))
+                self.assertFalse(temp_fs.exists(compressed_bbox_path))
+                self.assertFalse(temp_fs.exists(compressed_data_timeless_path))
+
+                save_compressed_task(self.eopatch, eopatch_folder=patch_folder)
+                self.assertFalse(temp_fs.exists(bbox_path))
+                self.assertFalse(temp_fs.exists(data_timeless_path))
+                self.assertTrue(temp_fs.exists(compressed_bbox_path))
+                self.assertTrue(temp_fs.exists(compressed_data_timeless_path))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/core/eolearn/tests/test_eodata_io.py
+++ b/core/eolearn/tests/test_eodata_io.py
@@ -265,6 +265,22 @@ class TestEOPatchIO(unittest.TestCase):
                 self.assertTrue(temp_fs.exists(compressed_bbox_path))
                 self.assertTrue(temp_fs.exists(compressed_data_timeless_path))
 
+    def test_lazy_loading_plus_overwrite_patch(self):
+        for folder in ['/', 'foo', 'foo/bar']:
+            for fs_loader in self.filesystem_loaders:
+                with fs_loader() as temp_fs:
+                    self.eopatch.save(folder, filesystem=temp_fs)
+
+                    lazy_eopatch = EOPatch.load(folder, filesystem=temp_fs, lazy_loading=True)
+                    lazy_eopatch.data['whatever'] = np.empty((2, 3, 3, 2))
+                    lazy_eopatch.remove_feature(FeatureType.DATA_TIMELESS, 'mask')
+
+                    lazy_eopatch.save(
+                        folder, filesystem=temp_fs, overwrite_permission=OverwritePermission.OVERWRITE_PATCH,
+                    )
+                    self.assertTrue(temp_fs.exists(fs.path.join(folder, 'data', 'whatever.npy')))
+                    self.assertFalse(temp_fs.exists(fs.path.join(folder, 'data_timeless', 'mask.npy')))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Saving eopatch features at different compression levels produces an issue with old files not being properly overwritten (due to the added `.gz` file suffix). This leads to duplication of files as well as possible bugs when loading features.

This is now fixed with an additional step, where such files are found and removed (after the new ones are saved).