### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -15,7 +15,16 @@ jobs:
           - '3.8'
           - '3.9'
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out current branch in case of a push event
+        if: github.event_name == 'push'
+        uses: actions/checkout@v2
+
+      - name: Check out develop branch in case of a scheduled event
+        if: github.event_name == 'schedule'
+        uses: actions/checkout@v2
+        with:
+          ref: develop
+
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,5 +13,5 @@ run_sh_integration_tests:
     - pip install -r requirements-dev.txt --upgrade
     - FORCE_CYTHON=1 pip install cartopy  # temporary fix for cartopy==0.19.0
     - python install_all.py
-    - sentinelhub.config --sh_client_id "$SH_CLIENT_ID" --sh_client_secret "$SH_CLIENT_SECRET"
+    - sentinelhub.config --sh_client_id "$SH_CLIENT_ID" --sh_client_secret "$SH_CLIENT_SECRET" > /dev/null  # Gitlab can't mask SH_CLIENT_SECRET in logs
     - pytest -m sh_integration

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,32 @@
 # Makefile for creating a new release of the package and uploading it to PyPI
 
 PYTHON = python3
-PACKAGES = core coregistration features geometry io mask ml_tools
+PACKAGES = core coregistration features geometry io mask ml_tools visualization
 PYLINT = pylint
 
 .PHONY: $(PACKAGES:test)
+.SILENT: pylint pylint-fast
 
 help:
 	@echo "Use 'make upload-<package>' to upload the package to PyPi"
 	@echo "Use 'make pylint' to run pylint on the code of all subpackages"
 
 pylint:
-	$(PYLINT) core/eolearn/core/*.py
-	$(PYLINT) coregistration/eolearn/coregistration/*.py
-	$(PYLINT) features/eolearn/features/*.py
-	$(PYLINT) geometry/eolearn/geometry/*.py
-	$(PYLINT) io/eolearn/io/*.py
-	$(PYLINT) mask/eolearn/mask/*.py
-	$(PYLINT) ml_tools/eolearn/ml_tools/*.py
-	$(PYLINT) visualization/eolearn/visualization/*.py
+	# Runs pylint on all subpackages consecutively and makes sure any error status code gets propagated.
+	export PYLINT_STATUS=0
+	for package in $(PACKAGES) ; do \
+    	$(PYLINT) $$package/eolearn/$$package || export PYLINT_STATUS=$$?; \
+	done;
+	exit $$PYLINT_STATUS
+
+
+pylint-fast:
+	# Runs pylint on all subpackages in parallel. Because of that output verdicts are not in the order of package
+	# names and this process cannot be interrupted.
+	for package in $(PACKAGES) ; do \
+    	$(PYLINT) $$package/eolearn/$$package & \
+	done;
+	wait
 
 .ONESHELL:
 build-core:

--- a/io/eolearn/tests/test_sentinelhub_process.py
+++ b/io/eolearn/tests/test_sentinelhub_process.py
@@ -539,8 +539,8 @@ class TestSentinelHubInputTaskDataCollections:
             bbox=bbox,
             time_interval=('2021-02-10', '2021-02-15'),
             data_size=3,
-            timestamp_length=14,
-            stats=[0.4236, 0.6353, 0.5117]
+            timestamp_length=13,
+            stats=[0.4236, 0.6339, 0.5117]
         ),
         IoTestCase(
             name='Sentinel-5P',

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ pytest>=4.0.0
 pytest-mock
 pytest-cov
 codecov
-pylint
+pylint==2.10.2
 hypothesis
 twine
 scikit-image>=0.14.1


### PR DESCRIPTION
Fixes a few issues in CI:

- Switches scheduled (i.e. cron job) testing from master to develop branch. This way we don't have to push to master whenever any minor tests start failing.
- Sets pylint to a fixed older version because clearly `2.11` has some issues.
- Updates Makefile pylint command to correctly propagate a status code.
- Suppresses info about setting SH credentials during Gitlab CI runs.
- Updates a failing integration test.