### PR TITLE
Update example notebooks that appear in docs

### DIFF
--- a/examples/mask/ValidDataMask.ipynb
+++ b/examples/mask/ValidDataMask.ipynb
@@ -70,10 +70,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class ValidDataPredicate:\n",
-    "    def __call__(self, eopatch):\n",
-    "        return np.logical_and(eopatch.mask['dataMask'].astype(np.bool), \n",
-    "                              np.logical_not(eopatch.mask['CLM'].astype(np.bool)))"
+    "def is_valid(eopatch):\n",
+    "    return eopatch.mask['dataMask'].astype(bool) & ~(eopatch.mask['CLM'].astype(bool))"
    ]
   },
   {
@@ -91,14 +89,14 @@
     "    time_difference=datetime.timedelta(hours=2),\n",
     "    max_threads=3\n",
     ")\n",
-    "add_valmask = AddValidDataMaskTask(predicate=ValidDataPredicate(), valid_data_feature='VALID_DATA')"
+    "add_valmask = AddValidDataMaskTask(predicate=is_valid, valid_data_feature='VALID_DATA')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Run workflow"
+    "### Run workflow"
    ]
   },
   {
@@ -120,7 +118,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Plot results"
+    "### Plot results"
    ]
   },
   {

--- a/examples/water-monitor/WaterMonitorWorkflow.ipynb
+++ b/examples/water-monitor/WaterMonitorWorkflow.ipynb
@@ -40,8 +40,7 @@
     "# We'll use Sentinel-2 imagery (Level-1C) provided through Sentinel Hub\n",
     "# If you don't know what `Level 1C` means, don't worry. It doesn't matter.\n",
     "\n",
-    "from eolearn.io.processing_api import SentinelHubInputTask\n",
-    "from eolearn.core import LoadFromDisk, SaveToDisk\n",
+    "from eolearn.io import SentinelHubInputTask\n",
     "\n",
     "from eolearn.mask import AddValidDataMaskTask\n",
     "\n",
@@ -49,7 +48,7 @@
     "from eolearn.features import SimpleFilterTask, NormalizedDifferenceIndexTask\n",
     "\n",
     "# burning the vectorised polygon to raster\n",
-    "from eolearn.geometry import VectorToRaster"
+    "from eolearn.geometry import VectorToRasterTask"
    ]
   },
   {
@@ -179,13 +178,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "download_task = SentinelHubInputTask(data_collection=DataCollection.SENTINEL2_L1C, \n",
-    "                                     bands_feature=(FeatureType.DATA, 'BANDS'),\n",
-    "                                     resolution=20, \n",
-    "                                     maxcc=0.5, \n",
-    "                                     bands=['B02', 'B03', 'B04', 'B08'], \n",
-    "                                     additional_data=[(FeatureType.MASK, 'dataMask', 'IS_DATA'), (FeatureType.MASK, 'CLM')]\n",
-    "                                    )\n",
+    "download_task = SentinelHubInputTask(\n",
+    "    data_collection=DataCollection.SENTINEL2_L1C, \n",
+    "    bands_feature=(FeatureType.DATA, 'BANDS'),\n",
+    "    resolution=20, \n",
+    "    maxcc=0.5, \n",
+    "    bands=['B02', 'B03', 'B04', 'B08'], \n",
+    "    additional_data=[(FeatureType.MASK, 'dataMask', 'IS_DATA'), (FeatureType.MASK, 'CLM')]\n",
+    ")\n",
     "\n",
     "calculate_ndwi = NormalizedDifferenceIndexTask((FeatureType.DATA, 'BANDS'), (FeatureType.DATA, 'NDWI'), (1, 3))"
    ]
