### PR TITLE
Introduce EONodes as EOWorkflow building blocks

### DIFF
--- a/core/eolearn/core/__init__.py
+++ b/core/eolearn/core/__init__.py
@@ -4,7 +4,8 @@ The following objects and functions are the core of eo-learn package
 from .constants import FeatureType, FeatureTypeSet, OverwritePermission
 from .eodata import EOPatch
 from .eotask import EOTask
-from .eoworkflow import EOWorkflow, LinearWorkflow, Dependency, WorkflowResults
+from .eonode import EONode, linearly_connect_tasks
+from .eoworkflow import EOWorkflow, WorkflowResults
 from .eoworkflow_tasks import OutputTask
 from .eoexecution import EOExecutor, execute_with_mp_lock
 

--- a/core/eolearn/core/eoexecution.py
+++ b/core/eolearn/core/eoexecution.py
@@ -94,10 +94,10 @@ class EOExecutor:
         if not isinstance(execution_args, (list, tuple)):
             raise ValueError("Parameter 'execution_args' should be a list")
 
-        for input_args in execution_args:
-            EOWorkflow.validate_input_args(input_args)
+        for input_kwargs in execution_args:
+            EOWorkflow.validate_input_kwargs(input_kwargs)
 
-        return [input_args or {} for input_args in execution_args]
+        return [input_kwargs or {} for input_kwargs in execution_args]
 
     @staticmethod
     def _parse_execution_names(execution_names, execution_args):

--- a/core/eolearn/core/eonode.py
+++ b/core/eolearn/core/eonode.py
@@ -1,0 +1,93 @@
+"""
+This module implements the EONode class, which specifies the local dependencies of an EOWorkflow
+"""
+
+import datetime as dt
+from dataclasses import dataclass, field
+from typing import Sequence, Optional, List, Tuple, Union, Set, Dict
+
+from .eotask import EOTask
+from .utilities import generate_uid
+
+
+@dataclass(frozen=True)
+class EONode:
+    """ Class representing a node in EOWorkflow graph
+
+    The object id is kept to help with serialization issues. Tasks created in different sessions have a small chance
+    of having an id clash. For this reason all tasks of a workflow should be created in the same session.
+
+    :param task: An instance of `EOTask` that is carried out at the node when executed
+    :param inputs: A sequence of `EONode` instances whose results this node takes as input
+    :param name: Custom name of the node
+    """
+    task: EOTask
+    inputs: Sequence['EONode'] = field(default_factory=tuple)
+    name: Optional[str] = field(default=None)
+    uid: str = field(init=False, repr=False)
+
+    def __post_init__(self):
+        """ Additionally verifies the parameters and adds a unique id to the node
+        """
+        if not isinstance(self.task, EOTask):
+            raise ValueError(f'Value of `task` should be an instance of {EOTask.__name__}, got {self.task}')
+
+        if not isinstance(self.inputs, Sequence):
+            raise ValueError(f'Value of `inputs` should be a sequence (`list`, `tuple`, ...), got {self.inputs}')
+        for input_node in self.inputs:
+            if not isinstance(input_node, EONode):
+                raise ValueError(f'Values in `inputs` should be instances of {EONode.__name__}, got {input_node}')
+        super().__setattr__('inputs', tuple(self.inputs))
+
+        if self.name is None:
+            super().__setattr__('name', self.task.__class__.__name__)
+
+        super().__setattr__('uid', generate_uid(self.name))
+
+    def get_custom_name(self, number=0):
+        """ Provides custom node name according to the class of the contained task and a given number
+        """
+        if number:
+            return f'{self.name}_{number}'
+        return self.name
+
+    def get_dependencies(self, *, _memo: Optional[Dict['EONode', Set['EONode']]] = None) -> Set['EONode']:
+        """ Returns a set of nodes that this node depends on. Set includes the node itself
+        """
+        _memo = _memo if _memo is not None else {}
+        if self not in _memo:
+            result = {self}.union(*(input_node.get_dependencies(_memo=_memo) for input_node in self.inputs))
+            _memo[self] = result
+
+        return _memo[self]
+
+
+def linearly_connect_tasks(*tasks: Union[EOTask, Tuple[EOTask, str]]) -> List[EONode]:
+    """ Creates a list of linearly linked nodes, suitable to construct an EOWorkflow.
+
+    Nodes depend on each other in such a way, that the node containing the task at index `i` is the input node for the
+    node at index `i+1`. Nodes are returned in the order of execution, so the task at index `j` is contained in the node
+    at index `j`, making it easier to construct execution arguments.
+
+    :param tasks: A sequence containing tasks and/or (task, name) pairs
+    """
+    nodes = []
+    endpoint: Sequence[EONode] = tuple()
+    for task_spec in tasks:
+        if isinstance(task_spec, EOTask):
+            node = EONode(task_spec, inputs=endpoint)
+        else:
+            task, name = task_spec
+            node = EONode(task, inputs=endpoint, name=name)
+        nodes.append(node)
+        endpoint = [node]
+
+    return nodes
+
+
+@dataclass(frozen=True)
+class NodeStats:
+    """ An object containing statistical info about a node execution
+    """
+    start_time: dt.datetime
+    end_time: dt.datetime

