### PR TITLE
Prevent loading lazy-loaded features when EOPatch is copied

### DIFF
--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -279,7 +279,7 @@ class EOPatch:
                 value = self[feature_type].__getitem__(feature_name, load=False)
 
                 if isinstance(value, FeatureIO):
-                    # We cannot copy the entire object because of the filesystem attribute
+                    # We cannot deepcopy the entire object because of the filesystem attribute
                     value = copy.copy(value)
                     value.loaded_value = copy.deepcopy(value.loaded_value, memo=memo)
                 else:

--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -242,8 +242,8 @@ class FeatureIO:
         return f'{self.__class__.__name__}({self.path})'
 
     def load(self):
-        """ Method for loading a feature. Loaded value is stored into an attribute in case the same value would have
-        to be loaded again from a this FeatureIO inside a shallow-copied EOPatch.
+        """ Method for loading a feature. The loaded value is stored into an attribute in case a second load request is
+        triggered inside a shallow-copied EOPatch.
         """
         if self.loaded_value is not None:
             return self.loaded_value

--- a/core/eolearn/tests/test_eodata.py
+++ b/core/eolearn/tests/test_eodata.py
@@ -241,28 +241,34 @@ class TestEOPatch(unittest.TestCase):
 
     def test_copy_lazy_loaded_patch(self):
         path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../example_data/TestEOPatch')
-        original_eopatch = EOPatch.load(path, lazy_loading=True)
-        copied_eopatch = original_eopatch.copy()
+        for features in (..., [(FeatureType.MASK, 'CLM')]):
+            original_eopatch = EOPatch.load(path, lazy_loading=True)
+            copied_eopatch = original_eopatch.copy(features=features)
 
-        value1 = original_eopatch.mask.__getitem__('CLM', load=False)
-        assert isinstance(value1, FeatureIO)
-        value2 = copied_eopatch.mask.__getitem__('CLM', load=False)
-        assert isinstance(value2, FeatureIO)
-        assert id(value1) == id(value2)
+            value1 = original_eopatch.mask.__getitem__('CLM', load=False)
+            assert isinstance(value1, FeatureIO)
+            value2 = copied_eopatch.mask.__getitem__('CLM', load=False)
+            assert isinstance(value2, FeatureIO)
+            assert value1 is value2
 
-        mask1 = original_eopatch.mask['CLM']
-        mask2 = copied_eopatch.mask['CLM']
-        assert isinstance(mask1, np.ndarray)
-        assert id(mask1) == id(mask2)
+            mask1 = original_eopatch.mask['CLM']
+            assert copied_eopatch.mask.__getitem__('CLM', load=False).loaded_value is not None
+            mask2 = copied_eopatch.mask['CLM']
+            assert isinstance(mask1, np.ndarray)
+            assert mask1 is mask2
 
-        original_eopatch = EOPatch.load(path, lazy_loading=True)
-        copied_eopatch = original_eopatch.copy(deep=True)
+            original_eopatch = EOPatch.load(path, lazy_loading=True)
+            copied_eopatch = original_eopatch.copy(features=features, deep=True)
 
-        value1 = original_eopatch.mask.__getitem__('CLM', load=False)
-        assert isinstance(value1, FeatureIO)
-        value2 = copied_eopatch.mask.__getitem__('CLM', load=False)
-        assert isinstance(value2, FeatureIO)
-        assert id(value1) != id(value2)
+            value1 = original_eopatch.mask.__getitem__('CLM', load=False)
+            assert isinstance(value1, FeatureIO)
+            value2 = copied_eopatch.mask.__getitem__('CLM', load=False)
+            assert isinstance(value2, FeatureIO)
+            assert value1 is not value2
+            mask1 = original_eopatch.mask['CLM']
+            assert copied_eopatch.mask.__getitem__('CLM', load=False).loaded_value is None
+            mask2 = copied_eopatch.mask['CLM']
+            assert np.array_equal(mask1, mask2) and mask1 is not mask2
 
     def test_remove_feature(self):
         bands = np.arange(2*3*3*2).reshape(2, 3, 3, 2)

--- a/features/eolearn/tests/test_blob.py
+++ b/features/eolearn/tests/test_blob.py
@@ -18,6 +18,7 @@ from numpy.testing import assert_array_equal
 from skimage.feature import blob_dog
 
 from eolearn.core import FeatureType
+from eolearn.core.eodata_io import FeatureIO
 from eolearn.features import BlobTask, DoGBlobTask, LoGBlobTask, DoHBlobTask
 
 
@@ -54,6 +55,8 @@ def test_haralick(eopatch, task, expected_min, expected_max, expected_mean, expe
 
     # Test that no other features were modified
     for feature, value in initial_patch.data.items():
+        if isinstance(value, FeatureIO):
+            value = value.load()
         assert_array_equal(value, eopatch.data[feature], err_msg=f"EOPatch data feature '{feature}' has changed")
 
     delta = 1e-4

--- a/features/eolearn/tests/test_haralick.py
+++ b/features/eolearn/tests/test_haralick.py
@@ -14,6 +14,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from eolearn.core import FeatureType
+from eolearn.core.eodata_io import FeatureIO
 from eolearn.features import HaralickTask
 
 
@@ -54,6 +55,8 @@ def test_haralick(eopatch, task, expected_min, expected_max, expected_mean, expe
 
     # Test that no other features were modified
     for feature, value in initial_patch.data.items():
+        if isinstance(value, FeatureIO):
+            value = value.load()
         assert_array_equal(value, eopatch.data[feature], err_msg=f"EOPatch data feature '{feature}' has changed")
 
     delta = 1e-4

--- a/features/eolearn/tests/test_hog.py
+++ b/features/eolearn/tests/test_hog.py
@@ -14,6 +14,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from eolearn.core import FeatureType
+from eolearn.core.eodata_io import FeatureIO
 from eolearn.features import HOGTask
 
 
@@ -36,6 +37,8 @@ def test_hog(eopatch):
 
     # Test that no other features were modified
     for feature, value in initial_patch.data.items():
+        if isinstance(value, FeatureIO):
+            value = value.load()
         assert_array_equal(value, eopatch.data[feature], err_msg=f"EOPatch data feature '{feature}' has changed")
 
     delta = 1e-4

--- a/features/eolearn/tests/test_local_binary_pattern.py
+++ b/features/eolearn/tests/test_local_binary_pattern.py
@@ -15,6 +15,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from eolearn.core import FeatureType
+from eolearn.core.eodata_io import FeatureIO
 from eolearn.features import LocalBinaryPatternTask
 
 
@@ -38,6 +39,8 @@ def test_local_binary_pattern(eopatch, task, expected_min, expected_max, expecte
 
     # Test that no other features were modified
     for feature, value in initial_patch.data.items():
+        if isinstance(value, FeatureIO):
+            value = value.load()
         assert_array_equal(value, eopatch.data[feature], err_msg=f"EOPatch data feature '{feature}' has changed")
 
     delta = 1e-4

--- a/features/eolearn/tests/test_radiometric_normalization.py
+++ b/features/eolearn/tests/test_radiometric_normalization.py
@@ -15,6 +15,7 @@ import pytest
 from pytest import approx
 
 from eolearn.core import FeatureType
+from eolearn.core.eodata_io import FeatureIO
 from eolearn.mask import MaskFeature
 from eolearn.features import (
     ReferenceScenesTask, BlueCompositingTask, HOTCompositingTask, MaxNDVICompositingTask, MaxNDWICompositingTask,
@@ -100,6 +101,8 @@ def test_haralick(eopatch, task, test_feature, expected_min, expected_max, expec
 
     # Test that no other features were modified
     for feature, value in initial_patch.data.items():
+        if isinstance(value, FeatureIO):
+            value = value.load()
         assert_array_equal(value, eopatch.data[feature], err_msg=f"EOPatch data feature '{feature}' has changed")
 
     assert isinstance(eopatch.timestamp, list), "Expected a list of timestamps"


### PR DESCRIPTION
Notes:

- Meta-features (BBOX, TIMESTAMP, META_INFO) are never being lazy-loaded, so I didn't have any complications with them.
- I'm not very happy that the implementation of `__deepcopy__` has now some code duplications with  `__copy__`. But I had to do it this way because `FeatureIO` objects cannot be simply deep-copied because they contain unpicklable filesystem object.