### PR TITLE
Add a temporary fix for LANDSAT collections

### DIFF
--- a/io/eolearn/io/sentinelhub_process.py
+++ b/io/eolearn/io/sentinelhub_process.py
@@ -411,8 +411,7 @@ class SentinelHubInputTask(SentinelHubInputBaseTask):
         :type data_source: DataCollection
         """
         super().__init__(data_collection=data_collection, size=size, resolution=resolution, cache_folder=cache_folder,
-                         config=config, max_threads=max_threads, data_source=data_source
-        )
+                         config=config, max_threads=max_threads, data_source=data_source)
         self.evalscript = evalscript
         self.maxcc = maxcc
         self.time_difference = time_difference or dt.timedelta(seconds=1)
@@ -436,9 +435,25 @@ class SentinelHubInputTask(SentinelHubInputBaseTask):
 
         self.additional_data = additional_data
 
-    @staticmethod
-    def _add_request_bands(request_dict, added_bands):
-        predefined_types = SentinelHubInputTask.PREDEFINED_BAND_TYPES.items()
+    def _add_request_bands(self, request_dict, added_bands):
+        handfixed_collections = [
+            DataCollection.LANDSAT_TM_L1, DataCollection.LANDSAT_TM_L2,
+            DataCollection.LANDSAT_ETM_L1, DataCollection.LANDSAT_ETM_L2,
+            DataCollection.LANDSAT_OT_L1, DataCollection.LANDSAT_OT_L2,
+            DataCollection.LANDSAT_MSS_L1,
+        ]
+
+        if self.data_collection in handfixed_collections:
+            types = SentinelHubInputTask.PREDEFINED_BAND_TYPES.copy()
+            old = ProcApiType("bands", 'DN', 'UINT16', np.uint16, FeatureType.DATA)
+            new = ProcApiType("bands", 'REFLECTANCE', 'FLOAT32', np.float32, FeatureType.DATA)
+            types[new] = types[old]
+            del types[old]
+
+            predefined_types = types.items()
+
+        else:
+            predefined_types = SentinelHubInputTask.PREDEFINED_BAND_TYPES.items()
 
         for band in added_bands:
             found = next(((btype, band) for btype, bands in predefined_types if band in bands), None)

--- a/io/eolearn/tests/test_sentinelhub_process.py
+++ b/io/eolearn/tests/test_sentinelhub_process.py
@@ -448,7 +448,7 @@ class TestSentinelHubInputTaskDataCollections:
             time_interval=time_interval,
             data_size=11,
             timestamp_length=1,
-            stats=[48.4545, 48.4545, 48.7273]
+            stats=[48.7592, 48.726, 48.9168]
         ),
         IoTestCase(
             name='MODIS',


### PR DESCRIPTION
Sentinel Hub Service recently changes the units of the Landsat collections. This makes `SentinelHubInputTask` unusable for Landsat collections (as seen [here](https://github.com/sentinel-hub/sentinelhub-py/issues/209)).

This is a temporary fix (since a proper fix requires large changes to sentinelhub-py) that manually changes the types used when a landasat collection is selected.

Also fixes a pycodestyle error (line 414) that has bothered me for a while.