--- a/core/eolearn/core/eoworkflow_tasks.py
+++ b/core/eolearn/core/eoworkflow_tasks.py
@@ -1,38 +1,53 @@
 """
 Module implementing tasks that have a special effect in `EOWorkflow`
 """
+from typing import Optional
 from .eotask import EOTask
 from .eodata import EOPatch
+from .utilities import generate_uid
+
+
+class InputTask(EOTask):
+    """ Introduces data into an EOWorkflow, where the data can be specified at initialization or at execution
+    """
+    def __init__(self, value: Optional[object] = None):
+        """
+        :param value: Default value that the task should provide as a result. Can be overridden in execution arguments
+        """
+        self.value = value
+
+    def execute(self, *, value: Optional[object] = None) -> object:
+        """
+        :param value: A value that the task should provide as it's result. If not set uses the value from initialization
+        :return: Directly returns `value`
+        """
+        return value or self.value
 
 
 class OutputTask(EOTask):
     """ Stores data as an output of `EOWorkflow` results
     """
-    def __init__(self, name=None, features=...):
+    def __init__(self, name: Optional[str] = None, features=...):
         """
-        :param name: A name under which the data will be saved in `WorkflowResults`
-        :type name: str or None
+        :param name: A name under which the data will be saved in `WorkflowResults`, auto-generated if `None`
         :param features: A collection of features to be kept if the data is an `EOPatch`
         :type features: an object supported by the :class:`FeatureParser<eolearn.core.utilities.FeatureParser>`
         """
-        self._name = name or f'output_{self.private_task_config.uid}'
+        self._name = name or generate_uid('output')
         self.features = features
 
     @property
-    def name(self):
+    def name(self) -> str:
         """ Provides a name under which data will be saved in `WorkflowResults`
 
         :return: A name
-        :rtype: str
         """
         return self._name
 
-    def execute(self, data):
+    def execute(self, data: object) -> object:
         """
         :param data: input data
-        :type data: object
         :return: Same data, to be stored in results (for `EOPatch` returns shallow copy containing only `features`)
-        :rtype: object
         """
         if isinstance(data, EOPatch):
             return data.copy(features=self.features)

--- a/core/eolearn/core/utilities.py
+++ b/core/eolearn/core/utilities.py
@@ -16,6 +16,7 @@ import warnings
 from collections import OrderedDict
 from logging import Filter
 
+import uuid
 import numpy as np
 import geopandas as gpd
 from geopandas.testing import assert_geodataframe_equal
