### PR TITLE
Update code for projecting to 2D in rasterization

### DIFF
--- a/geometry/eolearn/geometry/transformations.py
+++ b/geometry/eolearn/geometry/transformations.py
@@ -10,7 +10,7 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-from functools import partial
+import functools
 import logging
 import warnings
 
@@ -191,7 +191,9 @@ class VectorToRasterTask(EOTask):
         if vector_data.geometry.has_z.any():
             warnings.warn('Given vector polygons contain some 3D geometries, they will be projected to 2D',
                           EORuntimeWarning)
-            vector_data.geometry = vector_data.geometry.map(partial(shapely.ops.transform, lambda *args: args[:2]))
+            vector_data.geometry = vector_data.geometry.map(
+                functools.partial(shapely.ops.transform, lambda *args: args[:2])
+            )
 
         return vector_data
 
@@ -207,7 +209,8 @@ class VectorToRasterTask(EOTask):
         if join_per_value:
             classes = np.unique(vector_data[self.values_column])
             grouped = (vector_data.geometry[vector_data[self.values_column] == cl] for cl in classes)
-            grouped = (shapely.ops.unary_union(group) for group in grouped)
+            join_function = shapely.ops.unary_union if shapely.__version__ >= '1.8.0' else shapely.ops.cascaded_union
+            grouped = (join_function(group) for group in grouped)
             return zip(grouped, classes)
 
         return zip(vector_data.geometry, vector_data[self.values_column])
@@ -257,7 +260,7 @@ class VectorToRasterTask(EOTask):
 
         base_rasterize_func = rasterio.features.rasterize if self.overlap_value is None else self.rasterize_overlapped
 
-        return partial(base_rasterize_func, **rasterize_params)
+        return functools.partial(base_rasterize_func, **rasterize_params)
 
     def rasterize_overlapped(self, shapes, out, **rasterize_args):
         """ Rasterize overlapped classes.

--- a/geometry/eolearn/tests/test_transformations.py
+++ b/geometry/eolearn/tests/test_transformations.py
@@ -7,11 +7,12 @@ Copyright (c) 2017-2019 Blaž Sovdat, Nejc Vesel, Jovan Višnjić, Anže Zupanc,
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-
+from functools import partial
 import dataclasses
 from typing import Any
 
 import pytest
+import shapely
 import numpy as np
 from numpy.testing import assert_array_equal
 
@@ -30,6 +31,8 @@ RASTER_FEATURE_TIMED = FeatureType.MASK, 'RASTERIZED_CLM'
 
 CUSTOM_DATAFRAME = EOPatch.load(TEST_EOPATCH_PATH, lazy_loading=True)[VECTOR_FEATURE]
 CUSTOM_DATAFRAME = CUSTOM_DATAFRAME[(CUSTOM_DATAFRAME['AREA'] < 10 ** 3)]
+CUSTOM_DATAFRAME_3D = CUSTOM_DATAFRAME.copy()
+CUSTOM_DATAFRAME_3D.geometry = CUSTOM_DATAFRAME_3D.geometry.map(partial(shapely.ops.transform, lambda x, y: (x, y, 0)))
 
 
 @dataclasses.dataclass(frozen=True)
@@ -107,6 +110,13 @@ VECTOR_TO_RASTER_TEST_CASES = (
         name='different crs',
         task=VectorToRasterTask(
             vector_input=CUSTOM_DATAFRAME.to_crs(epsg=3857), raster_feature=RASTER_FEATURE, values_column='LULC_ID',
+            raster_shape=(FeatureType.DATA, 'BANDS-S2-L1C'), no_data_value=0
+        ),
+        img_max=8, img_mean=0.042079, img_median=0, img_shape=(101, 100, 1)),
+    VectorToRasterTestCase(
+        name='3D polygons',
+        task=VectorToRasterTask(
+            vector_input=CUSTOM_DATAFRAME_3D, raster_feature=RASTER_FEATURE, values_column='LULC_ID',
             raster_shape=(FeatureType.DATA, 'BANDS-S2-L1C'), no_data_value=0
         ),
         img_max=8, img_mean=0.042079, img_median=0, img_shape=(101, 100, 1)),


### PR DESCRIPTION
Fixes the issue with Shapely 1.8 removing the `to_wkt` method we used to project 3D -> 2D in rasterization task.