### PR TITLE
Ensure naming convention for tasks

### DIFF
--- a/core/eolearn/core/__init__.py
+++ b/core/eolearn/core/__init__.py
@@ -10,9 +10,12 @@ from .eotask import EOTask, CompositeTask
 from .eoworkflow import EOWorkflow, LinearWorkflow, Dependency, WorkflowResults
 from .eoexecution import EOExecutor, execute_with_mp_lock
 
-from .core_tasks import CopyTask, DeepCopyTask, SaveTask, LoadTask, AddFeature, RemoveFeature, RenameFeature,\
-    DuplicateFeature, InitializeFeature, MoveFeature, MergeFeatureTask, MapFeatureTask, ZipFeatureTask,\
-    ExtractBandsTask, CreateEOPatchTask, SaveToDisk, LoadFromDisk, MergeEOPatchesTask
+from .core_tasks import (
+    CopyTask, DeepCopyTask, SaveTask, LoadTask, AddFeature, RemoveFeature, RenameFeature, DuplicateFeature,
+    InitializeFeature, MoveFeature, AddFeatureTask, RemoveFeatureTask, RenameFeatureTask, DuplicateFeatureTask,
+    InitializeFeatureTask, MoveFeatureTask, MergeFeatureTask, MapFeatureTask, ZipFeatureTask, ExtractBandsTask,
+    CreateEOPatchTask, SaveToDisk, LoadFromDisk, MergeEOPatchesTask
+)
 
 from .fs_utils import get_filesystem, load_s3_filesystem
 from .utilities import deep_eq, negate_mask, constant_pad, get_common_timestamps, bgr_to_rgb, FeatureParser

--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -19,6 +19,7 @@ import numpy as np
 from .eodata import EOPatch
 from .eotask import EOTask
 from .fs_utils import get_filesystem
+from .utilities import renamed_and_deprecated
 
 warnings.simplefilter('default', DeprecationWarning)
 
@@ -127,14 +128,6 @@ class SaveTask(IOTask):
         return eopatch
 
 
-class SaveToDisk(SaveTask):
-    """ A deprecated version of SaveTask
-    """
-    def __init__(self, folder, *args, **kwargs):
-        warnings.warn('This task is deprecated, use SaveTask instead', DeprecationWarning)
-        super().__init__(folder, *args, **kwargs)
-
-
 class LoadTask(IOTask):
     """ Loads an EOPatch from a filesystem
     """
@@ -169,15 +162,7 @@ class LoadTask(IOTask):
         return EOPatch.load(path, filesystem=self.filesystem, **self.kwargs)
 
 
-class LoadFromDisk(LoadTask):
-    """ A deprecated version of LoadTask
-    """
-    def __init__(self, folder, *args, **kwargs):
-        warnings.warn('This task is deprecated, use LoadTask instead', DeprecationWarning)
-        super().__init__(folder, *args, **kwargs)
-
-
-class AddFeature(EOTask):
+class AddFeatureTask(EOTask):
     """Adds a feature to the given EOPatch.
     """
     def __init__(self, feature):
@@ -205,7 +190,7 @@ class AddFeature(EOTask):
         return eopatch
 
 
-class RemoveFeature(EOTask):
+class RemoveFeatureTask(EOTask):
     """Removes one or multiple features from the given EOPatch.
     """
     def __init__(self, features):
@@ -232,7 +217,7 @@ class RemoveFeature(EOTask):
         return eopatch
 
 
-class RenameFeature(EOTask):
+class RenameFeatureTask(EOTask):
     """Renames one or multiple features from the given EOPatch.
     """
     def __init__(self, features):
@@ -257,7 +242,7 @@ class RenameFeature(EOTask):
         return eopatch
 
 
-class DuplicateFeature(EOTask):
+class DuplicateFeatureTask(EOTask):
     """Duplicates one or multiple features in an EOPatch.
     """
 
@@ -294,7 +279,7 @@ class DuplicateFeature(EOTask):
         return eopatch
 
 
-class InitializeFeature(EOTask):
+class InitializeFeatureTask(EOTask):
     """ Initializes the values of a feature.
 
     Example:
@@ -353,7 +338,7 @@ class InitializeFeature(EOTask):
         return eopatch
 
 
-class MoveFeature(EOTask):
+class MoveFeatureTask(EOTask):
     """ Task to copy/deepcopy fields from one eopatch to another.
     """
     def __init__(self, features, deep_copy=False):
@@ -596,3 +581,51 @@ class MergeEOPatchesTask(EOTask):
             raise ValueError('At least one EOPatch should be given')
 
         return eopatches[0].merge(*eopatches[1:], **self.merge_kwargs)
+
+
+@renamed_and_deprecated
+class SaveToDisk(SaveTask):
+    """ A deprecated version of SaveTask
+    """
+
+
+@renamed_and_deprecated
+class LoadFromDisk(LoadTask):
+    """ A deprecated version of LoadTask
+    """
+
+
+@renamed_and_deprecated
+class AddFeature(AddFeatureTask):
+    """ A deprecated version of AddFeatureTask
+    """
+
+
+@renamed_and_deprecated
+class RemoveFeature(RemoveFeatureTask):
+    """ A deprecated version of RemoveFeatureTask
+    """
+
+
+@renamed_and_deprecated
+class RenameFeature(RenameFeatureTask):
+    """ A deprecated version of RenameFeatureTask
+    """
+
+
+@renamed_and_deprecated
+class DuplicateFeature(DuplicateFeatureTask):
+    """ A deprecated version of DuplicateFeatureTask
+    """
+
+
+@renamed_and_deprecated
+class InitializeFeature(InitializeFeatureTask):
+    """ A deprecated version of InitializeFeatureTask
+    """
+
+
+@renamed_and_deprecated
+class MoveFeature(MoveFeatureTask):
+    """ A deprecated version of MoveFeatureTask
+    """

--- a/core/eolearn/core/utilities.py
+++ b/core/eolearn/core/utilities.py
@@ -12,6 +12,7 @@ file in the root directory of this source tree.
 """
 
 import logging
+import warnings
 from collections import OrderedDict
 from logging import Filter
 
