### PR TITLE
Make merge functionality work with lazy loading

### DIFF
--- a/core/eolearn/core/eodata_merge.py
+++ b/core/eolearn/core/eodata_merge.py
@@ -183,8 +183,8 @@ def _extract_and_join_time_dependent_feature_values(eopatches, feature, order_ma
     feature_type, feature_name = feature
 
     for eopatch, order_mask in zip(eopatches, order_mask_per_eopatch):
-        array = eopatch[feature_type].get(feature_name)
-        if array is not None:
+        if feature_name in eopatch[feature_type]:
+            array = eopatch[feature_type, feature_name]
             if order_mask.size != array.shape[0]:
                 raise ValueError(f'Cannot merge a time-dependent feature {feature} because time dimension of an array '
                                  f'in one EOPatch is {array.shape[0]} but EOPatch has {order_mask.size} timestamps')

--- a/core/eolearn/tests/test_eodata_merge.py
+++ b/core/eolearn/tests/test_eodata_merge.py
@@ -7,6 +7,7 @@ Copyright (c) 2017-2020 Nejc Vesel, Jovan Višnjić, Anže Zupanc (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+import os
 import unittest
 import logging
 import datetime as dt
@@ -15,12 +16,15 @@ import numpy as np
 from geopandas import GeoDataFrame
 
 from sentinelhub import BBox, CRS
-from eolearn.core import EOPatch
+from eolearn.core import EOPatch, FeatureType
+from eolearn.core.eodata_io import FeatureIO
 
 logging.basicConfig(level=logging.INFO)
 
 
 class TestEOPatchMerge(unittest.TestCase):
+
+    PATCH_FILENAME = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../example_data/TestEOPatch')
 
     def test_time_dependent_merge(self):
         all_timestamps = [dt.datetime(2020, month, 1) for month in range(1, 7)]
@@ -206,6 +210,15 @@ class TestEOPatchMerge(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             eop1.merge(eop2)
+
+    def test_lazy_loading(self):
+        eop1 = EOPatch.load(self.PATCH_FILENAME, lazy_loading=True)
+        eop2 = EOPatch.load(self.PATCH_FILENAME, lazy_loading=True)
+
+        eop = eop1.merge(eop2, features=(FeatureType.MASK, ...))
+        assert isinstance(eop.mask.get('CLM'), np.ndarray)
+        assert isinstance(eop1.mask.get('CLM'), np.ndarray)
+        assert isinstance(eop1.mask_timeless.get('LULC'), FeatureIO)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In the current implementation the merge functions use direct `get` access in a feature dict, bypassing the mechanisms for loading features. This can be fixed by restructuring the control flow just a bit.