### PR TITLE
Remove tzinfo from timestamps and update Landsat8 L1 test

### DIFF
--- a/io/eolearn/io/sentinelhub_process.py
+++ b/io/eolearn/io/sentinelhub_process.py
@@ -110,10 +110,12 @@ class SentinelHubInputBaseTask(EOTask):
         else:
             timestamp = eopatch.timestamp
 
-        if eopatch.timestamp and timestamp:
+        eop_timestamp = [time_point.replace(tzinfo=None) for time_point in timestamp]
+
+        if eopatch.timestamp and eop_timestamp:
             self.check_timestamp_difference(timestamp, eopatch.timestamp)
         elif timestamp:
-            eopatch.timestamp = timestamp
+            eopatch.timestamp = eop_timestamp
 
         requests = self._build_requests(eopatch.bbox, size_x, size_y, timestamp, time_interval)
         requests = [request.download_list[0] for request in requests]

--- a/io/eolearn/tests/test_sentinelhub_process.py
+++ b/io/eolearn/tests/test_sentinelhub_process.py
@@ -448,7 +448,7 @@ class TestSentinelHubInputTaskDataCollections:
             time_interval=time_interval,
             data_size=11,
             timestamp_length=1,
-            stats=[0.2211, 0.2456, 0.1984]
+            stats=[48.4545, 48.4545, 48.7273]
         ),
         IoTestCase(
             name='MODIS',
@@ -568,6 +568,7 @@ class TestSentinelHubInputTaskDataCollections:
         assert data.shape == (test_case.timestamp_length, height, width, test_case.data_size)
 
         timestamps = eopatch.timestamp
+        assert all(timestamp.tzinfo is None for timestamp in timestamps), f'`tzinfo` present in timestamps {timestamps}'
         assert len(timestamps) == test_case.timestamp_length
 
         data = eopatch[(test_case.feature_type, test_case.feature)]


### PR DESCRIPTION
As discussed with @AleksMat, there no little reason to keep `tzinfo` in timestamps when downloading from sentinelhub, and removing this makes it easier to work with.

I also updated the failing Landsat8 test, since the data changed in a recent update.