@@ -232,34 +232,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZgAAADYCAYAAADWFPWNAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3dd3xV9f348dfnZu+EDBISIECYsgkyBMWBItoiaq2jgnvV2Vpba7Xf79f6q9a2iq111jqr1okVUYY4ASHsAAECBEjIJHvn3vv5/XEPeMHse89dvJ+PRx7cs9+5nJv3PZ+ptNYIIYQQ7mbxdgBCCCECkyQYIYQQppAEI4QQwhSSYIQQQphCEowQQghTSIIRQghhimBvB+BOSUlJOjMz09thCCGEX9mwYUOF1jrZ3ecNqASTmZlJTk6Ot8MQQgi/opQ6YMZ5pYhMCCGEKSTBCCGEMIUkGCGEEKaQBCOEEMIUkmCEEEKYQhKMEEIIU0iC8SN5JbW0WG0dbm9qtbFyZykFFQ0ejEoIIdoXUP1gAt2qvHJuWb+BmUOTSYkJIzwkiLAQCw0tNrYVVbN67xGqG9u4//wR3HzGEG+HK4Q4yUmC8SP9+0RQcKSRgiOd94maPiTJQxEJIUTHpIjMj2wrrOlyn7BgCw2tVmSmUiGEt0mC8SNf7i7vcp8Wq53Ln1/LnCe/5p2cQ7TZ7B6ITAghfkiKyPxETVMbu0rrur3/rtI6fvXuVh5cnMvItFhOH5rMRRPSyUiIoLKhlUOVjbzw9T4Kq5q46fTBzBufbmL0QoiTkSQYP7HpYBW9KfVqbrOz6WA1mw5Ws2jlnnb3eeCDXJKjw5ielYTWGqWUi9EKIYQkGL+x4UCVaeeub7Gy6VA1qXHh3PP2ZlCKv18xgf59Ik27phAi8EkdjJ/IKTAvwQB8s6eCc5/4ii2FNWw5VM0lz6ymor7F1GsKIQKbJBg/oLVm86FqU6+xZt8RrPbvy+DK6lq4/uX1FNc0mXpdIUTgkgTjB3aV1tHU1nEPfrNsKazhgqe+Iaeg0uPXFkL4P0kwPu61tQeYu+hrr12/sqGVa/+1nl0l3W/BJoQQIAnG5325qwy7l/tM1rVYeWVNgXeDEEL4HUkwPmzzoWounpjB5MwEb4fCsu0l2Lyd6YQQfkWaKfuw37y3lTwfKZqqqG/loy1FzJ+Q4e1QhBB+Qp5gfFBTq6NC/48Xj2HmUN8ZuPLxT3fR2Gr1dhhCCD8hCcbHFFY1cvnza9hWWMO4jHheve5UfnfBSPrGhnk7NA7XNLNoRfujAQghxIkkwfgYq02zpbCGH/39G7IfWcHvPszl+hmDWHb3GZzSL9bb4fHPb/aTX1bv7TCEEH5A6mB8gN2u+XhbMYs3FfH1nopj6ysbWnnju4NUNrQyNiOePlGhXozSwWrXPLF8N09fNdHboQghfJwkGC/bWljNg4u3s6WTnvpLc0tYmlviwag69+n2EoprmkiLi/B2KEIIHyZFZF703oZC5j39bafJxRfZ7Jo31h70dhhCCB/nUoJRSj2slNqqlNqslFqmlOp3wvbJSimrUurSDo6fpJTappTKV0o9pYxx4pVSfZRSy5VSe4x/vd8RxM0Kqxr5/UfbezUEvy949su9vPztfpk5UwjRIVefYB7XWo/VWo8HPgYeOrpBKRUEPAYs6+T4Z4AbgaHGzxxj/W+AlVrrocBKYzlg2O2a+97dSn2L/zb5tdo1//PfHfz2g1zs0gFTCNEOlxKM1rrWaTEKcP5LcwfwHlDW3rFKqTQgVmu9Vju+Br8KXGRsnge8Yrx+xWl9QFi0cg+r9x7xdhhu8ea6g9zx5iaqGlq9HYoQwse4XMmvlHoEWADUAGca69KB+cby5A4OTQcKnZYLjXUAfbXWxcbrEqCvq3H6isWbizqcWdJfLdlWTJBF8dQVE7wdihDCh3T5BKOUWqGUym3nZx6A1voBrXV/4A3gduOwJ4Ffa63trgZoPN10WAajlLpJKZWjlMopLy939XKmq25s83YIbhceYuG2M4d4OwwhhI/p8glGa31ON8/1BvAJ8HsgG3jLqLNPAuYqpaxa6w+d9i8CnAe2yjDWAZQqpdK01sVGUVq7xWxGfM8DzwNkZ2f7dGVAcU0TK3aWejsMt2tus3PlC99x26wh/CS7P3ERId4OSQjhA1xtRTbUaXEekAegtR6ktc7UWmcC7wK3nZBcMIrAapVSU43WYwuAxcbmj4CFxuuFTuv91nf7jjD7r18d15EykFQ2tPKHJTsZ97/L+NmL31FW2+ztkIQQXuZqK7JHjeKyrcC5wF1dHaCU2uy0eBvwIpAP7AWWHj0vMFsptQc4x1j2a2+tP+TXrcZ64pv8CuY+9TVvrz+I1eZyKakQwk+pQOrHkJ2drXNycrwdxnFsds27Gw7xh493UneSJBhng5OjeOSiMUwbkujtUIQQHVBKbdBaZ7v7vNKT30Rr9h5h7qKv+fV7207K5AKwr7yBK19cy1+X75anGSFOMjIWmRtprdl4sJqqhlaW5pbw3sbCrg86CWgNT63cw7f5FTx2yViyUqK9HZIQwgMkwbjREyv28FSA9XFxpw0Hqpj71Nf8cvYwbpw5GItFeTskIYSJpIjMTZZsLZbk0g2tVjt/XJrHDa/mUCm9/4UIaJJg3OTl1fu9HYJf+TyvjLP/8gX//u4gNhnLTIiAJEVkbnDwSCPrC6q8HYbfqWps47cfbOOV1QXMGpFM9sA+jOoXS2iQhdBgS486bLbZ7OwprSf3cA3bi2qobmpjXEY8kwYmMCY9TorjhPACSTBusGZfYHae9JRdpXXsKq3jOfYdt37BtIH8es4IosLav01rm9tYlVfGsu2lfLGrjIZW23HbF28+DDiaSl87PZOLJ2Z0eC4hhPvJp80NDhxp9HYIAenVNQdYmlvC0JRoEqPDSIwKJTEqlMiwYNbsreCr3RW0dqPp877yBh5cvJ1FK/fwi9nDuSw7g+AgKR0WwmySYNygqLrJ2yEErPK6FsrrWtxyror6Vn77wTZe+nY/M7KSyEqJZnhqDGMz4ggLDnLLNYQQ35ME4wbyBONf8svqyS+rP7YcFmxhcmYffpKdwQVj0uTpRgg3kU+SGxyqlATjz1qsdr7Jr+CutzZzy+sbpFWbEG4iCcZF9S1Wjkh/joCxYmcZv3lvqyQZIdxAishcVFIjw9IHmnc2FJJXUsekgQnY7JphqTFcMjGdyFD5uAjRE/KJcdHJMgT/yWZbUQ3bimqOLb+x9gCvXT+F5JgwL0YlhH+RIjIXNUiCOSnkldTxx6U7vR2GEH5FEoyLpKz+5PH+xiJ2ldR5Owwh/IYkGBf1jQ33dgjCg2QKBiG6TxKMi1IlwZxU3l5/iC2Hqr0dhnCzvJJaGluluNvdJMG4KCZc2kmcTGqa2vjp82v4cne5t0MRbvKf9Yf48d+/5bLn1tBqlVlX3UkSjIssFkW0DKB4Umlus3PjKzl8tr3E26GIXmhus7FyZymLVuxh4UvruO+9rbRa7eQW1fL62gPeDi+gyF9GN4gMDZLmyieZVpudn7+xkScvH8+FY/t5OxzRTTa75vLn17K5g2LOZ7/cy7WnZaKUTO/gDpJgXLR23xHK3DQYo+hcZmIkd58zjB+N60dJbTObD1bz2Kd5HPTSUD1Wu+autzYTbLEwZ3SqV2IQPfN5XlmHyQWgrK6FyoZWEqOlv5M7SIJxQZvNzh+W7PB2GCeFPlGhfHr36YSHOEY9To+PID0+gtmj+vJ2ziFqm9qIjQhhZGoMIUEWthRW8/K3BeyraDA1Lptdc+ebm3j/tumMTo8z9VrCNTa75q/Ld3e5X5tNuh64iySYXmpus/HzNzaSW1Tr7VBOCjfMHHQsuTgLDbZw9dSBP1g/rn88V00ZyJ8+y+O5L/f9YLs7tdrs3P7vjXx850ypj/Nhi1buYWdx15/XPlGhHojm5CCfhl5oaLFy46s5rN57xNuhBKz0+AjS4sK5ZFIGg5KiGJkW2+NzBFkU958/kviIUB77NM+EKL9XcKSRZ77I51fnjTD1OqLntNY8uWIPT63c0+W+UaFBhAZL2yd3kQTTQzWNbVzz8jo2HZS+EGaICQvmhYXZTBnUx20VrTefPphVeWWsK6h0y/k68uGmw/xy9nAsFqkg9hV1zW08/PEO/pPTvQ6y6QkRJkd0cpEE0wMV9S0s+Oc6dnTjMVv0TGx4MI9eMpazR6a4fXZJi0Xx+E/GMnfR1zS02tx6bmdF1U2sK6hk6uBE064RaJrbbHyzp4J+8RGMTItxy5eKstpmvthdzur8ClbtKqemqa1bx2UmRvLa9VNcvr74nksJRin1MDAPsANlwDVa68NO2ycDa4DLtdbvtnP8JOBlIAL4BLhLa62VUo8DPwJagb3AtVprrz4ylNQ0c9WLa9lbbm6l8cloeN8Ynl8wiYGJUaZdY2BiFI/MH8Pdb2827RoAn+aWSILpJq01v3xnC0u2FgNww4xB/O7CUb0+X3ldCwteWtetepYThQZZ+MdVk2ToJzdztbDxca31WK31eOBj4KGjG5RSQcBjwLJOjn8GuBEYavzMMdYvB0ZrrccCu4H7XYzTJVUNrfzkudWSXEwwOj2W926bbmpyOeqiCemcMSzZ1Gt8mluCXQZA7VJhVSPX/Gv9seSSHBPGVe001uiJmqa2XiUXgFtmDWFUv57X84nOuZRgtNbO/5tRgPMn6w7gPRxPNj+glEoDYrXWa7XWGngVuMg47zKt9dGei2uBDFfidNWDi3M5VNnkzRAC1rXTB3m05dWlk8y9lUpqm1mzTxp/dMRu12w8WMWCf647brids4anMCjJtS8ZbbbeDfOSEhPGbbOGuHTtnqpqaOWdnEO8uqaA6sbAnRHX5U+2UuoRYAFQA5xprEsH5hvLkzs4NB1wrnkrNNad6DrgbVfj7K2l24r52PiWJdyvpNazM4KeM7Iv0WHBpo68cN+7W/nkzpnERYaYdg1/9MiSHbzw9f52t505IsXl8/c2wcyfmN5uE3h3s9rsvLuhkI+3FrNm35FjU3384eOdzD6lL5dl92dGVhJBAdRIpMsnGKXUCqVUbjs/8wC01g9orfsDbwC3G4c9Cfxaa+3SyHFKqQcAq3Hujva5SSmVo5TKKS937wCE1Y2tPLh4u1vPKb530fh+zMhK8ug1I0KDTH+KKapu4q63N1FcI0+9R+0qqeO1Dsb5ig4LZtZw14sua5t696XhtCHm34MHjzTy0+fX8pv3t/FNfsVx80i12uws2VrMwpfWMeOxz3n2y70BM89UlwlGa32O1np0Oz+LT9j1DeAS43U28JZSqgC4FPiHUuqiE/Yv4viirwxjHQBKqWuAC4GrjCK0juJ7XmudrbXOTk52b/n6H5bspKJehoExwzXTM3ny8gmM6x/v8Ws7xpoy9xpf7Crn9D+t4rkv95p7IT9Q2dDK9a+sp7mt/e+bZ49McfkJoqHFyjNf5vfqWDOfGLTWvLuhkLlPfc2GA1Vd7l9c08yjS/NY8NJ3lAfAEFQu1cEopYY6Lc4D8gC01oO01pla60zgXeA2rfWHzsdqrYuBWqXUVOVom7gAWGycdw5wH/BjrbVXBpr6anc5724wf3KpxKhQhiRH0S8unAB6Mu7SpIEJXrv2wMQozh3V1/TrtNk0b68/ZPp1fN27Gw5RWNXx01xaXO/7nmit+WRbMXMWfcW3+b2r++psbDJXPbFiD/e+s6XHRbLf5h8xkpK5fbfM5modzKNKqeE4mikfAG7p6gCl1Gaj1RnAbXzfTHmp8QPwdyAMWG60i1+rte7y3O60bIf5Q7E/eOEorp2eeaxj3rr9lVz23BrTr+sLEr08HMfC6Zl8tr3U9Ovsq2igqqGVhJN0+JGapjaW7+j8fW7qxURfWms+zyvjqc/zXZ4A7onlu1m2o5Spg/pw/9yRLp3rRKvy2m3j1C3ldS389v1cPr17pt+O7uxSgtFaX9KNfa45YXm80+scYHQ7x2S5Epc79LY8tydeXr2fq6YMINziKB6YNDCB2aP6dvmB9GfBFsWPx/fzepNQT/Z3aGqz4b3nNe+KDA1id2l9p/v8d2sxPz8zi5R2/k/abHaWbS/lm/wK6luspMSEERyk+CKvnF2ldW6J0WrXbDlUTScl8b2y5VA1eSWudcreVVrHV3sqTG9ebxbpyd+BqYMT+WjL4a537KHU2HAuy84gNS6CAX0iCXMa9yjIonjuZ5N47qt9/HX5roAa1VUpuHRiBnecNZQBiZHeDod+cRHERYR0u5e3K1buLOWKUwcQHHTyjXEVEmRh2T2n85dluzocrqWyoZUFL63j7ZumHdfyrqaxjZtey+G7/eYWE1kUnJaVxP+bP8Yt52uz2fn75/n8fVW+WyrrX/hqnySYQDPeDZXP0WHBnD4siVMz+/DmukPsq6jnycvHd9rT22JR3DprCEOSo7j59Q24+UuV1zx2yVguy+7v7TCOiQgN4voZg7o1fLurHly8nf59Ipk13PWmuP6ob2w4p2UldToeWF5JHb96dwvPXT0JpRTNbTZ+8/5W05LLtMGJXDopg6yUaIakRLu1L9ay7aUs6sbAmt2VX9b5E6AvkwTTjsqGVm59Y0Ovjx+THscvZg/jtKykYyOzXjwpg8r6VjK72Zns3FNSefrKidz//jaPfMs20wNzR/pUcjnq8lP78+SK3XiiRegXu8q9mmBqGtv4w5IdDE+N4eKJGR4fkr62uesi52U7Svnpc2tJjQtn06Eq0zo333lWFvfMHmZavca3eyvcer7IMPP76JhFEkw77n57MweO9K7xWpBF8eZNU3/wjSg2PITY8J51vJs7Jo1x/eO54ZWcXg+B4W0/GtePG2YO8nYY7UqJCWfakMRetz7qiTVentqhuqmVd4xWka+sKeCfCyczrG+MR659uLqJP3VzugSzR7y+6fTB/OLc4aZeY3W+exNMVKj//pn238hNVOjCFLw/GptGuBvnk0iPj2DJHTMoONLAlsJq1u2vZOXOMr+ZpvmWMwb7dAuYs0b09UiCKfdCf6rS2mb+97/b2V1az36nmT0PVTZxyT9W89K1k5mc2cfUGFqsNu5+azN13XiCMVvf2DDuOnto1zv20JZD1bzw9T4GJ0WR0SeSgl5+Oe1IZKg8wQSU5JiwXk21++zPJjJndJrb47FYFIOToxmcHM38CRnkl9Vzzl+/dPt1zOCJIThccebwZP74icJqcjlZZUMrxTVNLvX56ImPthzmwQ9zOyxerWuxsvCldbxy3ammJRm7XXPvO1tNfyrprkcvHkuUG+tamttsPLliD89/tdfUYlZ3xuxp/hu5id6+eRrNbTbKaltotdkJCVIEB1kItiiCLIqGFisFRxp5ZXUBnxvt3EOCFDOHeqalR1ZKNBkJEZ12XvMVvR0fylMGJ0fzwsJsbn19Q4c9zd3l4n+s5oaZg7l8cn/Cgi0cqmrq9QCP1Y2tLN9RyuDkKIb1jcFud/Q5WbOvgn+vO9StviGNrTaueWkdb988jdHpcb2Koz0tVhtr91Xy5IrdPjMx34MXjurVeGd2u6O/zcq8Uprb7LRYbbRa7bRY7ewrb6Co2vzPYISPf0nrjCSYDoSHBHXYnDYpOoyBiVGcMSyZbYU1/HnZLr7Jr+BwdRNDPVSunZUS7RcJZn95AyNSfXsY9DOHp/Dc1dksfGmdqdcprmnm4Y938MTy3YQEKaoa27jjrCx+0U6Fc11zG7lFtewsrqWouonimiaqGtqIjwwhKiyYz3JLqHPDgJ0NrTau+dc63r1lercboHSkoKKB577ay+LNh2k0cWK3ngoLtpAQGYLWutvFtbXNbbyTU8irawp6XR/rLv48pp0kGBeNyYjjletOpanVRoQHy0r7xfvH1K7LdpRy/hj3Fxu62+TMBM4fncrSXPNHcHAeNuRvn+dzWXZ/kqLDKK1tZsm2Yv675TB5Je7pRNgdFfWtXPHCWl67fgpZKdE9Pr6mqY1FK/bwypoCnxykscVq5xf/2cJn20v4v3mjSY4OO25aa601ZXUt7K9ooKCiga1FNSzeVGTq7Kc94c/94STBuIknkws4hv72B7lFNd4OoVvabJphfWPISommrtlKwZEGmttspMSE02K1cbi6maLqJiobjp+7w6IcY5vNGp7MBWPSqGu2knOgkqdXdX+Qy5l/WuXuX6fHimuaufgf33LzGUNYOD2zw34hdc1tbC2sYcfhWvZVNLCvvJ4dxbU+UYnflc+2lx4bHig0yEJYsIWwkCAaW60+9cR1outn+GYrzO6QBOOn3D1vvVkKjjRgtdl9vhd7XEQI98we1uV+Ta026prbaGqz0Wazk5EQ+YOGDMkxYT1KML6ittnK45/t4vmv9jFtcCITB8YTFRZMQ4uV/LJ6Nh2sJr+8PiA6/7ba7LTa7G4pZjTbOR4YmNUskmD8lL8UkbXZNIVVTS6X7/uKiNCgLp9WBydHMTIt1m/7LtU0tfHp9hI+3W5+caHoXFJ0qEdnfHU33/5aKTqU4EezJTZbfbf4wQyRocG8ct1kBvTx/phrwr+F+PiTf1f8O/qTmK/3L3Fm8eGOlmZJiQnnH1dN9HYYws/5cxNlkCIyv3X+mFQSo09lf0UD7+QUss2HK9P9pTjP3UanxzFxQDwbfaQviPA//l60LE8wfiosOIiZQ5NZMC2T926dzplumNPcDP5ehuyqq6YM9HYIwo/1tiOur5AEEwBCgy0887NJJEX73qyJqXGem9jLF/WXehjhgkwfmDvJFZJgAkR4SBDnnpLq7TB+IMhyct9ilQ3+MSip8E0DEuUJRviIu88eSkpMmLfDOE6Fn4z6bJYWq390iBW+KS7Cf1qLtkcSTABJiQ3n52dmeTuM43h6hANfMzip50OvCBEoJMEEmMuy+xMe4jv/rQ/MHentELwqKyWak7CVthCAJJiAExEaxKmDEr0dBgD3zRneqyHSA0l4iGOaByF6w99vHUkwAWhGlvcTzOWT+3PrGUO8HYbXNbTa/Ho0XOFd/tShuj2SYALQ6H7umzyqN2YNT+YPF4326amSPaWgFzOjCnGUv/chkwQTgLz5ffmCMWk8feVEnx892RO01vxhyQ5vhyH8VHp8BGl+3o/Mv9OjaNfBSs/PwNcvLpy/XTmBSQPNmd/dH32wqYi1+3xjPnrhf2YOTfL7UgD5munHmlptFNc0oZ0m6LDbNS9+vc+jcVwwJo2P75wpycVJdWMrjyzZ2aNjxmXEkexj/ZiEd8SGBzNvfLq3w3CZS08wSqmHgXmAHSgDrtFaH3baPhlYA1yutX63neMnAS8DEcAnwF3a6a+lUuqXwJ+BZK11hSux+rs2m50dh2tZubOUz3eVUVDReGzq3bEZcZw7qi95JXVsKazmUKVn5vAekx7HfXOGM3Oob46D5k1/+mwXR06Y/bIjoUEWfnfhSK6e6hi3LK+kji93l/Px1sPkFvnnnDLCNW/dNI1R/WK9HYbLXC0ie1xr/SCAUupO4CHgFmM5CHgMWNbJ8c8ANwLf4Ugwc4ClxvH9gXOBgy7G6Je01iileG3tAZ5ZlU9pXUuH851vLaxha6FnRlNWCqYM6sPNZwxh1rBkv3+EN8OGA1X8+7vu3bYpMWE8d/UkJgxIOLZuZFosI9NiueWMIew4XMs7Gw6xePPhH0zX7E3RYcGcPTKFSQMTSI+PILeolhU7S316VG9/EWRRDE727yFijnIpwWitnb9eRXF8/fIdwHvA5PaOVUqlAbFa67XG8qvARRgJBngCuA9Y7EqM/qq0toVbXt/A5kPeH+o92KK4bsYgBiZGcs7IvvSN9e+KRzNZbXZ+92Fut/ZVCj66fUanA4KO6hfL7/udwv3nj+TKF9aSc6DKXaG65LmrJ3FaVtKx5bNH9uXOs7PYeLCa//fJTjb4SJz+yGbXvLK6gJsDoJm/y3UwSqlHlFKHgKtwPMGglEoH5uN4QulIOlDotFxorEMpNQ8o0lpvcTU+f5UaF87TV01koA+MpnreKan8du5IrpoyUJJLF/6+Kr/bUyVnJER0e7Tp0GALd50z1JXQ3GZMetxxyeUopRSTBibwzs3TuPNs34jVXwXK56zLJxil1AqgvWF6H9BaL9ZaPwA8oJS6H7gd+D3wJPBrrbW9p0UoSqlI4Lc4ise6s/9NwE0AAwYM6NG1vKm+xUpDi7XDG0lrzfr9lTx95UQufXY1zW3eGTQxIyGCBy8c5ZVr+5tNB6v42+f5x5ZDgy2cPSKFcf3jGZsRR1xECLe+vvFYK7+s5J6NUzYjK4kJA+LZZPIEZqHBFoamRGMxEsaZI1Jos9r5JLeYJVuL+eW5wzo93mJR3HPOUIqrm3hnQ2Gn+4rjDUmOYurgROaM9r2R0XtDObdAculESg0APtFaj1ZK7QeOZpYkoBG4SWv9odP+acAqrfUIY/kKYBbwd2ClcQxABnAYOFVrXdJZDNnZ2TonJ8ctv4+ZthZWc/0rOYQGWXjrpqnHzRmitWbFzjL+9vkethbW8PBFo9ldUsdraw94PM7hfWN4cWG2zGnSDY2tVi546hv2VzRgUY6Jxm4/K+sHXyDK6pq5/Y1NNFtt/GRSBldPy+zRdT7NLeaW1ze6MXKHmLBg5o5JIyslmtmj+nY4k2J5XUu3W7rZ7Zq/LN/F06v2ujPUgHXrrCHce+5wgrwwPoxSaoPWOtvd53W1FdlQrfUeY3EekAegtR7ktM/LwMfOycXYp1gpVauUmoqjkn8B8Det9TYgxen4AiA7EFqR1TS1sTq/gvve3Uqd0QLsZ//8jpevPZVBSVHsOFzLQ4tzjytnX7a9hKunDvR4gjlrRAqLLh9PTLh/DxfuKY8s2cn+igYGJUXxl8vGMdGp0t5ZSkw4/7llWq+vkxzj/qKTc0am8LsLRnVret6eNKO2WBS/Om8EA/pE8uv3trkSYsDrFxfOXWcP9UpyMZOrrcgeVUoNx9FM+QBGC7LOKKU2a63HG4u38X0z5aV8X8EfMI7Ut/DexkLe21DErtK6H2w/cKSRC576mhGpMWw+VM2JDcU2Hazmr5eN/8FxZkmNDed3F47k/NFpAXezm+XL3eW88d1Bzh6RwqIrJpg6vIe7/0+uO20QD1440tTWgHXK5aMAABjwSURBVD+dPICI0GA2HqgiJEjR2GqjvK6FNXuPHPuidTIbmBjJ69dP8ftxx9rjaiuyS7qxzzUnLI93ep0DjO7i+Mxehud1u0vrePyzXazdd4S65o4/SI2tNjZ2UK5e32KlqrGV9PgIiqrN7d/SLy6cN2+aykA/n0XP0+qbrdx0+mB+PWeE6Uk5yM2J4NZZQzzS1PzH4/rx43H9jltXVtvM//x3O59s67TkO+Bdd9qggC2GlqFiTDSsbwwvLMjGbtfsLqtj44FqXvh6H/t7OADi5oPVjB8Qb2qCSYsL5+2bpwXsjW6m80encsHYNI9cq7NcEBcRQlxECG02O8U1zd06X2yE9/4EpMSG84+rJvHhpiLufWcL1g76eQW6swJ4SgtJMB5gsShGpMYyIjWWivoW/rp8d4+OzzlQyYT+8SzZWmxKfH2iQnnt+imSXHrJ4sGixPaekMJDLPzqvBFcMz2TIIvCbtcszS3hiRW7yS+r7/BcYcEWwoK9Xyxz0YR0woIt3P7mpg47E3cmNjyYcf3jGZUWS1J0GDVNbWwtqqGqoZWUmDASo0NZvfcIhVWeGeGiJ0akxgT0504SjAc1tFh7VVm/Zt8RLppgzrhEUaFBvHztZLJSZGpff2A54RFm6uA+PHbJ2OOKNS0WxQVj05gzOpW31h/kwQ9zf1C3B741FPz5Y9L4fX0LDy3e3q39o8OCuWZ6JuePSWVkamyXSb6qoZVLn13N3nLfmj7h3FMCozlyR2SwSw968ev9lNe19Pi4Q5VNpMSEERrs3v+u0GALLyzMZmxGvFvPK8zj/ARz9ogU3rih4zqzIIviqikDeeKn49udGdHXhvm5eurALr/ohAZbuPn0wXx935nce95wTukX160nyISoUD67+3R+NtW3+sqFufkz7WsC+7fzIeV1LTz/Ve/7A6zbX8UFY9xXzh8TFswLC7KZPuSHPbKF70qKDgXglH6xPHXFhG41Kpg3Pp3HLx33g/XRYd4vHnOmlOKqKR0ngPNO6csX987i/rkjSYgK7fH5g4MsnOLlyfhOVNvc5u0QTCUJxkRW2/e97x/7NI+GVluvz/W3z/dwx1lZZCREuBzXwMRIPvj5dM4YJqMg+5u4iBAGJ0Xx0jWTiepBEdclkzK4ddbxY1uN7+97T64XT8wgKvT4xBcaZOGxS8bw7M8m0S/etfs/08daSFY3BHaC8Z1C2ADzaW4x976zlfH947FYFF/tLnfpfMU1zfxl2W7G948nLiKExlYbCkcxiEUp0uLDmT4kkdfXHuxwwrFgi+LH4/vx0IWjiI/s+TdA4X1KKd64cUqvxqr65exhrMorI6/E0R9r/sQMd4fnsriIEK6fMYinjCF3EiJDeH5BNpMz3TPX0IQB8QxNiWZPJ40fPOlwje81PHAnSTAmyCmo5M43N9Nqs/NNvvsGIFiyrZggi2Ln/83psD7mutMGsWRbMYtW7mHfCRWab988VSYFCwBpcb37Fh8cZOH3PzqFK15Yy4ysJE4f6pvFo32M4q8zhyfzx4vHdntA0O4IDwniPzdP4+JnVve4u4AZthXV0NxmC8hOliAJxu1W7CjlF/9xJBcz3Hvu8E4r+4ODLMwbn86FY/uxdt8RvtpdTovVzrj+cZJcBNOGJDJ7VF8eu2Ssz1XyHzVjaDLv3TqdSQPbH27HVQlRoTx68Rh++vxaU87fE9WNbewprWdMhm/VDbmLJBg3aWix8oclO3lznXnzo91zzjBuOWNwt/YNsihOy0pqd1h1cXK7YcagY08JvsgTTeYnDUzgkokZvLfRu6M9B1sUQ/sGbhcBSTBOWqw2QoMsPfpmV9vcxutrD/DSN/upqDdvxsHR6bE+Mx+I8G9TBid6OwSvCw6y8OefjKW6sZWVeWVeiyMtPjxgi8dAEsxxbn19I+sLKhnQJ5LhqTGM7hfHoOQoEqNCSYgMJS4yhOjQYIqqm9h4sIpPc0v4Ylc5TW29bx3WXdlSvCWEWymluG/OCFbtKjuuI2pkaBBtNjttNvOHrokKDew/wYH92/WA1WZn3f5K6lusbD9cy/bDtby/scjbYR3Tk2HShRDdMzw1hn9cNZEXv97PlsJqzh2Vyh8vGcPavUe46bUNpl8/kJ9eQPrBHLP9cC31Pjx0+OLNRTR74ElJiJPNnNFpvHLdqVw6KYOBiZF8mlvCH5fmeeTagf6ZlicYw66SH87V4kt2l9azYmcpF47t1/XOQogeefjjHby1/pDHr9vZNB6BQBKMYW+5eR2vMhMjmT2qLwlRoRyqbGTJ1mJqe3FjlXRzCHYhRPdYbXYWrdzjleQCUFTdxO7SOob1jfHK9c0mCcZgVoK5b85wbj3j+EmdHrloDPWtVkKDLFQ3trG3vJ7cohq+ya9g08HqDovqNh1qf1IyIUTPbSus4YEPt7G1sMarcSzeXMSvzhvh1RjMIgnGcEq/OFbtKu/VfBQdOe+Uvtw2K+sH6y0WRawx131qXBCpceGclpXEzWcMwW7XbDxYxUOLt7OjuPa441razOm8KUQgstrsfLCpiJU7y9hdWkdNUxtp8eGMSovlSH0rn+8qQ/vAHGcrdpRJggl098wexlkjUvhgUxHbimrYVVLX60r/0GALwRbFpZP69/hYi0WRndmHJXfOYGdxHfnl9ZTVNmOzaxn5WIhuKqtr5vZ/b2Ld/srj1h9paCW3qLaDo7xjX4VvjItmBkkwTsb1j2ecMcKs1pqDlY28vLqAN747SKvV8fQQEqQYlBRFenwEKTHhVNS3oIEhyVGM75/AjKwk4iJDXI5FKcWofrGM6hfr8rmEOJm0Wu1c+6/1bD/sW4mkI202TVOrjYjQwGuyLAmmA0opBiZG8fsfncLNpw/h462HGZUWy4QBCQF5IwgRKBat3O03yeWo9zcVctWUgd4Ow+2kH0w3pMaFc8PMwUzPSpLkIoQPW5VXxjNf9H5iP295ZMlOqhvNG2rKWyTBCCECwtp9R/j5vzfixnY6HtPYauNtLzWVNpMUkQkh/FJhVSPvbihEodhdWseSbcXeDsklrsx466skwQgh/Naraw5Q2eD/RUvp8RHcMHOQt8NwOykiE0L4pYyESF697lTCQ8z9MxZkUZg1N5tScOHYNN6+eeqxvnGBRJ5ghBB+a1RaLIlRYRRVu3du+6jQIM4YnsxPJw9gRlYS9c1WHvool8WbD7v1OnecmcUvzh3u1nP6EkkwQgi/9dWe8h4nl4yECM47JZVpgxNJjA6luc1OWV0z/eIjSIsLR2tIiwsnOOj7J6O4yBD+3/wxfLW7nKrGNrfFPykzsOd5cinBKKUeBuYBdqAMuEZrfdhp+2RgDXC51vrddo6fBLwMRACfAHdp7Ri8QSl1B/BzwAYs0Vrf50qsQojA0txm4/HPdnVr34GJkYxJjyN7YAJXThlIaHDPi9WiwoKZNLAPK3aW9vjYjtTLaMqdelxr/SCAUupO4CHgFmM5CHgMWNbJ8c8ANwLf4Ugwc4ClSqkzcSSucVrrFqVUiotxCiH8WHObjRarnbgIRz3FntI6Hl6ys9MOlRYFPz8zi/kT0hmc7Pq890fHCXSnrYXVXDA2za3n9CUuJRittfP/bhTg3AL9DuA9YHJ7xyql0oBYrfVaY/lV4CJgKXAr8KjWusW4jvcmzRZCeM2WQ9X869v9fGjUfSRGhdJqtVPXxTiBp2b24e7ZQ906fp9Sjqk33Nlq7T85h7hn9rCAndnS5ToYpdQjwAKgBjjTWJcOzDeW200wQDpQ6LRcaKwDGAbMNM7dDNyrtV7fwfVvAm4CGDBggEu/ixDCN1TUt/B//93BR1uOr1Q/0sUf9yHJUTx80WhTBoZVSjF/YgYbD7pv2oyqxjZ2FNcycUCC287pS7pMMEqpFUBqO5se0Fov1lo/ADyglLofuB34PfAk8GuttV31rn1fMNAHmIojQf1HKTX4aP2MM63188DzANnZ2X7Yh1cIcdT+igae+3IvH2wqwq41EwfEM2lgAmHBQRRVN7Fuf2WHlfpzTkll0RXjCQs272lgVJr7B59dnV9x8iYYrfU53TzXGzjqUX4PZANvGcklCZirlLJqrT902r8IyHBazjDWgeNp5n0joaxTStmN85R3MxYhhJ9Zt7+SV9YUcEq/WJ67ehJTBiX+YOw/rTUHjjTy1Z5yPs0tYfXeIwCEh1j482XjTE0uACPTYlAKt84j88m2Em4/a6j7TuhDXG1FNlRrvcdYnAfkAWitBznt8zLw8QnJBa11sVKqVik1FUcl/wLgb8bmD3EUr61SSg0DQoEKV2IVQvi2Uwf14dRBnTfbVUqRmRRFZlIUC6ZlsnJnKXe8uQmFo++K2SJDgxmUFMW+8ga3nTOvpJb6FivRYYHXa8TVLrCPKqVylVJbgXOBu7o6QCm12WnxNuBFIB/Yi6OCH+AlYLBSKhd4C1jYXvGYEOLkdvbIvvz9ygm0WO0UVrm3s2VH+idEuvV8dg2bDlZR29zGzuJaCqsaCZQ/dypQfhFw1MHk5OR4OwwhhIflFtWwp6yO+RMyut7ZRT95djXrC9zbXLlvbBhWmz7WiGFQUhRPXznRYxMOKqU2aK2z3X3ewHsmE0KcdEanxzE6Pc7069jsmrziOreft7S25djrqYP78Mj8MQxxQ98db5MEI4QQ3ZRbVNNlHxxXhIdYWHT5BPrGhpt2DU+S0ZSFEKKbvsk3t63RhP4JAZNcQBKMEEJ021VTBnD2CPNGrtpZUovdH6fk7IAkGCGE6Kb4yFBeXJjNr84zZ4j96sY2yupaut7RT0iCEUKIHlBKcdusIczIcv9wNOeM7EtqnBSRCSHESetoknE3q90eMH1gQBKMEEL0ytj+8W4/5xe7ynknp7DrHf2EJBghhOiF6LBg0kwozvpwc1HXO/kJSTBCCNFL7h42BmD13iMs3+G+WTO9SRKMEEL0Ur94cyrkf/7vjaze6//j+0qCEUKIXuoXH2HKeVutdq7913qe/XIvn+YWc7iDOXB8nQwVI4QQvRRk6dWEit3SYrXz6NI8ACzKMXL0wmmZnJaVSC8ncvQ4STBCCNFLcREhHrmOXcPyHaUs31HKqZl9uG/OcLIzO587xxdIghFCiF6w2TWbD1V7/LrrCiq59Nk1zByaxJRBfThnVF9GpHpmWP+ekjoYIYToof0VDdz4ag4fby32Wgxf76ngz8t2c8FT37CtsMZrcXRGnmCEEKIHNh2sYv4/Vns7jGNsds36gkrGZJg/H05PyROMEEL0QHJMGJdMzCA6zDe+n4cGWZg/Id3bYbRLEowQQvRARkIkf7lsHGt/ezYPzB1JaJB3/4yeMyqFhKhQr8bQEUkwQgjRC9Fhwdx4+mD+duUEr8Zx7WmDvHr9zkiCEUIIF5x3SiqXZWd45dqzR/Ule2CCV67dHZJghBDCRQ9fNJqzTJzpsj2RoUE8evEYn+50KQlGCCFcFBYcxD8XZnP6sGSPXfPyyQNIjA7z2PV6QxKMEEK4gVKKB+aOZGhKtEeud9c5Qz1yHVdIghFCCDeob7HybX4FQ5LNTzAXT0z3mWbSnfH9CIUQwodVNbSydt8RFq3cQ15JnanXGpMex/3nj2B6VpKp13EXSTBCCNELtc1t/G3lHl5eXUCbTXe5//j+8Vw+uT9D+0bTPyESu3YMObN8RykfbCqkqrGtw2PT4yO4b85wfjS2HxYTR3B2N5cSjFLqYWAeYAfKgGu01oedtk8G1gCXa63fbef4ScDLQATwCXCX1lorpcYDzwLhgBW4TWu9zpVYhRDCXfaU1vGzf35HaW1Lt/Y/fVgy/7pm8g+G90+NC2fakETunj2UV1cX8PLqAirqW49tz0iIYOG0TK6eNpDwkCC3/g6eoLTuOvN2eLBSsVrrWuP1ncAorfUtxnIQsBxoBl7qIMGsA+4EvsORYJ7SWi9VSi0DnjBezwXu01rP6iqe7OxsnZOT0+vfRwghurK/ooEHP8xl6uA+zBqeQnJMGDkFVdS3tFFS00JVYyuNrVaiw0IYnBzFhAHxjEqL7VZz4uY2G9/sqaCh1cqwvjGMSI3xSDNkpdQGrXW2u8/r0hPM0eRiiAKcs9UdwHvA5PaOVUqlAbFa67XG8qvARcBS4zxHx5+OAw63dw4hhPA0rTUvXzuZYKchYi4Ym+aWc4eHBHHOqL5uOZcvcLkORin1CLAAqAHONNalA/ON5XYTDJAOFDotFxrrAO4GPlNK/RlHS7fprsYphBDuMNgDrcQCRZfNlJVSK5RSue38zAPQWj+gte4PvAHcbhz2JPBrrbW9l3HdCtxjnPce4J+dxHeTUipHKZVTXl7ey8sJIYRwN5fqYI47kVIDgE+01qOVUvuBowWHSUAjcJPW+kOn/dOAVVrrEcbyFcAsrfXNSqkaIN6o8FdAjda6yynbpA5GCCF6zqw6GJc6WiqlnLuSzgPyALTWg7TWmVrrTOBdHK3APnQ+VmtdDNQqpaYaSWQBsNjYfBg4w3h9FrDHlTiFEEJ4nqt1MI8qpYbjaKZ8ALilqwOUUpu11uONxdv4vpnyUuMH4EZgkVIqGEcrtJtcjFMIIYSHua2IzBdIEZkQQvScTxaRCSGEEB2RBCOEEMIUAVVEppQqx1EX1BtJQIUbw/EUf4xbYvYcf4xbYvaco3EP1Fq7fTKbgEowrlBK5ZhRBmk2f4xbYvYcf4xbYvYcs+OWIjIhhBCmkAQjhBDCFJJgvve8twPoJX+MW2L2HH+MW2L2HFPjljoYIYQQppAnGCGEEKYImASjlHpJKVWmlMp1WjdOKbVGKbVNKfVfpVS7A2a2d6yx/nGlVJ5SaqtS6gOlVLyxPlMp1aSU2mz8POtDMf+PUqrIKba5TtvuV0rlK6V2KaXO86GY33aKt0AptdlY75b32ZW4lVL9lVKrlFI7lFLblVJ3OW3ro5RarpTaY/ybYKxXSqmnjPd6q1Jqog/F7JP3dBcxm3pPmxi3qfe1CzGHK6XWKaW2GDH/r9O2QUqp74z39G2lVKixPsxYzje2Z3YrSK11QPwApwMTgVyndeuBM4zX1wEPd/dYY/25QLDx+jHgMeN15on7+lDM/wPc287+o4AtQBgwCNgLBPlCzCfs8xfgIXe+z67EDaQBE43XMcBuHDO3AvwJ+I3x+jdO98dcHOPqKWAq8J0PxeyT93QXMZt6T5sVt9n3tQsxKyDaeB2CY0bhqcbyf3BMcQ+OaetvNV7fBjxrvL4ceLtbMbr6S/rSz4n/cTgmQTtaz9Qf2NHdY9vZPh94w503iBkxd/JhvB+432n5M2CaL8TstE0Bh4Ch7n6fXY3b6ZjFwGzj9S4gzXidBuwyXj8HXOF0zLH9vB2zr9/THbzPpt/TZr7XZt7XrsYMRAIbgSlGnBV8/wVkGvDZie8tjkGSK45ep7OfgCki68B2HNMIAPwExxveW9fx/WjPAIOUUpuUUl8qpWa6cN4TuSPm240ikJeOFtvgmC30kNM+zjOIuspd7/NMoFRr7Tw9g1nvM/QwbqNYYAKOb3wAfbVj2gmAEuDoXLc+8163E7Mzn7ynO4jZ0/c0uO+99uR93a2YlVJBRpFdGbBca/0dkAhUa62txm7O7+ex99rYXmPs36lATzDXAbcppTbgeHxt7c1JlFIPAFYcs3YCFAMDtNYTgF8A/26vrLOXXI35GWAIMN6I8y9uiqszbnmfgSuAN52WzXyfoQdxK6WigfeAu7XWtSdu146vdp5okumWmH31nu4gZm/c0+C++8OT93W3YtZa27Rj2pQM4FSl1Gg3Xf84rs4H49O01nk4ypxRSg0DLujpOZRS1wAXAmcbf0TQWrcALcbrDUqpvcAwwOW5AlyNWWtd6hT7C8DHxmIRx3+byTDWucxN73MwcDEwyem8pr3Pxjm7FbdSKgTHH483tNbvO20qVUqlaa2LlWOG1jJjvdff605i9tl7uqOYvXFPuyNuY5tH7+uefha11tVKqVXAHByJO14pFWw8pTi/n0ff60Ljd4oDjnQVT0A/wSilUox/LcDvcFRa9eT4OcB9wI+11o1O65OVUkHG68HAUGCfj8Sc5rQ4HzjawuQj4HKjNcggHDGvcz1i12M2nAPkaa0Lnc5r2vtsnLPLuJVSCvgnsFNr/dcTNn8ELDReL+T7GVk/AhYoh6k4pvwuxg1cjdlX7+kuYvb4Pe2OuA0eva+7GXOy+r71YAQw24hRA6uAS41dT7ynj97rlwKfH/1y0il3VDT5wg+OR9BioA1H2eH1wF04WnXsBh7l+8qvfsAnnR1rrM/HUe642fg52oriEhxlnZtxVJD9yIdifg3YBmw1boo0p2MewNHSZhdwvq/EbGx7GbjlhGu55X12JW5gBo6ir61O98FcY1sisBLHlN4rgD7GegU8bbzX24BsH4rZJ+/pLmI29Z42K26z72sXYh4LbDJizsVo3WZsG4wjSecD7wBhxvpwYznf2D64OzFKT34hhBCmCOgiMiGEEN4jCUYIIYQpJMEIIYQwhSQYIYQQppAEI4QQwhSSYIQQQphCEowQQghTSIIRQghhiv8PQ1W6z7OdNmoAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "dam_gdf.plot();"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
-    "add_nominal_water = VectorToRaster(dam_gdf, (FeatureType.MASK_TIMELESS, 'NOMINAL_WATER'), values=1, \n",
-    "                                   raster_shape=(FeatureType.MASK, 'IS_DATA'), raster_dtype=np.uint8)"
+    "add_nominal_water = VectorToRasterTask(\n",
+    "    dam_gdf, (FeatureType.MASK_TIMELESS, 'NOMINAL_WATER'), values=1, \n",
+    "    raster_shape=(FeatureType.MASK, 'IS_DATA'), raster_dtype=np.uint8\n",
+    ")"
    ]
   },
   {
@@ -306,7 +286,7 @@
     "def calculate_coverage(array):\n",
     "    return 1.0 - np.count_nonzero(array) / np.size(array)\n",
     "\n",
-    "class AddValidDataCoverage(EOTask):\n",
+    "class AddValidDataCoverageTask(EOTask):\n",
     "    \n",
     "    def execute(self, eopatch):\n",
     "        \n",
@@ -316,10 +296,10 @@
     "        coverage = np.apply_along_axis(calculate_coverage, 1,\n",
     "                                       valid_data.reshape((time, height * width * channels)))\n",
     "        \n",
-    "        eopatch.add_feature(FeatureType.SCALAR, 'COVERAGE', coverage[:, np.newaxis])\n",
+    "        eopatch[FeatureType.SCALAR, 'COVERAGE'] = coverage[:, np.newaxis]\n",
     "        return eopatch\n",
     "    \n",
-    "add_coverage = AddValidDataCoverage()"
+    "add_coverage = AddValidDataCoverageTask()"
    ]
   },
   {
@@ -363,12 +343,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class WaterDetector(EOTask):\n",
+    "class WaterDetectionTask(EOTask):\n",
     "    \n",
     "    @staticmethod\n",
     "    def detect_water(ndwi):\n",
-    "        \"\"\"\n",
-    "        Very simple water detector based on Otsu thresholding method of NDWI.\n",
+    "        \"\"\" Very simple water detector based on Otsu thresholding method of NDWI.\n",
     "        \"\"\"\n",
     "        otsu_thr = 1.0\n",
     "        if len(np.unique(ndwi)) > 1:\n",
@@ -386,12 +365,12 @@
     "        water_levels = np.asarray([np.count_nonzero(mask)/np.count_nonzero(eopatch.mask_timeless['NOMINAL_WATER']) \n",
     "                                   for mask in water_masks])\n",
     "        \n",
-    "        eopatch.add_feature(FeatureType.MASK, 'WATER_MASK', water_masks)\n",
-    "        eopatch.add_feature(FeatureType.SCALAR, 'WATER_LEVEL', water_levels[...,np.newaxis])\n",
+    "        eopatch[FeatureType.MASK, 'WATER_MASK'] = water_masks\n",
+    "        eopatch[FeatureType.SCALAR, 'WATER_LEVEL'] = water_levels[...,np.newaxis]\n",
     "        \n",
     "        return eopatch\n",
     "    \n",
-    "water_detection = WaterDetector()"
+    "water_detection = WaterDetectionTask()"
    ]
   },
   {
@@ -407,8 +386,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "workflow = LinearWorkflow(download_task, calculate_ndwi, add_nominal_water, add_valid_mask,\n",
-    "                          add_coverage, remove_cloudy_scenes, water_detection)"
+    "workflow = LinearWorkflow(\n",
+    "    download_task,\n",
+    "    calculate_ndwi,\n",
+    "    add_nominal_water,\n",
+    "    add_valid_mask,\n",
+    "    add_coverage,\n",
+    "    remove_cloudy_scenes,\n",
+    "    water_detection\n",
+    ")"
    ]
   },
   {
@@ -595,7 +581,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -609,9 +595,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Minimal updates just to get the notebooks to work without any kind of deprecation errors.

I marked it as a draft, because if we add new sampling methods, the LULC pipeline notebook needs to be updated again.