@@ -517,6 +518,17 @@ def constant_pad(X, multiple_of, up_down_rule='even', left_right_rule='even', pa
 def bgr_to_rgb(bgr):
     """Converts Blue, Green, Red to Red, Green, Blue."""
     return bgr[..., [2, 1, 0]]
+
+
+def generate_uid(prefix: str):
+    """ Generates a (sufficiently) unique ID starting with the `prefix`
+
+    The ID is composed from the prefix, a hexadecimal string obtained from the current time and a random hexadecimal
+    string. This makes the uid sufficiently unique.
+    """
+    time_uid = uuid.uuid1(node=0).hex[:-12]
+    random_uid = uuid.uuid4().hex[:12]
+    return f'{prefix}-{time_uid}-{random_uid}'
 
 
 def renamed_and_deprecated(deprecated_class):

--- a/core/eolearn/tests/test_eonode.py
+++ b/core/eolearn/tests/test_eonode.py
@@ -1,0 +1,60 @@
+"""
+Tests the eonode.py module
+"""
+from eolearn.core import EOTask, EONode, linearly_connect_tasks, OutputTask
+
+
+class InputTask(EOTask):
+    def execute(self, *, val=None):
+        return val
+
+
+class DivideTask(EOTask):
+    def execute(self, x, y, *, z=0):
+        return x / y + z
+
+
+class Inc(EOTask):
+    def execute(self, x, *, d=1):
+        return x + d
+
+
+def test_nodes_different_uids():
+    uids = set()
+    for _ in range(5000):
+        node = EONode(Inc())
+        uids.add(node.uid)
+
+    assert len(uids) == 5000, 'Different nodes should have different uids.'
+
+
+def test_get_dependencies():
+    input_node1 = EONode(InputTask())
+    input_node2 = EONode(InputTask(), name='some name')
+    divide_node1 = EONode(DivideTask(), inputs=(input_node1, input_node2), name='some name')
+    divide_node2 = EONode(DivideTask(), inputs=(divide_node1, input_node2), name='some name')
+    output_node = EONode(OutputTask(name='output'), inputs=[divide_node2])
+    all_nodes = {input_node1, input_node2, divide_node1, divide_node2, output_node}
+
+    assert len(output_node.get_dependencies()) == len(all_nodes), "Wrong number of nodes returned"
+
+    assert all_nodes == set(output_node.get_dependencies())
+
+
+def test_linearly_connect_tasks():
+    tasks = [InputTask(), Inc(), (Inc(), "special inc"), Inc(), OutputTask(name='out')]
+    nodes = linearly_connect_tasks(*tasks)
+
+    assert all(isinstance(node, EONode) for node in nodes), "Function does not return EONodes"
+
+    assert len(tasks) == len(nodes), "Function returns incorrect number of nodes"
+
+    pure_tasks = tasks[:]
+    pure_tasks[2] = pure_tasks[2][0]
+    assert all(task == node.task for task, node in zip(pure_tasks, nodes)), "Nodes do not contain correct tasks"
+
+    for i, node in enumerate(nodes):
+        previous_endpoint = () if i == 0 else (nodes[i-1],)
+        assert node.inputs == previous_endpoint, "Nodes are not linked linearly"
+
+    assert nodes[2].name == "special inc", "Names are not handled correctly"

--- a/core/eolearn/tests/test_eotask.py
+++ b/core/eolearn/tests/test_eotask.py
@@ -75,34 +75,6 @@ def test_call_equals_execute():
     assert task(14) == task.execute(14), 't(x) should given the same result as t.execute(x)'
 
 
-def test_task_different_uids():
-    uids = set()
-    for _ in range(5000):
-        task = PlusOneTask()
-        uids.add(task.private_task_config.uid)
-
-    assert len(uids) == 5000, 'Different tasks should have different uids.'
-
-
-def test_task_copy():
-    task1 = PlusConstSquaredTask(12)
-    task2 = SelfRecursiveTask([1, 2, 3], 3, 'apple', this=12, that=task1)
-    assert task1.private_task_config.uid != copy.copy(task1).private_task_config.uid, \
-        'Copied tasks should have different uids.'
-    assert task1.private_task_config.uid != copy.deepcopy(task1).private_task_config.uid, \
-        'Copied tasks should have different uids.'
-
-    assert id(task2.arg_x) == id(copy.copy(task2).arg_x), 'Shallow copies should not recursively copy values.'
-    assert id(task2.kwargs['that']) != id(copy.deepcopy(task2).kwargs['that']), \
-        'Deep copies should recursively copy values.'
-    assert all(x == y for x, y in zip(task2.arg_x, copy.deepcopy(task2).arg_x)), \
-        'Recursively copied values should be copied correctly.'
-
-    deepcopied_task = copy.deepcopy(task2)
-    assert deepcopied_task.private_task_config.uid == deepcopied_task.recursive.private_task_config.uid, \
-        'Recursive copies of same task should have equal uids.'
-
-
 @pytest.mark.parametrize(
     ('parameter', 'exception_type'), [('test_exception_fail', TypeError), ('value_error', ValueError)]
 )

--- a/core/eolearn/tests/test_eoworkflow.py
+++ b/core/eolearn/tests/test_eoworkflow.py
@@ -7,20 +7,17 @@ Copyright (c) 2017-2019 Blaž Sovdat, Nejc Vesel, Jovan Višnjić, Anže Zupanc,
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-import functools
 import concurrent.futures
 import datetime as dt
 
 import pytest
 import numpy as np
-from hypothesis import given, strategies as st
 
 from eolearn.core import (
-    EOPatch, EOTask, EOWorkflow, Dependency, LinearWorkflow, OutputTask, WorkflowResults, FeatureType,
-    InitializeFeatureTask, RemoveFeatureTask
+    EOPatch, EOTask, EONode, EOWorkflow, OutputTask, WorkflowResults, FeatureType, InitializeFeatureTask,
+    RemoveFeatureTask, CreateEOPatchTask
 )
-from eolearn.core.eoworkflow import CyclicDependencyError, TaskStats
-from eolearn.core.graph import DirectedGraph
+from eolearn.core.eoworkflow import NodeStats
 
 
 class InputTask(EOTask):
@@ -44,135 +41,127 @@ class Pow(EOTask):
 
 
 def test_workflow_arguments():
-    input_task1 = InputTask()
-    input_task2 = InputTask()
-    divide_task = DivideTask()
-    output_task = OutputTask(name='output')
+    input_node1 = EONode(InputTask())
+    input_node2 = EONode(InputTask(), name='some name')
+    divide_node = EONode(DivideTask(), inputs=(input_node1, input_node2), name='some name')
+    output_node = EONode(OutputTask(name='output'), inputs=[divide_node])
 
-    workflow = EOWorkflow([
-        (input_task1, []),
-        (input_task2, [], 'some name'),
-        Dependency(task=divide_task, inputs=[input_task1, input_task2], name='some name'),
-        (output_task, [divide_task])
-    ])
+    workflow = EOWorkflow([input_node1, input_node2, divide_node, output_node])
 
     with concurrent.futures.ProcessPoolExecutor(max_workers=5) as executor:
         k2future = {
             k: executor.submit(
-                workflow.execute, {input_task1: {'val': k ** 3}, input_task2: {'val': k ** 2}}
+                workflow.execute, {input_node1: {'val': k ** 3}, input_node2: {'val': k ** 2}}
             ) for k in range(2, 100)
         }
         executor.shutdown()
         for k in range(2, 100):
             assert k2future[k].result().outputs['output'] == k
 
-    result1 = workflow.execute({input_task1: {'val': 15}, input_task2: {'val': 3}})
+    result1 = workflow.execute({input_node1: {'val': 15}, input_node2: {'val': 3}})
     assert result1.outputs['output'] == 5
 
-    result2 = workflow.execute({input_task1: {'val': 6}, input_task2: {'val': 3}})
+    result2 = workflow.execute({input_node1: {'val': 6}, input_node2: {'val': 3}})
     assert result2.outputs['output'] == 2
 
-    result3 = workflow.execute({input_task1: {'val': 6}, input_task2: {'val': 3}, divide_task: {'z': 1}})
-    assert result3.outputs[output_task.name] == 3
+    result3 = workflow.execute({input_node1: {'val': 6}, input_node2: {'val': 3}, divide_node: {'z': 1}})
+    assert result3.outputs[output_node.task.name] == 3
 
 
-def test_linear_workflow():
-    in_task, in_task_name = InputTask(), 'My input task'
-    inc_task1 = Inc()
-    inc_task2 = Inc()
-    pow_task = Pow()
-    output_task = OutputTask(name='output')
+def test_get_nodes():
+    in_node = EONode(InputTask())
+    inc_node0 = EONode(Inc(), inputs=[in_node])
+    inc_node1 = EONode(Inc(), inputs=[inc_node0])
+    inc_node2 = EONode(Inc(), inputs=[inc_node1])
+    output_node = EONode(OutputTask(name='out'), inputs=[inc_node2])
 
-    eow = LinearWorkflow((in_task, in_task_name), inc_task1, inc_task2, pow_task, output_task)
-    res = eow.execute({in_task: {'val': 2}, inc_task1: {'d': 2}, pow_task: {'n': 3}})
-    assert res.outputs['output'] == (2 + 2 + 1) ** 3
+    eow = EOWorkflow([in_node, inc_node0, inc_node1, inc_node2, output_node])
 
-    task_map = eow.get_tasks()
-    assert in_task_name in task_map, f"A task with name '{in_task_name}' should be among tasks"
-    assert task_map[in_task_name] == in_task, f"A task with name '{in_task_name}' should map into {in_task_name}"
+    returned_nodes = eow.get_nodes()
 
+    assert [in_node, inc_node0, inc_node1, inc_node2, output_node] == returned_nodes, (
+        'Returned nodes differ from original nodes'
+    )
 
-def test_get_tasks():
-    in_task = InputTask()
-    inc_task0 = Inc()
-    inc_task1 = Inc()
-    inc_task2 = Inc()
-    output_task = OutputTask(name='out')
-
-    task_names = ['InputTask', 'Inc', 'Inc_1', 'Inc_2', 'OutputTask']
-    eow = LinearWorkflow(in_task, inc_task0, inc_task1, inc_task2, output_task)
-
-    returned_tasks = eow.get_tasks()
-
-    assert sorted(task_names) == sorted(returned_tasks), 'Returned tasks differ from original tasks'
-
-    arguments_dict = {in_task: {'val': 2}, inc_task0: {'d': 2}}
+    arguments_dict = {in_node: {'val': 2}, inc_node0: {'d': 2}}
     workflow_res = eow.execute(arguments_dict)
 
     manual_res = []
-    for _, task in enumerate(returned_tasks.values()):
-        manual_res = [task.execute(*manual_res, **arguments_dict.get(task, {}))]
+    for _, node in enumerate(returned_nodes):
+        manual_res = [node.task.execute(*manual_res, **arguments_dict.get(node, {}))]
 
-    assert workflow_res.outputs['out'] == manual_res[0], 'Manually running returned tasks produces different results.'
-
-
-@given(
-    st.lists(
-        st.tuples(
-            st.integers(min_value=0, max_value=10),
-            st.integers(min_value=0, max_value=10)
-        ).filter(lambda p: p[0] != p[1]),
-        min_size=1, max_size=110
-    )
-)
-def test_resolve_dependencies(edges):
-    dag = DirectedGraph.from_edges(edges)
-
-    if DirectedGraph._is_cyclic(dag):
-        with pytest.raises(CyclicDependencyError):
-            EOWorkflow._schedule_dependencies(dag)
-    else:
-        vertex_position = {vertex: i for i, vertex in enumerate(EOWorkflow._schedule_dependencies(dag))}
-        assert functools.reduce(lambda P, Q: P and Q, [vertex_position[u] < vertex_position[v] for u, v in edges])
+    assert workflow_res.outputs['out'] == manual_res[0], 'Manually running returned nodes produces different results.'
 
 
 @pytest.mark.parametrize(
     'faulty_parameters',
     [
-        (None,),
-        (InputTask(), 'a string'),
-        (InputTask(), ('something', InputTask())),
-        (InputTask(), 'name', 'something else'),
-        ('task', 'name')
+        [InputTask(), Inc(), Inc()],
+        EONode(InputTask()),
+        [EONode(Inc()), Inc()],
+        [EONode(Inc()), (EONode(Inc()), 'name')],
+        [EONode(Inc()), (EONode(Inc(), inputs=[EONode(Inc())]))],
+        [EONode(Inc()), (EONode(Inc()), Inc())],
     ]
 )
-def test_exceptions(faulty_parameters):
+def test_input_exceptions(faulty_parameters):
     with pytest.raises(ValueError):
-        LinearWorkflow(*faulty_parameters)
+        EOWorkflow(faulty_parameters)
+
+
+def test_bad_structure_exceptions():
+    in_node = EONode(InputTask())
+    inc_node0 = EONode(Inc(), inputs=[in_node])
+    inc_node1 = EONode(Inc(), inputs=[inc_node0])
+    inc_node2 = EONode(Inc(), inputs=[inc_node1])
+    output_node = EONode(OutputTask(name='out'), inputs=[inc_node2])
+
+    # This one must work
+    EOWorkflow([in_node, inc_node0, inc_node1, inc_node2, output_node])
+
+    # Duplicated node
+    with pytest.raises(ValueError):
+        EOWorkflow([in_node, inc_node0, inc_node0, inc_node1, inc_node2, output_node])
+
+    # Missing node
+    with pytest.raises(ValueError):
+        EOWorkflow([in_node, inc_node0, inc_node2, output_node])
+
+    # Create circle (much more difficult now)
+    super(EONode, inc_node0).__setattr__('inputs', (inc_node1,))
+    with pytest.raises(ValueError):
+        EOWorkflow([in_node, inc_node0, inc_node1, inc_node2, output_node])
+
+
+def test_multiedge_workflow():
+    in_node = EONode(InputTask())
+    inc_node = EONode(Inc(), inputs=[in_node])
+    div_node = EONode(DivideTask(), inputs=[inc_node, inc_node])
+    output_node = EONode(OutputTask(name='out'), inputs=[div_node])
+
+    workflow = EOWorkflow([in_node, output_node, inc_node, div_node])
+    arguments_dict = {in_node: {'val': 2}}
+    workflow_res = workflow.execute(arguments_dict)
+
+    assert workflow_res.outputs['out'] == 1
 
 
 def test_workflow_copying_eopatches():
     feature1 = FeatureType.DATA, 'data1'
     feature2 = FeatureType.DATA, 'data2'
 
-    init_task = InitializeFeatureTask(
-        [feature1, feature2],
-        shape=(2, 4, 4, 3),
-        init_value=1
+    create_node = EONode(CreateEOPatchTask())
+    init_node = EONode(
+        InitializeFeatureTask([feature1, feature2], shape=(2, 4, 4, 3), init_value=1),
+        inputs=[create_node],
     )
-    remove_task1 = RemoveFeatureTask(feature1)
-    remove_task2 = RemoveFeatureTask(feature2)
-    output_task1 = OutputTask(name='out1')
-    output_task2 = OutputTask(name='out2')
+    remove_node1 = EONode(RemoveFeatureTask(feature1), inputs=[init_node])
+    remove_node2 = EONode(RemoveFeatureTask(feature2), inputs=[init_node])
+    output_node1 = EONode(OutputTask(name='out1'), inputs=[remove_node1])
+    output_node2 = EONode(OutputTask(name='out2'), inputs=[remove_node2])
 
-    workflow = EOWorkflow([
-        (init_task, []),
-        (remove_task1, [init_task]),
-        (remove_task2, [init_task]),
-        (output_task1, [remove_task1]),
-        (output_task2, [remove_task2]),
-    ])
-    results = workflow.execute({init_task: (EOPatch(),)})
+    workflow = EOWorkflow([create_node, init_node, remove_node1, remove_node2, output_node1, output_node2])
+    results = workflow.execute()
 
     eop1 = results.outputs['out1']
     eop2 = results.outputs['out2']
@@ -181,26 +170,26 @@ def test_workflow_copying_eopatches():
     assert eop2 == EOPatch(data={'data1': np.ones((2, 4, 4, 3), dtype=np.uint8)})
 
 
-def test_workflows_sharing_tasks():
+def test_workflows_reusing_nodes():
 
-    in_task = InputTask()
-    task1 = Inc()
-    task2 = Inc()
-    out_task = OutputTask(name='out')
-    input_args = {in_task: {'val': 2}, task2: {'d': 2}}
+    in_node = EONode(InputTask())
+    node1 = EONode(Inc(), inputs=[in_node])
+    node2 = EONode(Inc(), inputs=[node1])
+    out_node = EONode(OutputTask(name='out'), inputs=[node2])
+    input_args = {in_node: {'val': 2}, node2: {'d': 2}}
 
-    original = EOWorkflow([(in_task, []), (task1, in_task), (task2, task1), (out_task, task2)])
-    task_reuse = EOWorkflow([(in_task, []), (task1, in_task), (task2, task1), (out_task, task2)])
+    original = EOWorkflow([in_node, node1, node2, out_node])
+    node_reuse = EOWorkflow([in_node, node1, node2, out_node])
 
-    assert original.execute(input_args).outputs['out'] == task_reuse.execute(input_args).outputs['out']
+    assert original.execute(input_args).outputs['out'] == node_reuse.execute(input_args).outputs['out']
 
 
 def test_workflow_results():
-    input_task = InputTask()
-    output_task = OutputTask(name='out')
-    workflow = LinearWorkflow(input_task, output_task)
+    input_node = EONode(InputTask())
+    output_node = EONode(OutputTask(name='out'), inputs=[input_node])
+    workflow = EOWorkflow([input_node, output_node])
 
-    results = workflow.execute({input_task: {'val': 10}})
+    results = workflow.execute({input_node: {'val': 10}})
 
     assert isinstance(results, WorkflowResults)
     assert results.outputs == {'out': 10}
@@ -211,6 +200,35 @@ def test_workflow_results():
 
     assert isinstance(results.stats, dict)
     assert len(results.stats) == 2
-    for task in [input_task, output_task]:
-        stats_uid = task.private_task_config.uid
-        assert isinstance(results.stats.get(stats_uid), TaskStats)
+    for node in [input_node, output_node]:
+        stats_uid = node.uid
+        assert isinstance(results.stats.get(stats_uid), NodeStats)
+
+
+def test_workflow_from_endnodes():
+    input_node1 = EONode(InputTask())
+    input_node2 = EONode(InputTask(), name='some name')
+    divide_node = EONode(DivideTask(), inputs=(input_node1, input_node2), name='some name')
+    output_node = EONode(OutputTask(name='out'), inputs=[divide_node])
+
+    regular_workflow = EOWorkflow([input_node1, input_node2, divide_node, output_node])
+    endnode_workflow = EOWorkflow.from_endnodes([output_node])
+
+    assert isinstance(endnode_workflow, EOWorkflow)
+    assert set(endnode_workflow.get_nodes()) == set(regular_workflow.get_nodes()), "Nodes are different"
+
+    with concurrent.futures.ProcessPoolExecutor(max_workers=5) as executor:
+        regular_results = [
+            executor.submit(
+                regular_workflow.execute, {input_node1: {'val': k ** 3}, input_node2: {'val': k ** 2}}
+            ) for k in range(2, 100)
+        ]
+        endnode_results = [
+            executor.submit(
+                endnode_workflow.execute, {input_node1: {'val': k ** 3}, input_node2: {'val': k ** 2}}
+            ) for k in range(2, 100)
+        ]
+        executor.shutdown()
+        assert all(
+            x.result().outputs['out'] == y.result().outputs['out'] for x, y in zip(regular_results, endnode_results)
+        )

--- a/core/eolearn/tests/test_eoworkflow_tasks.py
+++ b/core/eolearn/tests/test_eoworkflow_tasks.py
@@ -1,13 +1,26 @@
 """
 Test for module eoworkflow_tasks.py
 """
-from eolearn.core import EOTask, EOWorkflow, FeatureType, LoadTask, OutputTask
+from eolearn.core import EOTask, EOWorkflow, FeatureType, LoadTask, OutputTask, EONode
+from eolearn.core.eoworkflow_tasks import InputTask
 
 
 class DummyTask(EOTask):
 
     def execute(self, *eopatches):
         return eopatches[0]
+
+
+def test_input_task():
+    """ Test basic functionalities of InputTask
+    """
+    task = InputTask(value=31)
+    assert task.execute() == 31
+    assert task.execute(value=42) == 42
+
+    task = InputTask()
+    assert task.execute() is None
+    assert task.execute(value=42) == 42
 
 
 def test_output_task(test_eopatch):
@@ -25,14 +38,10 @@ def test_output_task(test_eopatch):
 
 
 def test_output_task_in_workflow(test_eopatch_path, test_eopatch):
-    load = LoadTask(test_eopatch_path)
-    output = OutputTask(name='result-name')
+    load = EONode(LoadTask(test_eopatch_path))
+    output = EONode(OutputTask(name='result-name'), inputs=[load])
 
-    workflow = EOWorkflow([
-        (load, []),
-        (output, [load]),
-        (DummyTask(), [load])
-    ])
+    workflow = EOWorkflow([load, output, EONode(DummyTask(), inputs=[load])])
 
     results = workflow.execute()
 

--- a/core/eolearn/tests/test_graph.py
+++ b/core/eolearn/tests/test_graph.py
@@ -7,10 +7,12 @@ Copyright (c) 2017-2019 Blaž Sovdat, Nejc Vesel, Jovan Višnjić, Anže Zupanc,
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+import functools
 
 import pytest
+from hypothesis import given, strategies as st
 
-from eolearn.core.graph import DirectedGraph
+from eolearn.core.graph import DirectedGraph, CyclicDependencyError
 
 
 @pytest.fixture(name='test_graph')
@@ -19,40 +21,48 @@ def test_graph_fixture():
 
 
 def test_is_edge():
-    d = DirectedGraph({1: [2]})
-    assert d.is_edge(1, 2)
-    assert not d.is_edge(2, 1)
+    graph = DirectedGraph({1: [2]})
+    assert graph.is_edge(1, 2)
+    assert not graph.is_edge(2, 1)
 
 
 def test_add_edge():
-    d = DirectedGraph()
-    assert not d.is_edge(1, 2)
-    assert d.get_outdegree(1) == 0
+    graph = DirectedGraph()
+    assert not graph.is_edge(1, 2)
+    assert graph.get_outdegree(1) == 0
 
-    d.add_edge(1, 2)
+    graph.add_edge(1, 2)
 
-    assert d.get_outdegree(1) == 1
-    assert d.get_indegree(2) == 1
-    assert d.is_edge(1, 2)
+    assert graph.get_outdegree(1) == 1
+    assert graph.get_indegree(2) == 1
+    assert graph.is_edge(1, 2)
 
-    d.add_edge(1, 2)
+    graph.add_edge(1, 2)
 
-    assert d.get_indegree(1) == 0
-    assert d.get_indegree(2) == 1
+    assert graph.get_indegree(1) == 0
+    assert graph.get_outdegree(1) == 2
+    assert graph.get_indegree(2) == 2
 
 
 def test_del_edge():
-    d = DirectedGraph({1: [2]})
-    assert d.is_edge(1, 2)
-    d.del_edge(1, 2)
-    assert not d.is_edge(1, 2)
+    graph = DirectedGraph({1: [2]})
+    assert graph.is_edge(1, 2)
+    graph.del_edge(1, 2)
+    assert not graph.is_edge(1, 2)
+
+    graph = DirectedGraph({1: [2, 2]})
+    assert graph.is_edge(1, 2)
+    graph.del_edge(1, 2)
+    assert graph.is_edge(1, 2)
+    graph.del_edge(1, 2)
+    assert not graph.is_edge(1, 2)
 
 
 def test_neigbors(test_graph):
-    assert test_graph.neighbors(1) == [2, 3]
-    assert test_graph.neighbors(2) == [4]
-    assert test_graph.neighbors(3) == [4]
-    assert test_graph.neighbors(4) == []
+    assert test_graph.get_neighbors(1) == [2, 3]
+    assert test_graph.get_neighbors(2) == [4]
+    assert test_graph.get_neighbors(3) == [4]
+    assert test_graph.get_neighbors(4) == []
 
 
 def test_get_indegree(test_graph):
@@ -70,35 +80,55 @@ def test_get_outdegree(test_graph):
 
 
 def test_vertices(test_graph):
-    assert set(test_graph.vertices()) == set([1, 2, 3, 4])
+    assert test_graph.get_vertices() == set([1, 2, 3, 4])
 
-    d2 = DirectedGraph()
-    d2.add_edge(1, 2)
-    d2.add_edge(2, 3)
-    d2.add_edge(3, 4)
-    assert set(d2.vertices()) == set([1, 2, 3, 4])
+    graph = DirectedGraph()
+    graph.add_edge(1, 2)
+    graph.add_edge(2, 3)
+    graph.add_edge(3, 4)
+    assert graph.get_vertices() == set([1, 2, 3, 4])
 
 
 def test_add_vertex():
-    d = DirectedGraph({1: [2, 3], 2: [4], 3: [4]})
-    d.add_vertex(5)
-    assert 5 in d
-    assert d.get_indegree(5) == 0
-    assert d.get_outdegree(5) == 0
-    assert d[5] == []
+    graph = DirectedGraph({1: [2, 3], 2: [4], 3: [4]})
+    graph.add_vertex(5)
+    assert 5 in graph
+    assert graph.get_indegree(5) == 0
+    assert graph.get_outdegree(5) == 0
+    assert graph.get_neighbors(5) == []
 
 
 def test_del_vertex():
-    d = DirectedGraph({1: [2, 3], 2: [4], 3: [4]})
+    graph = DirectedGraph({1: [2, 3], 2: [4], 3: [4]})
 
-    assert d.get_outdegree(1) == 2
-    assert d.get_indegree(4) == 2
-    assert len(d) == 4
-    assert 2 in d
+    assert graph.get_outdegree(1) == 2
+    assert graph.get_indegree(4) == 2
+    assert len(graph) == 4
+    assert 2 in graph
 
-    d.del_vertex(2)
+    graph.del_vertex(2)
 
-    assert d.get_outdegree(1) == 1
-    assert d.get_indegree(4) == 1
-    assert len(d) == 3
-    assert 2 not in d
+    assert graph.get_outdegree(1) == 1
+    assert graph.get_indegree(4) == 1
+    assert len(graph) == 3
+    assert 2 not in graph
+
+
+@given(
+    st.lists(
+        st.tuples(
+            st.integers(min_value=0, max_value=10),
+            st.integers(min_value=0, max_value=10)
+        ).filter(lambda p: p[0] != p[1]),
+        min_size=1, max_size=110
+    )
+)
+def test_resolve_dependencies(edges):
+    graph = DirectedGraph.from_edges(edges)
+
+    if DirectedGraph._is_cyclic(graph):
+        with pytest.raises(CyclicDependencyError):
+            graph.toplogically_ordered_vertices()
+    else:
+        vertex_position = {vertex: i for i, vertex in enumerate(graph.toplogically_ordered_vertices())}
+        assert functools.reduce(lambda P, Q: P and Q, [vertex_position[u] < vertex_position[v] for u, v in edges])

--- a/visualization/eolearn/tests/test_eoexecutor_visualization.py
+++ b/visualization/eolearn/tests/test_eoexecutor_visualization.py
@@ -12,7 +12,7 @@ import os
 import logging
 import tempfile
 
-from eolearn.core import EOTask, EOWorkflow, Dependency, EOExecutor
+from eolearn.core import EOTask, EOWorkflow, EONode, EOExecutor
 
 
 logging.basicConfig(level=logging.DEBUG)
@@ -30,13 +30,13 @@ class ExampleTask(EOTask):
             raise Exception
 
 
-TASK = ExampleTask()
-WORKFLOW = EOWorkflow([(TASK, []), Dependency(task=ExampleTask(), inputs=[TASK, TASK])])
+NODE = EONode(ExampleTask())
+WORKFLOW = EOWorkflow([NODE, EONode(task=ExampleTask(), inputs=[NODE, NODE])])
 EXECUTION_ARGS = [
-    {TASK: {'arg1': 1}},
+    {NODE: {'arg1': 1}},
     {},
-    {TASK: {'arg1': 3, 'arg3': 10}},
-    {TASK: {'arg1': None}}
+    {NODE: {'arg1': 3, 'arg3': 10}},
+    {NODE: {'arg1': None}}
 ]
 
 

--- a/visualization/eolearn/tests/test_eoworkflow_visualization.py
+++ b/visualization/eolearn/tests/test_eoworkflow_visualization.py
@@ -10,7 +10,7 @@ file in the root directory of this source tree.
 import pytest
 from graphviz import Digraph
 
-from eolearn.core import EOTask, EOWorkflow, Dependency
+from eolearn.core import EOTask, EOWorkflow, EONode
 
 
 class FooTask(EOTask):
@@ -20,14 +20,10 @@ class FooTask(EOTask):
 
 @pytest.fixture(name='workflow')
 def workflow_fixture():
-    task1, task2, task3 = FooTask(), FooTask(), FooTask()
+    node1, node2 = EONode(FooTask()), EONode(FooTask())
+    node3 = EONode(FooTask(), [node1, node2])
 
-    workflow = EOWorkflow(
-        dependencies=[
-            Dependency(task=task1, inputs=[]),
-            Dependency(task=task2, inputs=[]),
-            Dependency(task=task3, inputs=[task1, task2])
-        ])
+    workflow = EOWorkflow([node1, node2, node3])
     return workflow
 
 


### PR DESCRIPTION
This introduces a very code-breaking change, but strengthens the foundations of eo-learn.

EOWorkflows are no longer built directly from tasks, but now require EONodes, which contain tasks and describe the graph structure of the workflow.