### PR TITLE
Update meta_info handling to ensure serialization

### DIFF
--- a/features/eolearn/features/feature_manipulation.py
+++ b/features/eolearn/features/feature_manipulation.py
@@ -16,7 +16,6 @@ import datetime as dt
 
 import numpy as np
 
-from sentinelhub import parse_time_interval
 from eolearn.core import EOTask, FeatureType
 from eolearn.core.utilities import renamed_and_deprecated
 

--- a/features/eolearn/features/feature_manipulation.py
+++ b/features/eolearn/features/feature_manipulation.py
@@ -104,16 +104,6 @@ class FilterTimeSeriesTask(SimpleFilterTask):
 
         super().__init__(FeatureType.TIMESTAMP, lambda date: start_date <= date <= end_date, filter_features)
 
-    def _update_other_data(self, eopatch):
-
-        if 'time_interval' in eopatch.meta_info:
-
-            start_time, end_time = parse_time_interval(eopatch.meta_info['time_interval'])
-            eopatch.meta_info['time_interval'] = (max(start_time, self.start_date),
-                                                  min(end_time, self.end_date))
-
-        return eopatch
-
 
 class ValueFilloutTask(EOTask):
     """ Overwrites occurrences of a desired value with their neighbor values in either forward, backward direction or

--- a/features/eolearn/tests/test_feature_manipulation.py
+++ b/features/eolearn/tests/test_feature_manipulation.py
@@ -40,16 +40,12 @@ def test_content_after_timefilter():
 
     new_timestamps = timestamps[new_start:new_end+1]
 
-    eop = EOPatch(timestamp=timestamps, data={'data': data}, meta_info={'time_interval': old_interval})
+    eop = EOPatch(timestamp=timestamps, data={'data': data})
 
     filter_task = FilterTimeSeriesTask(start_date=new_interval[0], end_date=new_interval[1])
     filter_task.execute(eop)
 
-    updated_interval = eop.meta_info['time_interval']
-    updated_timestamps = eop.timestamp
-
-    assert new_interval == updated_interval
-    assert new_timestamps == updated_timestamps
+    assert new_timestamps == eop.timestamp
 
 
 def test_fill():

--- a/io/eolearn/io/sentinelhub_process.py
+++ b/io/eolearn/io/sentinelhub_process.py
@@ -17,7 +17,7 @@ from eolearn.core import EOPatch, EOTask, FeatureType, FeatureTypeSet
 
 from sentinelhub import (
     DataCollection, MimeType, SHConfig, SentinelHubCatalog, SentinelHubDownloadClient, SentinelHubRequest,
-    bbox_to_dimensions, filter_times, parse_time_interval, Band, Unit
+    bbox_to_dimensions, filter_times, parse_time_interval, serialize_time, Band, Unit
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -131,7 +131,7 @@ class SentinelHubInputBaseTask(EOTask):
         eopatch.meta_info['size_x'] = size_x
         eopatch.meta_info['size_y'] = size_y
         if timestamp:  # do not overwrite time interval in case of timeless features
-            eopatch.meta_info['time_interval'] = time_interval
+            eopatch.meta_info['time_interval'] = serialize_time(time_interval)
 
         self._add_meta_info(eopatch)
 
@@ -155,7 +155,7 @@ class SentinelHubInputBaseTask(EOTask):
         if self.maxcc:
             eopatch.meta_info['maxcc'] = self.maxcc
         if self.time_difference:
-            eopatch.meta_info['time_difference'] = self.time_difference
+            eopatch.meta_info['time_difference'] = self.time_difference.total_seconds()
 
     @staticmethod
     def _check_and_set_eopatch_bbox(bbox, eopatch):


### PR DESCRIPTION
With these changes only SH input tasks add meta_info information and even these make sure that all meta_info content is JSON serializable.