@@ -515,3 +516,28 @@ def constant_pad(X, multiple_of, up_down_rule='even', left_right_rule='even', pa
 def bgr_to_rgb(bgr):
     """Converts Blue, Green, Red to Red, Green, Blue."""
     return bgr[..., [2, 1, 0]]
+
+
+def renamed_and_deprecated(deprecated_class):
+    """ A class decorator that signals that the class has been renamed when initialized
+
+        Example of use:
+
+        .. code-block:: python
+            @renamed_and_deprecated
+            class OldNameForClass(NewNameForClass):
+                ''' Deprecated version of `NewNameForClass`
+                '''
+
+    """
+
+    def warn_and_init(self, *args, **kwargs):
+        warnings.warn(
+            f'The class {self.__class__.__name__} has been renamed to {self.__class__.__mro__[1].__name__}. '
+            'The old name is deprecated and will be removed in version 1.0',
+            DeprecationWarning
+        )
+        super(deprecated_class, self).__init__(*args, **kwargs)
+
+    deprecated_class.__init__ = warn_and_init
+    return deprecated_class

--- a/core/eolearn/core/utilities.py
+++ b/core/eolearn/core/utilities.py
@@ -524,6 +524,7 @@ def renamed_and_deprecated(deprecated_class):
         Example of use:
 
         .. code-block:: python
+
             @renamed_and_deprecated
             class OldNameForClass(NewNameForClass):
                 ''' Deprecated version of `NewNameForClass`

--- a/core/eolearn/tests/test_eoexecutor.py
+++ b/core/eolearn/tests/test_eoexecutor.py
@@ -17,7 +17,9 @@ import concurrent.futures
 import multiprocessing
 import time
 
-from eolearn.core import EOTask, EOWorkflow, Dependency, EOExecutor, WorkflowResults, execute_with_mp_lock, LinearWorkflow
+from eolearn.core import (
+    EOTask, EOWorkflow, Dependency, EOExecutor, WorkflowResults, execute_with_mp_lock, LinearWorkflow
+)
 
 
 logging.basicConfig(level=logging.DEBUG)

--- a/coregistration/eolearn/coregistration/__init__.py
+++ b/coregistration/eolearn/coregistration/__init__.py
@@ -2,7 +2,9 @@
 A collection of tools and EOTasks for image co-registration
 """
 
-from .coregistration import RegistrationTask, InterpolationType, ECCRegistration, PointBasedRegistration, \
-    ThunderRegistration
+from .coregistration import (
+    RegistrationTask, InterpolationType, ECCRegistration, PointBasedRegistration, ThunderRegistration,
+    ECCRegistrationTask, PointBasedRegistrationTask, ThunderRegistrationTask
+)
 
 __version__ = '0.9.0'

--- a/coregistration/eolearn/coregistration/coregistration.py
+++ b/coregistration/eolearn/coregistration/coregistration.py
@@ -19,6 +19,7 @@ import cv2
 import numpy as np
 import registration
 from eolearn.core import EOTask, FeatureType
+from eolearn.core.utilities import renamed_and_deprecated
 
 from .coregistration_utilities import EstimateEulerTransformModel, ransac
 
@@ -228,7 +229,7 @@ class RegistrationTask(EOTask, ABC):
         return 1 if int((rot_angle > MAX_ROTATION) or (transl_norm > MAX_TRANSLATION)) else 0
 
 
-class ThunderRegistration(RegistrationTask):
+class ThunderRegistrationTask(RegistrationTask):
     """ Registration task implementing a translational registration using the thunder-registration package
     """
 
@@ -268,7 +269,7 @@ class ThunderRegistration(RegistrationTask):
         pass
 
 
-class ECCRegistration(RegistrationTask):
+class ECCRegistrationTask(RegistrationTask):
     """ Registration task implementing an intensity-based method from OpenCV
     """
 
@@ -319,7 +320,7 @@ class ECCRegistration(RegistrationTask):
         return warp_matrix
 
 
-class PointBasedRegistration(RegistrationTask):
+class PointBasedRegistrationTask(RegistrationTask):
     """ Registration class implementing a point-based registration from OpenCV contrib package
     """
 
@@ -418,3 +419,21 @@ def get_gradient(src):
     # Combine the two gradients
     grad = cv2.addWeighted(np.absolute(grad_x), 0.5, np.absolute(grad_y), 0.5, 0)
     return grad
+
+
+@renamed_and_deprecated
+class ThunderRegistration(ThunderRegistrationTask):
+    """ A deprecated version of ThunderRegistrationTask
+    """
+
+
+@renamed_and_deprecated
+class ECCRegistration(ECCRegistrationTask):
+    """ A deprecated version of ECCRegistrationTask
+    """
+
+
+@renamed_and_deprecated
+class PointBasedRegistration(PointBasedRegistrationTask):
+    """ A deprecated version of PointBasedRegistrationTask
+    """

--- a/coregistration/eolearn/tests/test_coregistration.py
+++ b/coregistration/eolearn/tests/test_coregistration.py
@@ -13,7 +13,7 @@ import logging
 import pytest
 import numpy as np
 from eolearn.core import EOPatch, FeatureType
-from eolearn.coregistration import ECCRegistration, InterpolationType
+from eolearn.coregistration import ECCRegistrationTask, InterpolationType
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -38,7 +38,7 @@ def eopatch_fixture():
 
 
 def test_registration(eopatch):
-    reg = ECCRegistration(
+    reg = ECCRegistrationTask(
         (FeatureType.DATA, 'bands'),
         valid_mask_feature='cm',
         interpolation_type=InterpolationType.NEAREST,

--- a/features/eolearn/features/__init__.py
+++ b/features/eolearn/features/__init__.py
@@ -2,16 +2,24 @@
 A collection of EOTasks for feature manipulation
 """
 
-from .temporal_features import AddSpatioTemporalFeaturesTask, AddMaxMinTemporalIndicesTask, \
-    AddMaxMinNDVISlopeIndicesTask
-from .interpolation import InterpolationTask, LinearInterpolation, CubicInterpolation, SplineInterpolation, \
-    BSplineInterpolation, AkimaInterpolation, ResamplingTask, NearestResampling, LinearResampling, CubicResampling, \
-    KrigingInterpolation, LegacyInterpolation
+from .temporal_features import (
+    AddSpatioTemporalFeaturesTask, AddMaxMinTemporalIndicesTask, AddMaxMinNDVISlopeIndicesTask
+)
+from .interpolation import (
+    InterpolationTask, LinearInterpolation, CubicInterpolation, SplineInterpolation, BSplineInterpolation,
+    AkimaInterpolation, ResamplingTask, NearestResampling, LinearResampling, CubicResampling, KrigingInterpolation,
+    LegacyInterpolation, LinearInterpolationTask, CubicInterpolationTask, SplineInterpolationTask,
+    BSplineInterpolationTask, AkimaInterpolationTask, ResamplingTask, NearestResamplingTask, LinearResamplingTask,
+    CubicResamplingTask, KrigingInterpolationTask, LegacyInterpolationTask
+)
 from .feature_extractor import FeatureExtractionTask, FeatureExtendedExtractor
-from .feature_manipulation import SimpleFilterTask, FilterTimeSeries, ValueFilloutTask
+from .feature_manipulation import SimpleFilterTask, FilterTimeSeriesTask, FilterTimeSeries, ValueFilloutTask
 from .haralick import HaralickTask
-from .radiometric_normalization import ReferenceScenes, HistogramMatching, BlueCompositing, HOTCompositing, \
-    MaxNDVICompositing, MaxNDWICompositing, MaxRatioCompositing
+from .radiometric_normalization import (
+    ReferenceScenes, HistogramMatching, BlueCompositing, HOTCompositing, MaxNDVICompositing, MaxNDWICompositing,
+    MaxRatioCompositing, ReferenceScenesTask, HistogramMatchingTask, BlueCompositingTask, HOTCompositingTask,
+    MaxNDVICompositingTask, MaxNDWICompositingTask, MaxRatioCompositingTask
+)
 from .blob import BlobTask, DoGBlobTask, DoHBlobTask, LoGBlobTask
 from .hog import HOGTask
 from .local_binary_pattern import LocalBinaryPatternTask

--- a/features/eolearn/features/__init__.py
+++ b/features/eolearn/features/__init__.py
@@ -9,8 +9,8 @@ from .interpolation import (
     InterpolationTask, LinearInterpolation, CubicInterpolation, SplineInterpolation, BSplineInterpolation,
     AkimaInterpolation, ResamplingTask, NearestResampling, LinearResampling, CubicResampling, KrigingInterpolation,
     LegacyInterpolation, LinearInterpolationTask, CubicInterpolationTask, SplineInterpolationTask,
-    BSplineInterpolationTask, AkimaInterpolationTask, ResamplingTask, NearestResamplingTask, LinearResamplingTask,
-    CubicResamplingTask, KrigingInterpolationTask, LegacyInterpolationTask
+    BSplineInterpolationTask, AkimaInterpolationTask, NearestResamplingTask, LinearResamplingTask, CubicResamplingTask,
+    KrigingInterpolationTask, LegacyInterpolationTask
 )
 from .feature_extractor import FeatureExtractionTask, FeatureExtendedExtractor
 from .feature_manipulation import SimpleFilterTask, FilterTimeSeriesTask, FilterTimeSeries, ValueFilloutTask

--- a/features/eolearn/features/feature_manipulation.py
+++ b/features/eolearn/features/feature_manipulation.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from sentinelhub.time_utils import iso_to_datetime
 from eolearn.core import EOTask, FeatureType
+from eolearn.core.utilities import renamed_and_deprecated
 
 
 LOGGER = logging.getLogger(__name__)
@@ -79,7 +80,7 @@ class SimpleFilterTask(EOTask):
         return eopatch
 
 
-class FilterTimeSeries(SimpleFilterTask):
+class FilterTimeSeriesTask(SimpleFilterTask):
     """
     Removes all frames in the time-series with dates outside the user specified time interval.
     """
@@ -212,3 +213,9 @@ class ValueFilloutTask(EOTask):
         eopatch[self.feature] = data
 
         return eopatch
+
+
+@renamed_and_deprecated
+class FilterTimeSeries(FilterTimeSeriesTask):
+    """ A deprecated version of FilterTimeSeriesTask
+    """

--- a/features/eolearn/features/interpolation.py
+++ b/features/eolearn/features/interpolation.py
@@ -24,6 +24,7 @@ import numba
 from sklearn.gaussian_process import GaussianProcessRegressor
 
 from eolearn.core import EOTask, EOPatch, FeatureType, FeatureTypeSet
+from eolearn.core.utilities import renamed_and_deprecated
 
 
 def base_interpolation_function(data, times, resampled_times):
@@ -444,7 +445,7 @@ class InterpolationTask(EOTask):
         return new_eopatch
 
 
-class LegacyInterpolation(InterpolationTask):
+class LegacyInterpolationTask(InterpolationTask):
     """
     Implements `eolearn.features.InterpolationTask` by using `scipy.interpolate.interp1d(kind='linear')`
     """
@@ -455,7 +456,7 @@ class LegacyInterpolation(InterpolationTask):
             super().__init__(feature, scipy.interpolate.interp1d, kind='linear', **kwargs)
 
 
-class LinearInterpolation(InterpolationTask):
+class LinearInterpolationTask(InterpolationTask):
     """ Implements `eolearn.features.InterpolationTask` by using `numpy.interp` and `@numba.jit(nopython=True)`
 
     :param parallel: interpolation is calculated in parallel using as many CPUs as detected
@@ -485,7 +486,7 @@ class LinearInterpolation(InterpolationTask):
         return interpolation_function(data, times, resampled_times)
 
 
-class CubicInterpolation(InterpolationTask):
+class CubicInterpolationTask(InterpolationTask):
     """
     Implements `eolearn.features.InterpolationTask` by using `scipy.interpolate.interp1d(kind='cubic')`
     """
@@ -493,7 +494,7 @@ class CubicInterpolation(InterpolationTask):
         super().__init__(feature, scipy.interpolate.interp1d, kind='cubic', **kwargs)
 
 
-class SplineInterpolation(InterpolationTask):
+class SplineInterpolationTask(InterpolationTask):
     """
     Implements `eolearn.features.InterpolationTask` by using `scipy.interpolate.UnivariateSpline`
     """
@@ -501,7 +502,7 @@ class SplineInterpolation(InterpolationTask):
         super().__init__(feature, scipy.interpolate.UnivariateSpline, k=spline_degree, s=smoothing_factor, **kwargs)
 
 
-class BSplineInterpolation(InterpolationTask):
+class BSplineInterpolationTask(InterpolationTask):
     """
     Implements `eolearn.features.InterpolationTask` by using `scipy.interpolate.BSpline`
     """
@@ -509,7 +510,7 @@ class BSplineInterpolation(InterpolationTask):
         super().__init__(feature, scipy.interpolate.make_interp_spline, k=spline_degree, **kwargs)
 
 
-class AkimaInterpolation(InterpolationTask):
+class AkimaInterpolationTask(InterpolationTask):
     """
     Implements `eolearn.features.InterpolationTask` by using `scipy.interpolate.Akima1DInterpolator`
     """
@@ -540,7 +541,7 @@ class KrigingObject:
         return self.regressor.predict(new_times.reshape(-1, 1)/self.normalizing_factor, **call_args)
 
 
-class KrigingInterpolation(InterpolationTask):
+class KrigingInterpolationTask(InterpolationTask):
     """
     Implements `eolearn.features.InterpolationTask` by using `sklearn.gaussian_process.GaussianProcessRegressor`
     Gaussian processes (superset of kriging) are especially used in geological missing data estimation.
@@ -599,7 +600,7 @@ class ResamplingTask(InterpolationTask):
         return self.interpolation_object(times, series, axis=0, **self.interpolation_parameters)
 
 
-class NearestResampling(ResamplingTask):
+class NearestResamplingTask(ResamplingTask):
     """
     Implements `eolearn.features.ResamplingTask` by using `scipy.interpolate.interp1d(kind='nearest')`
     """
@@ -607,7 +608,7 @@ class NearestResampling(ResamplingTask):
         super().__init__(feature, scipy.interpolate.interp1d, resample_range, kind='nearest', **kwargs)
 
 
-class LinearResampling(ResamplingTask):
+class LinearResamplingTask(ResamplingTask):
     """
     Implements `eolearn.features.ResamplingTask` by using `scipy.interpolate.interp1d(kind='linear')`
     """
@@ -615,9 +616,69 @@ class LinearResampling(ResamplingTask):
         super().__init__(feature, scipy.interpolate.interp1d, resample_range, kind='linear', **kwargs)
 
 
-class CubicResampling(ResamplingTask):
+class CubicResamplingTask(ResamplingTask):
     """
     Implements `eolearn.features.ResamplingTask` by using `scipy.interpolate.interp1d(kind='cubic')`
     """
     def __init__(self, feature, resample_range, **kwargs):
         super().__init__(feature, scipy.interpolate.interp1d, resample_range, kind='cubic', **kwargs)
+
+
+@renamed_and_deprecated
+class LegacyInterpolation(LegacyInterpolationTask):
+    """ A deprecated version of LegacyInterpolationTask
+    """
+
+
+@renamed_and_deprecated
+class LinearInterpolation(LinearInterpolationTask):
+    """ A deprecated version of LinearInterpolationTask
+    """
+
+
+@renamed_and_deprecated
+class CubicInterpolation(CubicInterpolationTask):
+    """ A deprecated version of CubicInterpolationTask
+    """
+
+
+@renamed_and_deprecated
+class SplineInterpolation(SplineInterpolationTask):
+    """ A deprecated version of SplineInterpolationTask
+    """
+
+
+@renamed_and_deprecated
+class BSplineInterpolation(BSplineInterpolationTask):
+    """ A deprecated version of BSplineInterpolationTask
+    """
+
+
+@renamed_and_deprecated
+class AkimaInterpolation(AkimaInterpolationTask):
+    """ A deprecated version of AkimaInterpolationTask
+    """
+
+
+@renamed_and_deprecated
+class KrigingInterpolation(KrigingInterpolationTask):
+    """ A deprecated version of KrigingInterpolationTask
+    """
+
+
+@renamed_and_deprecated
+class NearestResampling(NearestResamplingTask):
+    """ A deprecated version of NearestResamplingTask
+    """
+
+
+@renamed_and_deprecated
+class LinearResampling(LinearResamplingTask):
+    """ A deprecated version of LinearResamplingTask
+    """
+
+
+@renamed_and_deprecated
+class CubicResampling(CubicResamplingTask):
+    """ A deprecated version of CubicResamplingTask
+    """

--- a/features/eolearn/features/radiometric_normalization.py
+++ b/features/eolearn/features/radiometric_normalization.py
@@ -12,9 +12,10 @@ file in the root directory of this source tree.
 import numpy as np
 
 from eolearn.core import EOTask, FeatureType
+from eolearn.core.utilities import renamed_and_deprecated
 
 
-class ReferenceScenes(EOTask):
+class ReferenceScenesTask(EOTask):
     """ Creates a layer of reference scenes which have the highest fraction of valid pixels.
 
         The number of reference scenes is limited to a definable number.
@@ -55,7 +56,7 @@ class ReferenceScenes(EOTask):
         return eopatch
 
 
-class BaseCompositing(EOTask):
+class BaseCompositingTask(EOTask):
     """ Base class to create a composite of reference scenes
 
         Contributor: Johannes Schmid, GeoVille Information Systems GmbH, 2018
@@ -175,7 +176,7 @@ class BaseCompositing(EOTask):
         return eopatch
 
 
-class BlueCompositing(BaseCompositing):
+class BlueCompositingTask(BaseCompositingTask):
     """ Blue band compositing method
 
         - blue     (25th percentile of the blue band)
@@ -199,7 +200,7 @@ class BlueCompositing(BaseCompositing):
         return data[..., self.blue_idx].astype("float32")
 
 
-class HOTCompositing(BaseCompositing):
+class HOTCompositingTask(BaseCompositingTask):
     """ HOT compositing method
 
         - HOT      (Index using bands blue and red)
@@ -230,7 +231,7 @@ class HOTCompositing(BaseCompositing):
         return data[..., self.blue_idx] - 0.5 * data[..., self.red_idx] - 0.08
 
 
-class MaxNDVICompositing(BaseCompositing):
+class MaxNDVICompositingTask(BaseCompositingTask):
     """ maxNDVI compositing method
 
         - maxNDVI  (temporal maximum of NDVI)
@@ -266,7 +267,7 @@ class MaxNDVICompositing(BaseCompositing):
         return indices
 
 
-class MaxNDWICompositing(BaseCompositing):
+class MaxNDWICompositingTask(BaseCompositingTask):
     """ maxNDWI compositing method
 
         - maxNDWI  (temporal maximum of NDWI)
@@ -295,7 +296,7 @@ class MaxNDWICompositing(BaseCompositing):
         return (nir - swir1) / (nir + swir1)
 
 
-class MaxRatioCompositing(BaseCompositing):
+class MaxRatioCompositingTask(BaseCompositingTask):
     """ maxRatio compositing method
 
         - maxRatio (temporal maximum of a ratio using bands blue, NIR and SWIR)
@@ -330,7 +331,7 @@ class MaxRatioCompositing(BaseCompositing):
         return np.nanmax(np.array([nir, swir1]), axis=0) / blue
 
 
-class HistogramMatching(EOTask):
+class HistogramMatchingTask(EOTask):
     """ Histogram match of each band of each scene within a time-series with respect to the corresponding band of a
         reference composite.
 
@@ -380,3 +381,51 @@ class HistogramMatching(EOTask):
                 source * (std_ref / std_src) + (mean_ref - (mean_src * (std_ref / std_src)))
 
         return eopatch
+
+
+@renamed_and_deprecated
+class ReferenceScenes(ReferenceScenesTask):
+    """ A deprecated version of ReferenceScenesTask
+    """
+
+
+@renamed_and_deprecated
+class BaseCompositing(BaseCompositingTask):
+    """ A deprecated version of BaseCompositingTask
+    """
+
+
+@renamed_and_deprecated
+class BlueCompositing(BlueCompositingTask):
+    """ A deprecated version of BlueCompositingTask
+    """
+
+
+@renamed_and_deprecated
+class MaxNDVICompositing(MaxNDVICompositingTask):
+    """ A deprecated version of MaxNDVICompositingTask
+    """
+
+
+@renamed_and_deprecated
+class MaxNDWICompositing(MaxNDWICompositingTask):
+    """ A deprecated version of MaxNDWICompositingTask
+    """
+
+
+@renamed_and_deprecated
+class HOTCompositing(HOTCompositingTask):
+    """ A deprecated version of HOTCompositingTask
+    """
+
+
+@renamed_and_deprecated
+class MaxRatioCompositing(MaxRatioCompositingTask):
+    """ A deprecated version of MaxRatioCompositingTask
+    """
+
+
+@renamed_and_deprecated
+class HistogramMatching(HistogramMatchingTask):
+    """ A deprecated version of HistogramMatchingTask
+    """

--- a/features/eolearn/tests/test_feature_manipulation.py
+++ b/features/eolearn/tests/test_feature_manipulation.py
@@ -14,7 +14,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 
-from eolearn.features import FilterTimeSeries, ValueFilloutTask
+from eolearn.features import FilterTimeSeriesTask, ValueFilloutTask
 from eolearn.core import EOPatch, FeatureType
 
 
@@ -42,7 +42,7 @@ def test_content_after_timefilter():
 
     eop = EOPatch(timestamp=timestamps, data={'data': data}, meta_info={'time_interval': old_interval})
 
-    filter_task = FilterTimeSeries(start_date=new_interval[0], end_date=new_interval[1])
+    filter_task = FilterTimeSeriesTask(start_date=new_interval[0], end_date=new_interval[1])
     filter_task.execute(eop)
 
     updated_interval = eop.meta_info['time_interval']

--- a/features/eolearn/tests/test_interpolation.py
+++ b/features/eolearn/tests/test_interpolation.py
@@ -19,8 +19,11 @@ import pytest
 from pytest import approx
 
 from eolearn.core import EOTask, FeatureType
-from eolearn.features import LinearInterpolation, CubicInterpolation, SplineInterpolation, BSplineInterpolation, \
-    AkimaInterpolation, LinearResampling, CubicResampling, NearestResampling, KrigingInterpolation, LegacyInterpolation
+from eolearn.features import (
+    LinearInterpolationTask, CubicInterpolationTask, SplineInterpolationTask, BSplineInterpolationTask,
+    AkimaInterpolationTask, LinearResamplingTask, CubicResamplingTask, NearestResamplingTask, KrigingInterpolationTask,
+    LegacyInterpolationTask
+)
 
 
 @dataclasses.dataclass
@@ -50,14 +53,14 @@ class InterpolationTestCase:
 INTERPOLATION_TEST_CASES = [
     InterpolationTestCase(
         'linear',
-        LegacyInterpolation(
+        LegacyInterpolationTask(
             'NDVI', result_interval=(0.0, 1.0), mask_feature=(FeatureType.MASK, 'IS_VALID'), unknown_value=10
         ),
         result_len=68, img_min=0.0, img_max=10.0, img_mean=0.720405, img_median=0.59765935
     ),
     InterpolationTestCase(
         'linear_change_timescale',
-        LegacyInterpolation(
+        LegacyInterpolationTask(
             'NDVI', result_interval=(0.0, 1.0), mask_feature=(FeatureType.MASK, 'IS_VALID'), unknown_value=10,
             scale_time=1
         ),
@@ -65,14 +68,14 @@ INTERPOLATION_TEST_CASES = [
     ),
     InterpolationTestCase(
         'linear',
-        LinearInterpolation(
+        LinearInterpolationTask(
             'NDVI', result_interval=(0.0, 1.0), mask_feature=(FeatureType.MASK, 'IS_VALID'), unknown_value=10
         ),
         result_len=68, img_min=0.0, img_max=10.0, img_mean=0.720405, img_median=0.59765935
     ),
     InterpolationTestCase(
         'linear-p',
-        LinearInterpolation(
+        LinearInterpolationTask(
             'NDVI', result_interval=(0.0, 1.0), mask_feature=(FeatureType.MASK, 'IS_VALID'), unknown_value=10,
             interpolate_pixel_wise=True
         ),
@@ -80,7 +83,7 @@ INTERPOLATION_TEST_CASES = [
     ),
     InterpolationTestCase(
         'linear_change_timescale',
-        LinearInterpolation(
+        LinearInterpolationTask(
             'NDVI', result_interval=(0.0, 1.0), mask_feature=(FeatureType.MASK, 'IS_VALID'), unknown_value=10,
             scale_time=1
         ),
@@ -88,7 +91,7 @@ INTERPOLATION_TEST_CASES = [
     ),
     InterpolationTestCase(
         'cubic',
-        CubicInterpolation(
+        CubicInterpolationTask(
             'NDVI', result_interval=(0.0, 1.0), mask_feature=(FeatureType.MASK, 'IS_VALID'),
             resample_range=('2015-01-01', '2018-01-01', 16), unknown_value=5, bounds_error=False
         ),
@@ -96,7 +99,7 @@ INTERPOLATION_TEST_CASES = [
     ),
     InterpolationTestCase(
         'spline',
-        SplineInterpolation(
+        SplineInterpolationTask(
             'NDVI', result_interval=(-0.3, 1.0), mask_feature=(FeatureType.MASK, 'IS_VALID'),
             resample_range=('2016-01-01', '2018-01-01', 5), spline_degree=3, smoothing_factor=0, unknown_value=0
         ),
@@ -104,7 +107,7 @@ INTERPOLATION_TEST_CASES = [
     ),
     InterpolationTestCase(
         'bspline',
-        BSplineInterpolation(
+        BSplineInterpolationTask(
             'NDVI', unknown_value=-3, mask_feature=(FeatureType.MASK, 'IS_VALID'),
             resample_range=('2017-01-01', '2017-02-01', 50), spline_degree=5
         ),
@@ -112,7 +115,7 @@ INTERPOLATION_TEST_CASES = [
     ),
     InterpolationTestCase(
         'bspline-p',
-        BSplineInterpolation(
+        BSplineInterpolationTask(
             'NDVI', unknown_value=-3, mask_feature=(FeatureType.MASK, 'IS_VALID'), spline_degree=5,
             resample_range=('2017-01-01', '2017-02-01', 50), interpolate_pixel_wise=True
         ),
@@ -120,34 +123,34 @@ INTERPOLATION_TEST_CASES = [
     ),
     InterpolationTestCase(
         'akima',
-        AkimaInterpolation('NDVI', unknown_value=0, mask_feature=(FeatureType.MASK, 'IS_VALID')),
+        AkimaInterpolationTask('NDVI', unknown_value=0, mask_feature=(FeatureType.MASK, 'IS_VALID')),
         result_len=68, img_min=-0.13793105, img_max=0.860242, img_mean=0.53159297, img_median=0.59087014
     ),
     InterpolationTestCase(
         'kriging interpolation',
-        KrigingInterpolation('NDVI', result_interval=(-10, 10), resample_range=('2016-01-01', '2018-01-01', 5)),
+        KrigingInterpolationTask('NDVI', result_interval=(-10, 10), resample_range=('2016-01-01', '2018-01-01', 5)),
         result_len=147, img_min=-0.252500534, img_max=0.659086704, img_mean=0.3825493, img_median=0.39931053
     ),
     InterpolationTestCase(
         'nearest resample',
-        NearestResampling('NDVI', result_interval=(0.0, 1.0), resample_range=('2016-01-01', '2018-01-01', 5)),
+        NearestResamplingTask('NDVI', result_interval=(0.0, 1.0), resample_range=('2016-01-01', '2018-01-01', 5)),
         result_len=147, img_min=-0.2, img_max=0.860242, img_mean=0.35143828, img_median=0.37481314, nan_replace=-0.2
     ),
     InterpolationTestCase(
         'linear resample',
-        LinearResampling('NDVI', result_interval=(0.0, 1.0), resample_range=('2016-01-01', '2018-01-01', 5)),
+        LinearResamplingTask('NDVI', result_interval=(0.0, 1.0), resample_range=('2016-01-01', '2018-01-01', 5)),
         result_len=147, img_min=-0.2, img_max=0.8480114, img_mean=0.350186, img_median=0.3393997, nan_replace=-0.2
     ),
     InterpolationTestCase(
         'cubic resample',
-        CubicResampling(
+        CubicResamplingTask(
             'NDVI', result_interval=(-0.2, 1.0), resample_range=('2015-01-01', '2018-01-01', 16), unknown_value=5
         ),
         result_len=69, img_min=-0.2, img_max=5.0, img_mean=1.234881997, img_median=0.465670556, nan_replace=-0.2
     ),
     InterpolationTestCase(
         'linear custom list',
-        LinearInterpolation(
+        LinearInterpolationTask(
             'NDVI', result_interval=(-0.2, 1.0), unknown_value=-2, parallel=True,
             resample_range=('2015-09-01', '2016-01-01', '2016-07-01', '2017-01-01', '2017-07-01')
         ),
@@ -155,7 +158,7 @@ INTERPOLATION_TEST_CASES = [
     ),
     InterpolationTestCase(
         'linear with bands and multiple masks',
-        LinearInterpolation(
+        LinearInterpolationTask(
             'BANDS-S2-L1C', result_interval=(0.0, 1.0), unknown_value=10,
             mask_feature=[
                 (FeatureType.MASK, 'IS_VALID'),
@@ -167,7 +170,7 @@ INTERPOLATION_TEST_CASES = [
     ),
     InterpolationTestCase(
         'linear custom list',
-        LegacyInterpolation(
+        LegacyInterpolationTask(
             'NDVI', result_interval=(-0.2, 1.0), unknown_value=-2,
             resample_range=('2015-09-01', '2016-01-01', '2016-07-01', '2017-01-01', '2017-07-01'),
         ),
@@ -175,7 +178,7 @@ INTERPOLATION_TEST_CASES = [
     ),
     InterpolationTestCase(
         'linear with bands and multiple masks',
-        LegacyInterpolation(
+        LegacyInterpolationTask(
             'BANDS-S2-L1C', result_interval=(0.0, 1.0), unknown_value=10,
             mask_feature=[
                 (FeatureType.MASK, 'IS_VALID'),
@@ -191,7 +194,7 @@ INTERPOLATION_TEST_CASES = [
 COPY_FEATURE_CASES = [
     InterpolationTestCase(
         'cubic_copy_success',
-        CubicInterpolation(
+        CubicInterpolationTask(
             'NDVI', result_interval=(0.0, 1.0), mask_feature=(FeatureType.MASK, 'IS_VALID'),
             resample_range=('2015-01-01', '2018-01-01', 16), unknown_value=5, bounds_error=False,
             copy_features=[
@@ -204,7 +207,7 @@ COPY_FEATURE_CASES = [
     ),
     InterpolationTestCase(
         'cubic_copy_fail',
-        CubicInterpolation(
+        CubicInterpolationTask(
             'NDVI', result_interval=(0.0, 1.0), mask_feature=(FeatureType.MASK, 'IS_VALID'),
             resample_range=('2015-01-01', '2018-01-01', 16), unknown_value=5, bounds_error=False,
             copy_features=[

--- a/features/eolearn/tests/test_radiometric_normalization.py
+++ b/features/eolearn/tests/test_radiometric_normalization.py
@@ -16,15 +16,17 @@ from pytest import approx
 
 from eolearn.core import FeatureType
 from eolearn.mask import MaskFeature
-from eolearn.features import ReferenceScenes, BlueCompositing, HOTCompositing, MaxNDVICompositing, \
-    MaxNDWICompositing, MaxRatioCompositing, HistogramMatching
+from eolearn.features import (
+    ReferenceScenesTask, BlueCompositingTask, HOTCompositingTask, MaxNDVICompositingTask, MaxNDWICompositingTask,
+    MaxRatioCompositingTask, HistogramMatchingTask
+)
 
 
 @pytest.fixture(name='eopatch')
 def eopatch_fixture(example_eopatch):
     np.random.seed(0)
     example_eopatch.mask['SCL'] = np.random.randint(0, 11, example_eopatch.data['BANDS-S2-L1C'].shape, np.uint8)
-    blue = BlueCompositing(
+    blue = BlueCompositingTask(
         (FeatureType.DATA, 'REFERENCE_SCENES'), (FeatureType.DATA_TIMELESS, 'REFERENCE_COMPOSITE'),
         blue_idx=0, interpolation='geoville'
     )
@@ -45,48 +47,48 @@ DATA_TIMELESS_TEST_FEATURE = FeatureType.DATA_TIMELESS, 'TEST'
         DATA_TEST_FEATURE, 0.0002, 1.4244, 0.21167801, 0.142
     ],
     [
-        ReferenceScenes(
+        ReferenceScenesTask(
             (FeatureType.DATA, 'BANDS-S2-L1C', 'TEST'), (FeatureType.SCALAR, 'CLOUD_COVERAGE'), max_scene_number=5
         ),
         DATA_TEST_FEATURE, 0.0005, 0.5318, 0.16823094, 0.1404
     ],
     [
-        BlueCompositing(
+        BlueCompositingTask(
             (FeatureType.DATA, 'REFERENCE_SCENES'), (FeatureType.DATA_TIMELESS, 'TEST'),
             blue_idx=0, interpolation='geoville'
         ),
         DATA_TIMELESS_TEST_FEATURE, 0.0005, 0.5075, 0.11658352, 0.0833
     ],
     [
-        HOTCompositing(
+        HOTCompositingTask(
             (FeatureType.DATA, 'REFERENCE_SCENES'), (FeatureType.DATA_TIMELESS, 'TEST'),
             blue_idx=0, red_idx=2, interpolation='geoville'
         ),
         DATA_TIMELESS_TEST_FEATURE, 0.0005, 0.5075, 0.117758796, 0.0846
     ],
     [
-        MaxNDVICompositing(
+        MaxNDVICompositingTask(
             (FeatureType.DATA, 'REFERENCE_SCENES'), (FeatureType.DATA_TIMELESS, 'TEST'),
             red_idx=2, nir_idx=7, interpolation='geoville'
         ),
         DATA_TIMELESS_TEST_FEATURE, 0.0005, 0.5075, 0.13430128, 0.0941
     ],
     [
-        MaxNDWICompositing(
+        MaxNDWICompositingTask(
             (FeatureType.DATA, 'REFERENCE_SCENES'), (FeatureType.DATA_TIMELESS, 'TEST'),
             nir_idx=6, swir1_idx=8, interpolation='geoville'
         ),
         DATA_TIMELESS_TEST_FEATURE, 0.0005, 0.5318, 0.2580135, 0.2888
     ],
     [
-        MaxRatioCompositing(
+        MaxRatioCompositingTask(
             (FeatureType.DATA, 'REFERENCE_SCENES'), (FeatureType.DATA_TIMELESS, 'TEST'),
             blue_idx=0, nir_idx=6, swir1_idx=8, interpolation='geoville'
         ),
         DATA_TIMELESS_TEST_FEATURE, 0.0006, 0.5075, 0.13513365, 0.0958
     ],
     [
-        HistogramMatching(
+        HistogramMatchingTask(
             (FeatureType.DATA, 'BANDS-S2-L1C', 'TEST'), (FeatureType.DATA_TIMELESS, 'REFERENCE_COMPOSITE')
         ),
         DATA_TEST_FEATURE, -0.049050678, 0.68174845, 0.1165936, 0.08370649

--- a/geometry/eolearn/geometry/__init__.py
+++ b/geometry/eolearn/geometry/__init__.py
@@ -4,7 +4,10 @@ Subpackage containing EOTasks for geometrical transformations
 
 from .morphology import ErosionTask
 from .sampling import PointSamplingTask, PointSampler, PointRasterSampler
-from .superpixel import SuperpixelSegmentation, FelzenszwalbSegmentation, SlicSegmentation, MarkSegmentationBoundaries
-from .transformations import VectorToRaster, RasterToVector
+from .superpixel import (
+    SuperpixelSegmentationTask, FelzenszwalbSegmentationTask, SlicSegmentationTask, MarkSegmentationBoundariesTask,
+    SuperpixelSegmentation, FelzenszwalbSegmentation, SlicSegmentation, MarkSegmentationBoundaries
+)
+from .transformations import VectorToRasterTask, RasterToVectorTask, VectorToRaster, RasterToVector
 
 __version__ = '0.9.2'

--- a/geometry/eolearn/geometry/superpixel.py
+++ b/geometry/eolearn/geometry/superpixel.py
@@ -17,11 +17,12 @@ import skimage.segmentation
 import numpy as np
 
 from eolearn.core import EOTask, FeatureType, FeatureTypeSet
+from eolearn.core.utilities import renamed_and_deprecated
 
 LOGGER = logging.getLogger(__name__)
 
 
-class SuperpixelSegmentation(EOTask):
+class SuperpixelSegmentationTask(EOTask):
     """ Super-pixel segmentation task
 
     Given a raster feature it will segment data into super-pixels. Representation of super-pixels will be returned as
@@ -72,26 +73,26 @@ class SuperpixelSegmentation(EOTask):
         return eopatch
 
 
-class FelzenszwalbSegmentation(SuperpixelSegmentation):
+class FelzenszwalbSegmentationTask(SuperpixelSegmentationTask):
     """ Super-pixel segmentation which uses Felzenszwalb's method of segmentation
 
     Uses segmentation function documented at:
     https://scikit-image.org/docs/dev/api/skimage.segmentation.html#skimage.segmentation.felzenszwalb
     """
     def __init__(self, feature, superpixel_feature, **kwargs):
-        """ Arguments are passed to `SuperpixelSegmentation` task
+        """ Arguments are passed to `SuperpixelSegmentationTask` task
         """
         super().__init__(feature, superpixel_feature, segmentation_object=skimage.segmentation.felzenszwalb, **kwargs)
 
 
-class SlicSegmentation(SuperpixelSegmentation):
+class SlicSegmentationTask(SuperpixelSegmentationTask):
     """ Super-pixel segmentation which uses SLIC method of segmentation
 
     Uses segmentation function documented at:
     https://scikit-image.org/docs/dev/api/skimage.segmentation.html#skimage.segmentation.slic
     """
     def __init__(self, feature, superpixel_feature, **kwargs):
-        """ Arguments are passed to `SuperpixelSegmentation` task
+        """ Arguments are passed to `SuperpixelSegmentationTask` task
         """
         super().__init__(
             feature, superpixel_feature, segmentation_object=skimage.segmentation.slic, start_label=0, **kwargs
@@ -105,7 +106,7 @@ class SlicSegmentation(SuperpixelSegmentation):
         return super()._create_superpixel_mask(data)
 
 
-class MarkSegmentationBoundaries(EOTask):
+class MarkSegmentationBoundariesTask(EOTask):
     """ Takes super-pixel segmentation mask and creates a new mask where boundaries of super-pixels are marked
 
     The result is a binary mask with values 0 and 1 and dtype `numpy.uint8`
@@ -139,3 +140,27 @@ class MarkSegmentationBoundaries(EOTask):
         bounds_mask = bounds_mask[..., :1].astype(np.uint8)
         eopatch[self.new_feature[0]][self.new_feature[1]] = bounds_mask
         return eopatch
+
+
+@renamed_and_deprecated
+class SuperpixelSegmentation(SuperpixelSegmentationTask):
+    """ A deprecated version of SuperpixelSegmentationTask
+    """
+
+
+@renamed_and_deprecated
+class FelzenszwalbSegmentation(FelzenszwalbSegmentationTask):
+    """ A deprecated version of FelzenszwalbSegmentationTask
+    """
+
+
+@renamed_and_deprecated
+class SlicSegmentation(SlicSegmentationTask):
+    """ A deprecated version of SlicSegmentationTask
+    """
+
+
+@renamed_and_deprecated
+class MarkSegmentationBoundaries(MarkSegmentationBoundariesTask):
+    """ A deprecated version of MarkSegmentationBoundariesTask
+    """

--- a/geometry/eolearn/geometry/transformations.py
+++ b/geometry/eolearn/geometry/transformations.py
@@ -26,11 +26,12 @@ from geopandas import GeoSeries, GeoDataFrame
 
 from sentinelhub import CRS, bbox_to_dimensions
 from eolearn.core import EOTask, FeatureType, FeatureTypeSet
+from eolearn.core.utilities import renamed_and_deprecated
 
 LOGGER = logging.getLogger(__name__)
 
 
-class VectorToRaster(EOTask):
+class VectorToRasterTask(EOTask):
     """ A task for transforming a vector feature into a raster feature
 
     Vector data can be given as an EOPatch feature or as an independent geopandas `GeoDataFrame`.
@@ -336,7 +337,7 @@ class VectorToRaster(EOTask):
         return eopatch
 
 
-class RasterToVector(EOTask):
+class RasterToVectorTask(EOTask):
     """ Task for transforming raster mask feature into vector feature.
 
     Each connected component with the same value on the raster mask is turned into a shapely polygon. Polygon are
@@ -455,3 +456,15 @@ class RasterToVector(EOTask):
                                                              crs=gpd_list[0].crs)
 
         return eopatch
+
+
+@renamed_and_deprecated
+class VectorToRaster(VectorToRasterTask):
+    """ A deprecated version of VectorToRasterTask
+    """
+
+
+@renamed_and_deprecated
+class RasterToVector(RasterToVectorTask):
+    """ A deprecated version of RasterToVectorTask
+    """

--- a/geometry/eolearn/geometry/transformations.py
+++ b/geometry/eolearn/geometry/transformations.py
@@ -81,7 +81,7 @@ class VectorToRasterTask(EOTask):
         """
         self.vector_input, self.raster_feature = self._parse_main_params(vector_input, raster_feature)
 
-        if self._vector_is_timeless(self.vector_input) and not self.raster_feature[0].is_timeless():
+        if _vector_is_timeless(self.vector_input) and not self.raster_feature[0].is_timeless():
             raise ValueError('Vector input has no time-dependence but a time-dependent raster feature was selected')
 
         self.values = values
@@ -103,46 +103,29 @@ class VectorToRasterTask(EOTask):
 
         self._rasterize_per_timestamp = self.raster_feature[0].is_time_dependent()
 
-    @staticmethod
-    def _parse_main_params(vector_input, raster_feature):
+    def _parse_main_params(self, vector_input, raster_feature):
         """ Parsing first 2 task parameters - what vector data will be used and in which raster feature it will be saved
         """
-        if VectorToRaster._is_geopandas_object(raster_feature):
+        if _is_geopandas_object(raster_feature):
             # pylint: disable=W1114
-            warnings.warn('In the new version of VectorToRaster task order of parameters changed. Parameter for '
+            warnings.warn('In the new version of VectorToRasterTask task order of parameters changed. Parameter for '
                           'specifying vector data or feature has to be before parameter specifying new raster feature',
                           DeprecationWarning, stacklevel=3)
-            return VectorToRaster._parse_main_params(raster_feature, vector_input)
+            return self._parse_main_params(raster_feature, vector_input)
 
-        if not VectorToRaster._is_geopandas_object(vector_input):
-            vector_input = VectorToRaster._parse_features(
+        if not _is_geopandas_object(vector_input):
+            vector_input = self._parse_features(
                 vector_input,
                 allowed_feature_types={FeatureType.VECTOR_TIMELESS, FeatureType.VECTOR}
             )
 
         raster_feature = next(iter(
-            VectorToRaster._parse_features(
+            self._parse_features(
                 raster_feature,
                 allowed_feature_types=FeatureTypeSet.RASTER_TYPES_3D.union(FeatureTypeSet.RASTER_TYPES_4D)
             )
         ))
         return vector_input, raster_feature
-
-    @staticmethod
-    def _is_geopandas_object(data):
-        """ A frequently used check if object is geopandas `GeoDataFrame` or `GeoSeries`
-        """
-        return isinstance(data, (GeoDataFrame, GeoSeries))
-
-    @staticmethod
-    def _vector_is_timeless(vector_input):
-        """ Used to check if the vector input (either geopandas object EOPatch Feature) is time independent
-        """
-        if VectorToRaster._is_geopandas_object(vector_input):
-            return 'TIMESTAMP' not in vector_input
-
-        vector_type = next(iter(vector_input))[0]
-        return vector_type.is_timeless()
 
     def _get_vector_data_iterator(self, eopatch, join_per_value):
         """ Collects and prepares vector shapes for rasterization. It works as an iterator that returns pairs of
@@ -166,7 +149,7 @@ class VectorToRasterTask(EOTask):
     def _get_vector_data_from_eopatch(self, eopatch):
         """ Provides a vector dataframe either from the attribute or from given EOPatch feature
         """
-        if self._is_geopandas_object(self.vector_input):
+        if _is_geopandas_object(self.vector_input):
             return self.vector_input
 
         feature = next(self.vector_input(eopatch))
@@ -456,6 +439,22 @@ class RasterToVectorTask(EOTask):
                                                              crs=gpd_list[0].crs)
 
         return eopatch
+
+
+def _is_geopandas_object(data):
+    """ A frequently used check if object is geopandas `GeoDataFrame` or `GeoSeries`
+    """
+    return isinstance(data, (GeoDataFrame, GeoSeries))
+
+
+def _vector_is_timeless(vector_input):
+    """ Used to check if the vector input (either geopandas object EOPatch Feature) is time independent
+    """
+    if _is_geopandas_object(vector_input):
+        return 'TIMESTAMP' not in vector_input
+
+    vector_type = next(iter(vector_input))[0]
+    return vector_type.is_timeless()
 
 
 @renamed_and_deprecated

--- a/geometry/eolearn/tests/test_superpixel.py
+++ b/geometry/eolearn/tests/test_superpixel.py
@@ -11,7 +11,7 @@ import numpy as np
 import pytest
 
 from eolearn.core import FeatureType
-from eolearn.geometry import SuperpixelSegmentation, FelzenszwalbSegmentation, SlicSegmentation
+from eolearn.geometry import SuperpixelSegmentationTask, FelzenszwalbSegmentationTask, SlicSegmentationTask
 
 
 SUPERPIXEL_FEATURE = FeatureType.MASK_TIMELESS, 'SP_FEATURE'
@@ -19,29 +19,29 @@ SUPERPIXEL_FEATURE = FeatureType.MASK_TIMELESS, 'SP_FEATURE'
 
 @pytest.mark.parametrize('task, expected_min, expected_max, expected_mean, expected_median', (
     [
-        SuperpixelSegmentation(
+        SuperpixelSegmentationTask(
             (FeatureType.DATA, 'BANDS-S2-L1C'), SUPERPIXEL_FEATURE, scale=100, sigma=0.5, min_size=100
         ),
         0, 25, 10.6809, 11
     ],
     [
-        FelzenszwalbSegmentation(
+        FelzenszwalbSegmentationTask(
             (FeatureType.DATA_TIMELESS, 'MAX_NDVI'), SUPERPIXEL_FEATURE, scale=21, sigma=1.0, min_size=52
         ),
         0, 22, 8.5302, 7
     ],
     [
-        FelzenszwalbSegmentation((FeatureType.MASK, 'CLM'), SUPERPIXEL_FEATURE, scale=1, sigma=0, min_size=15),
+        FelzenszwalbSegmentationTask((FeatureType.MASK, 'CLM'), SUPERPIXEL_FEATURE, scale=1, sigma=0, min_size=15),
         0, 171, 86.46267, 90
     ],
     [
-        SlicSegmentation(
+        SlicSegmentationTask(
             (FeatureType.DATA, 'CLP'), SUPERPIXEL_FEATURE, n_segments=55, compactness=25.0, max_iter=20, sigma=0.8
         ),
         0, 48, 24.6072, 25
     ],
     [
-        SlicSegmentation(
+        SlicSegmentationTask(
             (FeatureType.MASK_TIMELESS, 'RANDOM_UINT8'), SUPERPIXEL_FEATURE,
             n_segments=231, compactness=15.0, max_iter=7, sigma=0.2
         ),

--- a/geometry/eolearn/tests/test_transformations.py
+++ b/geometry/eolearn/tests/test_transformations.py
@@ -16,7 +16,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from eolearn.core import EOTask, EOPatch, FeatureType
-from eolearn.geometry import VectorToRaster, RasterToVector
+from eolearn.geometry import VectorToRasterTask, RasterToVectorTask
 from shapely.geometry import Polygon
 
 from conftest import TEST_EOPATCH_PATH
@@ -47,28 +47,28 @@ class VectorToRasterTestCase:
 VECTOR_TO_RASTER_TEST_CASES = (
     VectorToRasterTestCase(
         name='basic test',
-        task=VectorToRaster(
+        task=VectorToRasterTask(
             VECTOR_FEATURE, RASTER_FEATURE, values_column='LULC_ID',
             raster_shape=(FeatureType.DATA, 'BANDS-S2-L1C'), no_data_value=20
         ),
         img_max=8, img_mean=2.33267, img_median=2, img_shape=(101, 100, 1)),
     VectorToRasterTestCase(
         name='basic test timed',
-        task=VectorToRaster(
+        task=VectorToRasterTask(
             VECTOR_FEATURE_TIMED, RASTER_FEATURE_TIMED, values_column='VALUE',
             raster_shape=(FeatureType.DATA, 'BANDS-S2-L1C'), no_data_value=20
         ),
         img_min=1, img_max=20, img_mean=12.4854, img_median=20, img_shape=(68, 101, 100, 1)),
     VectorToRasterTestCase(
         name='single value filter, fixed shape',
-        task=VectorToRaster(
+        task=VectorToRasterTask(
             VECTOR_FEATURE, RASTER_FEATURE, values=8, values_column='LULC_ID',
             raster_shape=(50, 50), no_data_value=20, write_to_existing=True, raster_dtype=np.int32
         ),
         img_min=8, img_max=20, img_mean=19.76, img_median=20, img_dtype=np.int32, img_shape=(50, 50, 1)),
     VectorToRasterTestCase(
         name='multiple values filter, resolution, all touched',
-        task=VectorToRaster(
+        task=VectorToRasterTask(
             VECTOR_FEATURE, RASTER_FEATURE, values=[1, 5], values_column='LULC_ID',
             raster_resolution='60m', no_data_value=13, raster_dtype=np.uint16, all_touched=True,
             write_to_existing=False
@@ -76,14 +76,14 @@ VECTOR_TO_RASTER_TEST_CASES = (
         img_min=1, img_max=13, img_mean=12.7093, img_median=13, img_dtype=np.uint16, img_shape=(17, 17, 1)),
     VectorToRasterTestCase(
         name='deprecated parameters, single value, custom resolution',
-        task=VectorToRaster(
+        task=VectorToRasterTask(
             vector_input=CUSTOM_DATAFRAME, raster_feature=RASTER_FEATURE, values=14,
             raster_resolution=(32, 15), no_data_value=-1, raster_dtype=np.int32
         ),
         img_min=-1, img_max=14, img_mean=-0.8411, img_median=-1, img_dtype=np.int32, img_shape=(67, 31, 1)),
     VectorToRasterTestCase(
         name='empty vector data test',
-        task=VectorToRaster(
+        task=VectorToRasterTask(
             vector_input=CUSTOM_DATAFRAME[(CUSTOM_DATAFRAME.LULC_NAME == 'some_none_existent_name')],
             raster_feature=RASTER_FEATURE, values_column='LULC_ID',
             raster_shape=(FeatureType.DATA, 'BANDS-S2-L1C'), no_data_value=0
@@ -91,21 +91,21 @@ VECTOR_TO_RASTER_TEST_CASES = (
         img_max=0, img_mean=0, img_median=0, img_shape=(101, 100, 1)),
     VectorToRasterTestCase(
         name='negative polygon buffering',
-        task=VectorToRaster(
+        task=VectorToRasterTask(
             vector_input=CUSTOM_DATAFRAME, raster_feature=RASTER_FEATURE, values_column='LULC_ID', buffer=-2,
             raster_shape=(FeatureType.DATA, 'BANDS-S2-L1C'), no_data_value=0
         ),
         img_max=8, img_mean=0.0229, img_median=0, img_shape=(101, 100, 1)),
     VectorToRasterTestCase(
         name='positive polygon buffering',
-        task=VectorToRaster(
+        task=VectorToRasterTask(
             vector_input=CUSTOM_DATAFRAME, raster_feature=RASTER_FEATURE, values_column='LULC_ID', buffer=2,
             raster_shape=(FeatureType.DATA, 'BANDS-S2-L1C'), no_data_value=0
         ),
         img_max=8, img_mean=0.0664, img_median=0, img_shape=(101, 100, 1)),
     VectorToRasterTestCase(
         name='different crs',
-        task=VectorToRaster(
+        task=VectorToRasterTask(
             vector_input=CUSTOM_DATAFRAME.to_crs(epsg=3857), raster_feature=RASTER_FEATURE, values_column='LULC_ID',
             raster_shape=(FeatureType.DATA, 'BANDS-S2-L1C'), no_data_value=0
         ),
@@ -151,20 +151,20 @@ def test_polygon_overlap(test_eopatch):
     eop = test_eopatch
 
     # no overlap
-    eop = VectorToRaster(dframe[1:-1], (FeatureType.MASK_TIMELESS, 'OVERLAP_0'), overlap_value=5, **kwargs)(eop)
+    eop = VectorToRasterTask(dframe[1:-1], (FeatureType.MASK_TIMELESS, 'OVERLAP_0'), overlap_value=5, **kwargs)(eop)
 
     # overlap without taking intersection into account
-    eop = VectorToRaster(dframe, (FeatureType.MASK_TIMELESS, 'OVERLAP_1'), overlap_value=None, **kwargs)(eop)
+    eop = VectorToRasterTask(dframe, (FeatureType.MASK_TIMELESS, 'OVERLAP_1'), overlap_value=None, **kwargs)(eop)
 
     # overlap by setting intersections to 0
-    eop = VectorToRaster(dframe, (FeatureType.MASK_TIMELESS, 'OVERLAP_2'), overlap_value=0, **kwargs)(eop)
+    eop = VectorToRasterTask(dframe, (FeatureType.MASK_TIMELESS, 'OVERLAP_2'), overlap_value=0, **kwargs)(eop)
 
     # overlap by setting intersections to class 7
-    eop = VectorToRaster(dframe, (FeatureType.MASK_TIMELESS, 'OVERLAP_3'), overlap_value=7, **kwargs)(eop)
+    eop = VectorToRasterTask(dframe, (FeatureType.MASK_TIMELESS, 'OVERLAP_3'), overlap_value=7, **kwargs)(eop)
 
     # separately render bboxes for comparisons in asserts
-    eop = VectorToRaster(dframe[:1], (FeatureType.MASK_TIMELESS, 'TEST_BBOX1'), **kwargs)(eop)
-    eop = VectorToRaster(dframe[-1:], (FeatureType.MASK_TIMELESS, 'TEST_BBOX2'), **kwargs)(eop)
+    eop = VectorToRasterTask(dframe[:1], (FeatureType.MASK_TIMELESS, 'TEST_BBOX1'), **kwargs)(eop)
+    eop = VectorToRasterTask(dframe[-1:], (FeatureType.MASK_TIMELESS, 'TEST_BBOX2'), **kwargs)(eop)
 
     bbox1 = eop.mask_timeless['TEST_BBOX1']
     bbox2 = eop.mask_timeless['TEST_BBOX2']
@@ -203,13 +203,13 @@ class RasterToVectorTestCase:
 RASTER_TO_VECTOR_TEST_CASES = (
     # feature2 = FeatureType.MASK, 'CLM'
     RasterToVectorTestCase(
-        name='reverse test', task=RasterToVector((FeatureType.MASK_TIMELESS, 'LULC', 'NEW_LULC')),
+        name='reverse test', task=RasterToVectorTask((FeatureType.MASK_TIMELESS, 'LULC', 'NEW_LULC')),
         feature=(FeatureType.MASK_TIMELESS, 'LULC'), vector_feature=(FeatureType.VECTOR_TIMELESS, 'NEW_LULC'),
         data_len=126, test_reverse=True
     ),
     RasterToVectorTestCase(
         name='parameters test',
-        task=RasterToVector(
+        task=RasterToVectorTask(
             (FeatureType.MASK, 'CLM'), values=[1, 2], values_column='IS_CLOUD', raster_dtype=np.int16, connectivity=8
         ),
         feature=(FeatureType.MASK, 'CLM'), vector_feature=(FeatureType.VECTOR, 'CLM'), data_len=54
@@ -226,7 +226,7 @@ def test_raster_to_vector_result(test_case, test_eopatch):
         old_feature = test_case.feature
         new_feature = old_feature[0], f'{old_feature[1]}_NEW'
 
-        vector2raster_task = VectorToRaster(
+        vector2raster_task = VectorToRasterTask(
             test_case.vector_feature, new_feature, values_column=test_case.task.values_column, raster_shape=old_feature
         )
 

--- a/io/eolearn/io/__init__.py
+++ b/io/eolearn/io/__init__.py
@@ -2,8 +2,8 @@
 A collection of input and output EOTasks
 """
 
-from .geopedia import AddGeopediaFeature
-from .local_io import ExportToTiff, ImportFromTiff
+from .geopedia import AddGeopediaFeature, AddGeopediaFeatureTask
+from .local_io import ExportToTiff, ImportFromTiff, ExportToTiffTask, ImportFromTiffTask
 from .geometry_io import VectorImportTask, GeopediaVectorImportTask, GeoDBVectorImportTask
 from .sentinelhub_process import SentinelHubDemTask, SentinelHubEvalscriptTask, SentinelHubInputTask, \
     SentinelHubSen2corTask, get_available_timestamps

--- a/io/eolearn/io/geopedia.py
+++ b/io/eolearn/io/geopedia.py
@@ -18,11 +18,12 @@ import rasterio.warp
 from sentinelhub import MimeType, CRS, GeopediaWmsRequest
 
 from eolearn.core import EOTask, FeatureType
+from eolearn.core.utilities import renamed_and_deprecated
 
 LOGGER = logging.getLogger(__name__)
 
 
-class AddGeopediaFeature(EOTask):
+class AddGeopediaFeatureTask(EOTask):
     """
     Task for adding a feature from Geopedia to an existing EOPatch.
 
@@ -163,3 +164,9 @@ class AddGeopediaFeature(EOTask):
         eopatch[self.feature_type][self.feature_name] = raster
 
         return eopatch
+
+
+@renamed_and_deprecated
+class AddGeopediaFeature(AddGeopediaFeatureTask):
+    """ A deprecated version of AddGeopediaFeatureTask
+    """

--- a/io/eolearn/io/local_io.py
+++ b/io/eolearn/io/local_io.py
@@ -24,11 +24,12 @@ from sentinelhub import CRS, BBox
 
 from eolearn.core import EOTask, EOPatch
 from eolearn.core.fs_utils import get_base_filesystem_and_path
+from eolearn.core.utilities import renamed_and_deprecated
 
 LOGGER = logging.getLogger(__name__)
 
 
-class BaseLocalIo(EOTask):
+class BaseLocalIoTask(EOTask):
     """ Base abstract class for local IO tasks
     """
     def __init__(self, feature, folder=None, *, image_dtype=None, no_data_value=0, config=None):
@@ -104,7 +105,7 @@ class BaseLocalIo(EOTask):
         raise NotImplementedError
 
 
-class ExportToTiff(BaseLocalIo):
+class ExportToTiffTask(BaseLocalIoTask):
     """ Task exports specified feature to Geo-Tiff.
 
     When exporting multiple times OR bands, the Geo-Tiff `band` counts are in the expected order.
@@ -325,7 +326,7 @@ class ExportToTiff(BaseLocalIo):
         return eopatch
 
 
-class ImportFromTiff(BaseLocalIo):
+class ImportFromTiffTask(BaseLocalIoTask):
     """ Task for importing data from a Geo-Tiff file into an EOPatch
 
     The task can take an existing EOPatch and read the part of Geo-Tiff image, which intersects with its bounding
@@ -443,3 +444,21 @@ class ImportFromTiff(BaseLocalIo):
         eopatch[feature_type][feature_name] = data
 
         return eopatch
+
+
+@renamed_and_deprecated
+class BaseLocalIo(BaseLocalIoTask):
+    """ A deprecated version of BaseLocalIoTask
+    """
+
+
+@renamed_and_deprecated
+class ExportToTiff(ExportToTiffTask):
+    """ A deprecated version of ExportToTiffTask
+    """
+
+
+@renamed_and_deprecated
+class ImportFromTiff(ImportFromTiffTask):
+    """ A deprecated version of ImportFromTiffTask
+    """

--- a/io/eolearn/io/sentinelhub_process.py
+++ b/io/eolearn/io/sentinelhub_process.py
@@ -62,7 +62,7 @@ def get_available_timestamps(bbox, config, data_collection, time_difference, tim
     return filtered_timestamps
 
 
-class SentinelHubInputBase(EOTask):
+class SentinelHubInputBaseTask(EOTask):
     """ Base class for Processing API input tasks
     """
 
@@ -198,7 +198,7 @@ class SentinelHubInputBase(EOTask):
 ProcApiType = collections.namedtuple('ProcApiType', 'id unit sample_type np_dtype feature_type')
 
 
-class SentinelHubEvalscriptTask(SentinelHubInputBase):
+class SentinelHubEvalscriptTask(SentinelHubInputBaseTask):
     """ Process API task to download data using evalscript
     """
 
@@ -341,7 +341,7 @@ class SentinelHubEvalscriptTask(SentinelHubInputBase):
         return eopatch
 
 
-class SentinelHubInputTask(SentinelHubInputBase):
+class SentinelHubInputTask(SentinelHubInputBaseTask):
     """ Process API input task that loads 16bit integer data and converts it to a 32bit float feature.
     """
     # pylint: disable=too-many-arguments

--- a/mask/eolearn/mask/__init__.py
+++ b/mask/eolearn/mask/__init__.py
@@ -3,8 +3,8 @@ Public classes and functions of mask subpackage
 """
 
 from .cloud_mask import AddMultiCloudMaskTask, CloudMaskTask
-from .masking import AddValidDataMaskTask, MaskFeature
-from .snow_mask import SnowMask, TheiaSnowMask
+from .masking import AddValidDataMaskTask, MaskFeatureTask, MaskFeature
+from .snow_mask import SnowMask, TheiaSnowMask, SnowMaskTask, TheiaSnowMaskTask
 from .utilities import resize_images
 from .mask_counting import ClassFrequencyTask
 

--- a/mask/eolearn/mask/masking.py
+++ b/mask/eolearn/mask/masking.py
@@ -14,6 +14,7 @@ file in the root directory of this source tree.
 import numpy as np
 
 from eolearn.core import EOTask, FeatureType
+from eolearn.core.utilities import renamed_and_deprecated
 
 
 class AddValidDataMaskTask(EOTask):
@@ -47,7 +48,7 @@ class AddValidDataMaskTask(EOTask):
         return eopatch
 
 
-class MaskFeature(EOTask):
+class MaskFeatureTask(EOTask):
     """ Masks out values of a feature using defined values of a given mask feature.
 
     As an example, it can be used to mask the data feature using values from the Sen2cor Scene Classification
@@ -131,3 +132,9 @@ def apply_mask(data, mask, old_value, new_value, data_type, mask_type):
         raise ValueError(f'Mask feature has {mask.shape[-1]} number of bands while data feature has '
                          f'{data.shape[-1]} number of bands')
     return data
+
+
+@renamed_and_deprecated
+class MaskFeature(MaskFeatureTask):
+    """ A deprecated version of MaskFeatureTask
+    """

--- a/mask/eolearn/mask/snow_mask.py
+++ b/mask/eolearn/mask/snow_mask.py
@@ -17,13 +17,14 @@ import numpy as np
 from skimage.morphology import disk, binary_dilation
 
 from eolearn.core import EOTask, FeatureType
+from eolearn.core.utilities import renamed_and_deprecated
 from .utilities import resize_images
 
 
 LOGGER = logging.getLogger(__name__)
 
 
-class BaseSnowMask(EOTask):
+class BaseSnowMaskTask(EOTask):
     """ Base class for snow detection and masking
     """
     def __init__(self, data_feature, band_indices, dilation_size=0, undefined_value=0, mask_name='SNOW_MASK'):
@@ -52,7 +53,7 @@ class BaseSnowMask(EOTask):
         raise NotImplementedError
 
 
-class SnowMask(BaseSnowMask):
+class SnowMaskTask(BaseSnowMaskTask):
     """ The task calculates the snow mask using the given thresholds.
 
     The default values were optimised based on the Sentinel-2 L1C processing level. Values might not be optimal for L2A
@@ -104,7 +105,7 @@ class SnowMask(BaseSnowMask):
         return eopatch
 
 
-class TheiaSnowMask(BaseSnowMask):
+class TheiaSnowMaskTask(BaseSnowMaskTask):
     """ Task to add a snow mask to an EOPatch. The input data is either Sentinel-2 L1C or L2A level
 
     Original implementation and documentation available at https://gitlab.orfeo-toolbox.org/remote_modules/let-it-snow
@@ -267,3 +268,15 @@ class TheiaSnowMask(BaseSnowMask):
         eopatch[self.mask_feature] = snow_mask[..., np.newaxis].astype(bool)
 
         return eopatch
+
+
+@renamed_and_deprecated
+class SnowMask(SnowMaskTask):
+    """ A deprecated version of SnowMaskTask
+    """
+
+
+@renamed_and_deprecated
+class TheiaSnowMask(TheiaSnowMaskTask):
+    """ A deprecated version of TheiaSnowMaskTask
+    """

--- a/mask/eolearn/tests/test_masking.py
+++ b/mask/eolearn/tests/test_masking.py
@@ -10,7 +10,7 @@ import pytest
 import numpy as np
 
 from eolearn.core import FeatureType
-from eolearn.mask import MaskFeature
+from eolearn.mask import MaskFeatureTask
 
 
 BANDS_FEATURE = FeatureType.DATA, 'BANDS-S2-L1C'
@@ -22,7 +22,7 @@ LULC_FEATURE = FeatureType.MASK_TIMELESS, 'LULC'
 def test_bands_with_clm(test_eopatch):
     new_feature = FeatureType.DATA, 'BANDS-S2-L1C_MASKED'
 
-    mask_task = MaskFeature(BANDS_FEATURE, CLOUD_MASK_FEATURE, mask_values=[True], no_data_value=-1)
+    mask_task = MaskFeatureTask(BANDS_FEATURE, CLOUD_MASK_FEATURE, mask_values=[True], no_data_value=-1)
     eop = mask_task(test_eopatch)
 
     masked_count = np.count_nonzero(eop[new_feature] == -1)
@@ -34,7 +34,7 @@ def test_bands_with_clm(test_eopatch):
 def test_ndvi_with_clm(test_eopatch):
     new_feature = FeatureType.DATA, 'NDVI_MASKED'
 
-    mask_task = MaskFeature(NDVI_FEATURE, CLOUD_MASK_FEATURE, mask_values=[True])
+    mask_task = MaskFeatureTask(NDVI_FEATURE, CLOUD_MASK_FEATURE, mask_values=[True])
     eop = mask_task(test_eopatch)
 
     masked_count = np.count_nonzero(np.isnan(eop[new_feature]))
@@ -45,7 +45,7 @@ def test_ndvi_with_clm(test_eopatch):
 def test_clm_with_lulc(test_eopatch):
     new_feature = FeatureType.MASK, 'CLM_MASKED'
 
-    mask_task = MaskFeature(CLOUD_MASK_FEATURE, LULC_FEATURE, mask_values=[2], no_data_value=255)
+    mask_task = MaskFeatureTask(CLOUD_MASK_FEATURE, LULC_FEATURE, mask_values=[2], no_data_value=255)
     eop = mask_task(test_eopatch)
 
     masked_count = np.count_nonzero(eop[new_feature] == 255)
@@ -58,7 +58,7 @@ def test_clm_with_lulc(test_eopatch):
 def test_lulc_with_lulc(test_eopatch):
     new_feature = FeatureType.MASK_TIMELESS, 'LULC_MASKED'
 
-    mask_task = MaskFeature(LULC_FEATURE, LULC_FEATURE, mask_values=[1], no_data_value=100)
+    mask_task = MaskFeatureTask(LULC_FEATURE, LULC_FEATURE, mask_values=[1], no_data_value=100)
     eop = mask_task(test_eopatch)
 
     masked_count = np.count_nonzero(eop[new_feature] == 100)
@@ -68,4 +68,4 @@ def test_lulc_with_lulc(test_eopatch):
 
 def test_wrong_arguments():
     with pytest.raises(ValueError):
-        MaskFeature(BANDS_FEATURE, CLOUD_MASK_FEATURE, mask_values=10)
+        MaskFeatureTask(BANDS_FEATURE, CLOUD_MASK_FEATURE, mask_values=10)

--- a/mask/eolearn/tests/test_snow_mask.py
+++ b/mask/eolearn/tests/test_snow_mask.py
@@ -11,7 +11,7 @@ import pytest
 import numpy as np
 
 from eolearn.core import FeatureType
-from eolearn.mask import SnowMask, TheiaSnowMask
+from eolearn.mask import SnowMaskTask, TheiaSnowMaskTask
 
 
 @pytest.mark.parametrize('params', [
@@ -21,7 +21,7 @@ from eolearn.mask import SnowMask, TheiaSnowMask
 ])
 def test_raises_errors(params, test_eopatch):
     with pytest.raises(ValueError):
-        theia_mask = TheiaSnowMask(
+        theia_mask = TheiaSnowMaskTask(
             (FeatureType.DATA, 'BANDS-S2-L1C'), [2, 3, 11], (FeatureType.MASK, 'CLM'),
             (FeatureType.DATA_TIMELESS, 'DEM'), **params
         )
@@ -30,11 +30,11 @@ def test_raises_errors(params, test_eopatch):
 
 @pytest.mark.parametrize('task, result', [
     (
-        SnowMask((FeatureType.DATA, 'BANDS-S2-L1C'), [2, 3, 7, 11], mask_name='TEST_SNOW_MASK'),
+        SnowMaskTask((FeatureType.DATA, 'BANDS-S2-L1C'), [2, 3, 7, 11], mask_name='TEST_SNOW_MASK'),
         (50468, 1405)
     ),
     (
-        TheiaSnowMask(
+        TheiaSnowMaskTask(
             (FeatureType.DATA, 'BANDS-S2-L1C'), [2, 3, 11], (FeatureType.MASK, 'CLM'),
             (FeatureType.DATA_TIMELESS, 'DEM'), b10_index=10, mask_name='TEST_THEIA_SNOW_MASK'
         ),


### PR DESCRIPTION
Most tasks in `eolearn` follow the naming convention of the `Task` suffix. This PR ensures the naming convention is followed in the remaining tasks, while keeping the old versions with a deprecation warning.