### PR TITLE
EOWorkflow makes shallow copies of EOPatches

### DIFF
--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -235,10 +235,10 @@ class EOPatch:
         return '.'.join([cls.__module__.split('.')[0], cls.__name__])
 
     def __copy__(self, features=...):
-        """Returns a new EOPatch with shallow copies of given features.
+        """ Returns a new EOPatch with shallow copies of given features.
 
         :param features: A collection of features or feature types that will be copied into new EOPatch.
-        :type features: object supported by eolearn.core.utilities.FeatureParser class
+        :type features: object supported by the :class:`FeatureParser<eolearn.core.utilities.FeatureParser>`
         """
         if not features:  # For some reason deepcopy and copy pass {} by default
             features = ...
@@ -252,12 +252,12 @@ class EOPatch:
         return new_eopatch
 
     def __deepcopy__(self, memo=None, features=...):
-        """Returns a new EOPatch with deep copies of given features.
+        """ Returns a new EOPatch with deep copies of given features.
 
         :param memo: built-in parameter for memoization
         :type memo: dict
         :param features: A collection of features or feature types that will be copied into new EOPatch.
-        :type features: object supported by eolearn.core.utilities.FeatureParser class
+        :type features: object supported by the :class:`FeatureParser<eolearn.core.utilities.FeatureParser>`
         """
         if not features:  # For some reason deepcopy and copy pass {} by default
             features = ...
@@ -267,6 +267,21 @@ class EOPatch:
             new_eopatch[feature_type] = copy.deepcopy(new_eopatch[feature_type], memo)
 
         return new_eopatch
+
+    def copy(self, features=..., deep=False):
+        """ Get a copy of the current `EOPatch`.
+
+        :param features: Features to be copied into a new `EOPatch`. By default all features will be copied.
+        :type features: object supported by the :class:`FeatureParser<eolearn.core.utilities.FeatureParser>`
+        :param deep: If `True` it will make a deep copy of all data inside the `EOPatch`. Otherwise only a shallow copy
+            of `EOPatch` will be made. Note that `BBOX` and `TIMESTAMP` will be copied even with a shallow copy.
+        :type deep: bool
+        :return: An EOPatch copy.
+        :rtype: EOPatch
+        """
+        if deep:
+            return self.__deepcopy__(features=features)
+        return self.__copy__(features=features)
 
     def remove_feature(self, feature_type, feature_name):
         """Removes the feature ``feature_name`` from dictionary of ``feature_type``.

--- a/core/eolearn/tests/test_eodata.py
+++ b/core/eolearn/tests/test_eodata.py
@@ -172,6 +172,41 @@ class TestEOPatch(unittest.TestCase):
 
         self.assertTrue(np.array_equal(eop_bands, bands), msg="Data numpy array not returned properly")
 
+    def test_shallow_copy(self):
+        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../example_data/TestEOPatch')
+        eop = EOPatch.load(path)
+
+        eop_copy = eop.copy()
+        assert eop == eop_copy
+        assert eop is not eop_copy
+
+        eop_copy.mask['CLM'] += 1
+        assert eop == eop_copy
+
+        eop_copy.timestamp.pop()
+        assert eop != eop_copy
+
+    def test_deep_copy(self):
+        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../example_data/TestEOPatch')
+        eop = EOPatch.load(path)
+
+        eop_copy = eop.copy(deep=True)
+        assert eop == eop_copy
+        assert eop is not eop_copy
+
+        eop_copy.mask['CLM'] += 1
+        assert eop != eop_copy
+
+    def test_copy_features(self):
+        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../example_data/TestEOPatch')
+        eop = EOPatch.load(path)
+
+        feature = FeatureType.MASK, 'CLM'
+        eop_copy = eop.copy(features=[feature])
+        assert eop != eop_copy
+        assert eop_copy[feature] is eop[feature]
+        assert eop_copy.timestamp == []
+
     def test_remove_feature(self):
         bands = np.arange(2*3*3*2).reshape(2, 3, 3, 2)
         names = ['bands1', 'bands2', 'bands3']

--- a/core/eolearn/tests/test_eodata.py
+++ b/core/eolearn/tests/test_eodata.py
@@ -182,6 +182,7 @@ class TestEOPatch(unittest.TestCase):
 
         eop_copy.mask['CLM'] += 1
         assert eop == eop_copy
+        assert eop.mask['CLM'] is eop_copy.mask['CLM']
 
         eop_copy.timestamp.pop()
         assert eop != eop_copy


### PR DESCRIPTION
Before each task in an EOWorkflow is executed the workflow will make sure that all input EOPatches are shallow-copied. This ensures the correct logic in a complicated workflow. This PR also adds `EOPatch.copy` method.

Tests for checking the copy functionality of EOWorkflow will be added in another PR into develop-v1.0.