### PR TITLE
EOExecutor improvements, part 1

### DIFF
--- a/core/eolearn/core/eoexecution.py
+++ b/core/eolearn/core/eoexecution.py
@@ -133,8 +133,9 @@ class EOExecutor:
                            for init_args, log_path in zip(self.execution_args, log_paths)]
         processing_type = self._get_processing_type(workers, multiprocess)
 
-        self.execution_results = self._run_execution(processing_args, workers, processing_type)
+        full_execution_results = self._run_execution(processing_args, workers, processing_type)
 
+        self.execution_results = [results.drop_outputs() for results in full_execution_results]
         self.general_stats = self._prepare_general_stats(workers, processing_type)
 
         self.execution_logs = [None] * len(self.execution_args)
@@ -143,7 +144,7 @@ class EOExecutor:
                 with open(log_path) as fin:
                     self.execution_logs[idx] = fin.read()
 
-        return self.execution_results
+        return full_execution_results
 
     @staticmethod
     def _get_processing_type(workers: int, multiprocess: bool) -> _ProcessingType:

--- a/core/eolearn/core/eoexecution.py
+++ b/core/eolearn/core/eoexecution.py
@@ -21,8 +21,8 @@ import datetime as dt
 import multiprocessing
 import warnings
 from enum import Enum
-from logging import Filter
-from typing import List, Dict, Optional
+from logging import Logger, Handler, Filter
+from typing import Sequence, List, Tuple, Dict, Optional, Callable
 
 from tqdm.auto import tqdm
 
@@ -54,14 +54,14 @@ class EOExecutor:
     STATS_START_TIME = 'start_time'
     STATS_END_TIME = 'end_time'
 
-    def __init__(self, workflow: EOWorkflow, execution_args: List[Dict[EONode, Dict[str, object]]], *,
+    def __init__(self, workflow: EOWorkflow, execution_args: Sequence[Dict[EONode, Dict[str, object]]], *,
                  save_logs: bool = False, logs_folder: str = '.', logs_filter: Optional[Filter] = None,
                  execution_names: Optional[List[str]] = None):
         """
         :param workflow: A prepared instance of EOWorkflow class
         :param execution_args: A list of dictionaries where each dictionary represents execution inputs for the
             workflow. `EOExecutor` will execute the workflow for each of the given dictionaries in the list. The
-            content of such dictionary will be used as `input_args` parameter in `EOWorkflow.execution` method.
+            content of such dictionary will be used as `input_kwargs` parameter in `EOWorkflow.execution` method.
             Check `EOWorkflow.execution` for definition of a dictionary structure.
         :param save_logs: Flag used to specify if execution log files should be saved locally on disk
         :param logs_folder: A folder where logs and execution report should be saved
@@ -95,7 +95,7 @@ class EOExecutor:
         return [input_kwargs or {} for input_kwargs in execution_args]
 
     @staticmethod
-    def _parse_execution_names(execution_names, execution_args: Optional[List[str]]) -> List[str]:
+    def _parse_execution_names(execution_names: object, execution_args: Sequence) -> List[str]:
         """ Parses a list of execution names
         """
         if execution_names is None:
@@ -123,8 +123,8 @@ class EOExecutor:
         """
         self.start_time = dt.datetime.now()
         self.report_folder = self._get_report_folder()
-        if self.save_logs and not os.path.isdir(self.report_folder):
-            os.makedirs(self.report_folder)
+        if self.save_logs:
+            os.makedirs(self.report_folder, exist_ok=True)
 
         log_paths = self._get_log_paths()
 
@@ -156,7 +156,8 @@ class EOExecutor:
             return _ProcessingType.MULTIPROCESSING
         return _ProcessingType.MULTITHREADING
 
-    def _run_execution(self, processing_args, workers: int, processing_type: _ProcessingType) -> List[WorkflowResults]:
+    def _run_execution(self, processing_args: Sequence, workers: int,
+                       processing_type: _ProcessingType) -> List[WorkflowResults]:
         """ Runs the execution an each item of processing_args list
         """
         if processing_type is _ProcessingType.SINGLE_PROCESS:
@@ -178,7 +179,8 @@ class EOExecutor:
         return result
 
     @classmethod
-    def _try_add_logging(cls, log_path, filter_logs_by_thread, logs_filter):
+    def _try_add_logging(cls, log_path: str, filter_logs_by_thread: bool,
+                         logs_filter: Optional[Filter]) -> Tuple[Optional[Logger], Optional[Handler]]:
         """ Adds a handler to a logger and returns them both. In case this fails it shows a warning.
         """
         if log_path:
@@ -194,7 +196,7 @@ class EOExecutor:
         return None, None
 
     @classmethod
-    def _try_remove_logging(cls, log_path, logger, handler):
+    def _try_remove_logging(cls, log_path: str, logger: Optional[Logger], handler: Optional[Handler]):
         """ Removes a handler from a logger in case that handler exists.
         """
         if log_path and logger:
@@ -205,7 +207,7 @@ class EOExecutor:
                 warnings.warn(f'Failed to end logging with exception: {repr(exception)}', category=EORuntimeWarning)
 
     @classmethod
-    def _execute_workflow(cls, process_args):
+    def _execute_workflow(cls, process_args: object) -> WorkflowResults:
         """ Handles a single execution of a workflow
         """
         workflow, input_args, log_path, filter_logs_by_thread, logs_filter = process_args
@@ -223,7 +225,7 @@ class EOExecutor:
         return results
 
     @staticmethod
-    def _get_log_handler(log_path, filter_logs_by_thread, logs_filter):
+    def _get_log_handler(log_path: str, filter_logs_by_thread: bool, logs_filter: Optional[Filter]) -> Handler:
         """ Provides object which handles logs
         """
         handler = logging.FileHandler(log_path)
@@ -238,7 +240,7 @@ class EOExecutor:
 
         return handler
 
-    def _prepare_general_stats(self, workers, processing_type):
+    def _prepare_general_stats(self, workers: int, processing_type: _ProcessingType) -> Dict[str, object]:
         """ Prepares a dictionary with a general statistics about executions
         """
         failed_count = sum(results.workflow_failed() for results in self.execution_results)
@@ -251,13 +253,13 @@ class EOExecutor:
             'workers': workers
         }
 
-    def _get_report_folder(self):
+    def _get_report_folder(self) -> str:
         """ Returns file path of folder where report will be saved
         """
         return os.path.join(self.logs_folder,
                             f'eoexecution-report-{self.start_time.strftime("%Y_%m_%d-%H_%M_%S")}')
 
-    def _get_log_paths(self):
+    def _get_log_paths(self) -> List[Optional[str]]:
         """ Returns a list of file paths containing logs
         """
         if self.save_logs:
@@ -266,29 +268,26 @@ class EOExecutor:
 
         return [None] * len(self.execution_names)
 
-    def get_successful_executions(self):
+    def get_successful_executions(self) -> List[int]:
         """ Returns a list of IDs of successful executions. The IDs are integers from interval
         `[0, len(execution_args) - 1]`, sorted in increasing order.
 
         :return: List of successful execution IDs
-        :rtype: list(int)
         """
         return [idx for idx, results in enumerate(self.execution_results) if not results.workflow_failed()]
 
-    def get_failed_executions(self):
+    def get_failed_executions(self) -> List[int]:
         """ Returns a list of IDs of failed executions. The IDs are integers from interval
         `[0, len(execution_args) - 1]`, sorted in increasing order.
 
         :return: List of failed execution IDs
-        :rtype: list(int)
         """
         return [idx for idx, results in enumerate(self.execution_results) if results.workflow_failed()]
 
-    def get_report_filename(self):
+    def get_report_filename(self) -> str:
         """ Returns the filename and file path of the report
 
         :return: Report filename
-        :rtype: str
         """
         return os.path.join(self.report_folder, self.REPORT_FILENAME)
 
@@ -305,7 +304,7 @@ class EOExecutor:
         return EOExecutorVisualization(self).make_report()
 
 
-def execute_with_mp_lock(execution_function, *args, **kwargs):
+def execute_with_mp_lock(execution_function: Callable, *args, **kwargs) -> object:
     """ A helper utility function that executes a given function with multiprocessing lock if the process is being
     executed in a multi-processing mode
 

--- a/core/eolearn/core/eonode.py
+++ b/core/eolearn/core/eonode.py
@@ -89,5 +89,9 @@ def linearly_connect_tasks(*tasks: Union[EOTask, Tuple[EOTask, str]]) -> List[EO
 class NodeStats:
     """ An object containing statistical info about a node execution
     """
+    node_uid: str
+    node_name: str
     start_time: dt.datetime
     end_time: dt.datetime
+    exception: Optional[BaseException] = None
+    exception_traceback: Optional[str] = None

--- a/core/eolearn/core/eotask.py
+++ b/core/eolearn/core/eotask.py
@@ -16,7 +16,6 @@ file in the root directory of this source tree.
 """
 import inspect
 import logging
-import sys
 from abc import ABC, abstractmethod
 from typing import Dict
 from dataclasses import dataclass
@@ -57,20 +56,7 @@ class EOTask(ABC):
     def __call__(self, *eopatches, **kwargs):
         """ Executes the task and handles proper error propagation
         """
-        try:
-            return_value = self.execute(*eopatches, **kwargs)
-        except BaseException as exception:
-            traceback = sys.exc_info()[2]
-
-            # Some special exceptions don't accept an error message as a parameter and raise a TypeError in such case.
-            try:
-                errmsg = f'During execution of task {self.__class__.__name__}: {exception}'
-                extended_exception = type(exception)(errmsg)
-            except TypeError:
-                extended_exception = exception
-
-            raise extended_exception.with_traceback(traceback)
-        return return_value
+        return self.execute(*eopatches, **kwargs)
 
     @abstractmethod
     def execute(self, *eopatches, **kwargs):

--- a/core/eolearn/core/eoworkflow.py
+++ b/core/eolearn/core/eoworkflow.py
@@ -24,7 +24,7 @@ import logging
 import traceback
 import datetime as dt
 from typing import Dict, List, Optional, Sequence, Tuple, Set
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 
 from .eodata import EOPatch
 from .eonode import EONode, NodeStats
@@ -359,3 +359,11 @@ class WorkflowResults:
     def workflow_failed(self) -> bool:
         """Informs if the EOWorkflow execution failed"""
         return self.error_node_uid is not None
+
+    def drop_outputs(self) -> 'WorkflowResults':
+        """Creates a new WorkflowResults object without outputs which can take a lot of memory"""
+        new_params = {
+            param.name: {} if param.name == 'outputs' else getattr(self, param.name)
+            for param in fields(self) if param.init
+        }
+        return WorkflowResults(**new_params)

--- a/core/eolearn/core/eoworkflow.py
+++ b/core/eolearn/core/eoworkflow.py
@@ -163,7 +163,7 @@ class EOWorkflow:
             stats=stats_dict
         )
 
-        LOGGER.debug('Workflow finished with %s', repr(results))
+        LOGGER.debug('EOWorkflow ended with results %s', repr(results))
         return results
 
     @staticmethod
@@ -355,3 +355,7 @@ class WorkflowResults:
             if node_stats.exception is not None:
                 super().__setattr__('error_node_uid', node_uid)
                 break
+
+    def workflow_failed(self) -> bool:
+        """Informs if the EOWorkflow execution failed"""
+        return self.error_node_uid is not None

--- a/core/eolearn/core/eoworkflow.py
+++ b/core/eolearn/core/eoworkflow.py
@@ -229,7 +229,7 @@ class EOWorkflow:
 
     def _execute_node(
         self, *, node: EONode, node_input_values: List[object], node_input_kwargs: Dict[str, object], raise_errors: bool
-    ) -> Tuple[object, 'NodeStats']:
+    ) -> Tuple[object, NodeStats]:
         """ Executes a node in the workflow by running its task and returning the results
 
         :param node: A node of the workflow.
@@ -255,7 +255,6 @@ class EOWorkflow:
         if is_success:
             return result, NodeStats(**node_stats_params)
 
-        result: Tuple[BaseException, str]
         exception, exception_traceback = result
         LOGGER.error("Task '%s' with id %s failed with stack trace:\n%s", node.name, node.uid, exception_traceback)
         return None, NodeStats(exception=exception, exception_traceback=exception_traceback, **node_stats_params)

--- a/core/eolearn/core/extra/ray.py
+++ b/core/eolearn/core/extra/ray.py
@@ -12,7 +12,7 @@ file in the root directory of this source tree.
 try:
     import ray
 except ImportError as exception:
-    raise ImportError('This module requires an installation of ray Python package') from exception
+    raise ImportError('This module requires an installation of Ray Python package') from exception
 from tqdm.auto import tqdm
 
 from ..eoexecution import EOExecutor, _ProcessingType
@@ -21,22 +21,19 @@ from ..eoexecution import EOExecutor, _ProcessingType
 class RayExecutor(EOExecutor):
     """ A special type of `EOExecutor` that works with Ray framework
     """
-    def run(self, return_results=False):
+    def run(self):
         """ Runs the executor using a Ray cluster
 
         Before calling this method make sure to initialize a Ray cluster using `ray.init`.
 
-        :param return_results: If `True` this method will return a list of all results of the execution. Note that
-            this might exceed the available memory. By default this parameter is set to `False`.
-        :type: bool
-        :return: If `return_results` is set to `True` it will return a list of results, otherwise it will return `None`
+        :return: A list of EOWorkflow results
         :rtype: None or list(eolearn.core.WorkflowResults)
         """
         if not ray.is_initialized():
             raise RuntimeError('Please initialize a Ray cluster before calling this method')
 
         workers = ray.available_resources().get('CPU')
-        return super().run(workers=workers, multiprocess=True, return_results=return_results)
+        return super().run(workers=workers, multiprocess=True)
 
     @staticmethod
     def _get_processing_type(*_, **__):

--- a/core/eolearn/tests/test_eoexecutor.py
+++ b/core/eolearn/tests/test_eoexecutor.py
@@ -163,22 +163,16 @@ def test_execution_errors(multiprocess, workflow, execution_args):
         assert executor.get_failed_executions() == [3]
 
 
-@pytest.mark.parametrize('return_results', [True, False])
-def test_execution_results(return_results, workflow, execution_args):
+def test_execution_results(workflow, execution_args):
     executor = EOExecutor(workflow, execution_args)
-    results = executor.run(workers=2, multiprocess=True, return_results=return_results)
+    results = executor.run(workers=2, multiprocess=True)
 
-    if return_results:
-        assert isinstance(results, list)
+    assert isinstance(results, list)
 
-        for idx, workflow_results in enumerate(results):
-            if idx == 3:
-                assert workflow_results is None
-            else:
-                assert isinstance(workflow_results, WorkflowResults)
-                assert workflow_results.outputs['output'] == 42
-    else:
-        assert results is None
+    for idx, workflow_results in enumerate(results):
+        if idx != 3:
+            assert isinstance(workflow_results, WorkflowResults)
+            assert workflow_results.outputs['output'] == 42
 
 
 def test_exceptions(workflow, execution_args):

--- a/core/eolearn/tests/test_eoexecutor.py
+++ b/core/eolearn/tests/test_eoexecutor.py
@@ -136,15 +136,15 @@ def test_execution_logs(test_args, execution_names, workflow, execution_args):
             assert line_count == expected_line_count
 
 
-def test_execution_stats(workflow, execution_args):
+def test_execution_results(workflow, execution_args):
     with tempfile.TemporaryDirectory() as tmp_dir_name:
         executor = EOExecutor(workflow, execution_args, logs_folder=tmp_dir_name)
         executor.run(workers=2)
 
-        assert len(executor.execution_stats) == 4
-        for stats in executor.execution_stats:
-            for time_stat in ['start_time', 'end_time']:
-                assert time_stat in stats and isinstance(stats[time_stat], datetime.datetime)
+        assert len(executor.execution_results) == 4
+        for results in executor.execution_results:
+            for time_stat in [results.start_time, results.end_time]:
+                assert isinstance(time_stat, datetime.datetime)
 
 
 @pytest.mark.parametrize('multiprocess', [True, False])
@@ -153,11 +153,11 @@ def test_execution_errors(multiprocess, workflow, execution_args):
         executor = EOExecutor(workflow, execution_args, logs_folder=tmp_dir_name)
         executor.run(workers=5, multiprocess=multiprocess)
 
-        for idx, stats in enumerate(executor.execution_stats):
-            if idx != 3:
-                assert 'error' not in stats, f'Workflow {idx} should be executed without errors'
+        for idx, results in enumerate(executor.execution_results):
+            if idx == 3:
+                assert results.workflow_failed()
             else:
-                assert 'error' in stats and stats['error'], 'This workflow should be executed with an error'
+                assert not results.workflow_failed()
 
         assert executor.get_successful_executions() == [0, 1, 2]
         assert executor.get_failed_executions() == [3]
@@ -170,8 +170,8 @@ def test_execution_results(workflow, execution_args):
     assert isinstance(results, list)
 
     for idx, workflow_results in enumerate(results):
+        assert isinstance(workflow_results, WorkflowResults)
         if idx != 3:
-            assert isinstance(workflow_results, WorkflowResults)
             assert workflow_results.outputs['output'] == 42
 
 

--- a/core/eolearn/tests/test_eotask.py
+++ b/core/eolearn/tests/test_eotask.py
@@ -8,39 +8,7 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import copy
-
-import pytest
-
 from eolearn.core import EOTask
-
-
-class TwoParamException(BaseException):
-    def __init__(self, param1, param2):
-        # accept two parameters as opposed to BaseException, which just accepts one
-        super().__init__()
-        self.param1 = param1
-        self.param2 = param2
-
-
-class ExceptionTestingTask(EOTask):
-    def __init__(self, task_arg):
-        self.task_arg = task_arg
-
-    def execute(self, exec_param):
-        # try raising a subclassed exception with an unsupported __init__ arguments signature
-        if self.task_arg == 'test_exception':
-            raise TwoParamException(1, 2)
-
-        # try raising a subclassed exception with an unsupported __init__ arguments signature without initializing it
-        if self.task_arg == 'test_exception_fail':
-            raise TwoParamException
-
-        # raise one of the standard errors
-        if self.task_arg == 'value_error':
-            raise ValueError('Testing value error.')
-
-        return self.task_arg + ' ' + exec_param
 
 
 class PlusOneTask(EOTask):
@@ -73,24 +41,3 @@ def test_call_equals_execute():
     assert task(1) == task.execute(1), 't(x) should given the same result as t.execute(x)'
     task = PlusConstSquaredTask(20)
     assert task(14) == task.execute(14), 't(x) should given the same result as t.execute(x)'
-
-
-@pytest.mark.parametrize(
-    ('parameter', 'exception_type'), [('test_exception_fail', TypeError), ('value_error', ValueError)]
-)
-def test_execution_handling(parameter, exception_type):
-    task = ExceptionTestingTask('test_exception')
-    with pytest.raises(TwoParamException):
-        task('test')
-
-    task = ExceptionTestingTask('success')
-    assert task('test') == 'success test'
-
-    task = ExceptionTestingTask(parameter)
-    with pytest.raises(exception_type):
-        task('test')
-
-    try:
-        task('test')
-    except exception_type as exception:
-        assert str(exception).startswith('During execution of task ExceptionTestingTask: ')

--- a/core/eolearn/tests/test_eoworkflow.py
+++ b/core/eolearn/tests/test_eoworkflow.py
@@ -198,6 +198,10 @@ def test_workflow_results():
     assert isinstance(results, WorkflowResults)
     assert results.outputs == {'out': 10}
 
+    results_without_outputs = results.drop_outputs()
+    assert results_without_outputs.outputs == {}
+    assert id(results_without_outputs) != id(results)
+
     assert isinstance(results.start_time, dt.datetime)
     assert isinstance(results.end_time, dt.datetime)
     assert results.start_time < results.end_time < dt.datetime.now()

--- a/core/eolearn/tests/test_eoworkflow.py
+++ b/core/eolearn/tests/test_eoworkflow.py
@@ -20,6 +20,10 @@ from eolearn.core import (
 from eolearn.core.eoworkflow import NodeStats
 
 
+class CustomException(ValueError):
+    pass
+
+
 class InputTask(EOTask):
     def execute(self, *, val=None):
         return val
@@ -30,14 +34,14 @@ class DivideTask(EOTask):
         return x / y + z
 
 
-class Inc(EOTask):
+class IncTask(EOTask):
     def execute(self, x, *, d=1):
         return x + d
 
 
-class Pow(EOTask):
-    def execute(self, x, *, n=2):
-        return x ** n
+class ExceptionTask(EOTask):
+    def execute(self, *_, **__):
+        raise CustomException
 
 
 def test_workflow_arguments():
@@ -70,9 +74,9 @@ def test_workflow_arguments():
 
 def test_get_nodes():
     in_node = EONode(InputTask())
-    inc_node0 = EONode(Inc(), inputs=[in_node])
-    inc_node1 = EONode(Inc(), inputs=[inc_node0])
-    inc_node2 = EONode(Inc(), inputs=[inc_node1])
+    inc_node0 = EONode(IncTask(), inputs=[in_node])
+    inc_node1 = EONode(IncTask(), inputs=[inc_node0])
+    inc_node2 = EONode(IncTask(), inputs=[inc_node1])
     output_node = EONode(OutputTask(name='out'), inputs=[inc_node2])
 
     eow = EOWorkflow([in_node, inc_node0, inc_node1, inc_node2, output_node])
@@ -96,12 +100,12 @@ def test_get_nodes():
 @pytest.mark.parametrize(
     'faulty_parameters',
     [
-        [InputTask(), Inc(), Inc()],
+        [InputTask(), IncTask(), IncTask()],
         EONode(InputTask()),
-        [EONode(Inc()), Inc()],
-        [EONode(Inc()), (EONode(Inc()), 'name')],
-        [EONode(Inc()), (EONode(Inc(), inputs=[EONode(Inc())]))],
-        [EONode(Inc()), (EONode(Inc()), Inc())],
+        [EONode(IncTask()), IncTask()],
+        [EONode(IncTask()), (EONode(IncTask()), 'name')],
+        [EONode(IncTask()), (EONode(IncTask(), inputs=[EONode(IncTask())]))],
+        [EONode(IncTask()), (EONode(IncTask()), IncTask())],
     ]
 )
 def test_input_exceptions(faulty_parameters):
@@ -111,9 +115,9 @@ def test_input_exceptions(faulty_parameters):
 
 def test_bad_structure_exceptions():
     in_node = EONode(InputTask())
-    inc_node0 = EONode(Inc(), inputs=[in_node])
-    inc_node1 = EONode(Inc(), inputs=[inc_node0])
-    inc_node2 = EONode(Inc(), inputs=[inc_node1])
+    inc_node0 = EONode(IncTask(), inputs=[in_node])
+    inc_node1 = EONode(IncTask(), inputs=[inc_node0])
+    inc_node2 = EONode(IncTask(), inputs=[inc_node1])
     output_node = EONode(OutputTask(name='out'), inputs=[inc_node2])
 
     # This one must work
@@ -135,7 +139,7 @@ def test_bad_structure_exceptions():
 
 def test_multiedge_workflow():
     in_node = EONode(InputTask())
-    inc_node = EONode(Inc(), inputs=[in_node])
+    inc_node = EONode(IncTask(), inputs=[in_node])
     div_node = EONode(DivideTask(), inputs=[inc_node, inc_node])
     output_node = EONode(OutputTask(name='out'), inputs=[div_node])
 
@@ -173,8 +177,8 @@ def test_workflow_copying_eopatches():
 def test_workflows_reusing_nodes():
 
     in_node = EONode(InputTask())
-    node1 = EONode(Inc(), inputs=[in_node])
-    node2 = EONode(Inc(), inputs=[node1])
+    node1 = EONode(IncTask(), inputs=[in_node])
+    node2 = EONode(IncTask(), inputs=[node1])
     out_node = EONode(OutputTask(name='out'), inputs=[node2])
     input_args = {in_node: {'val': 2}, node2: {'d': 2}}
 
@@ -232,3 +236,32 @@ def test_workflow_from_endnodes():
         assert all(
             x.result().outputs['out'] == y.result().outputs['out'] for x, y in zip(regular_results, endnode_results)
         )
+
+
+def test_exception_handling():
+    input_node = EONode(InputTask(), name='xyz')
+    exception_node = EONode(ExceptionTask(), inputs=[input_node])
+    increase_node = EONode(IncTask(), inputs=[exception_node])
+    workflow = EOWorkflow([input_node, exception_node, increase_node])
+
+    with pytest.raises(CustomException):
+        workflow.execute()
+
+    results = workflow.execute(raise_errors=False)
+
+    assert results.outputs == {}
+    assert results.error_node_uid == exception_node.uid
+    assert len(results.stats) == 2
+
+    for node in [input_node, exception_node]:
+        node_stats = results.stats[node.uid]
+
+        assert node_stats.node_uid == node.uid
+        assert node_stats.node_name == node.name
+
+        if node is exception_node:
+            assert isinstance(node_stats.exception, CustomException)
+            assert node_stats.exception_traceback.startswith('Traceback')
+        else:
+            assert node_stats.exception is None
+            assert node_stats.exception_traceback is None

--- a/visualization/eolearn/visualization/report_templates/report.html
+++ b/visualization/eolearn/visualization/report_templates/report.html
@@ -92,8 +92,8 @@
         </ul>
 
         <p>
-            {% for execution in execution_stats %}
-                <a class="exec-status {{ 'exec-failed' if 'error' in execution else 'exec-finished' }}"
+            {% for execution in execution_results %}
+                <a class="exec-status {{ 'exec-failed' if execution.workflow_failed() else 'exec-finished' }}"
                    title="Execution {{ execution_names[loop.index - 1] }}"
                    href="#execution{{ loop.index }}"
                 ></a>
@@ -154,19 +154,19 @@
     <h2> Execution details </h2>
 
     <div class="indent">
-        {% for execution in execution_stats %}
+        {% for execution in execution_results %}
             <h3 id="execution{{ loop.index }}"> Execution {{ execution_names[loop.index - 1] }} </h3>
 
             <div class="indent">
                 Statistics<br/>
                 <ul>
-                    <li>Start time: {{ execution['start_time'] | datetime }}</li>
-                    <li>End time: {{ execution['end_time'] | datetime }}</li>
-                    <li>Duration: {{ timedelta(execution['start_time'], execution['end_time']) }}</li>
+                    <li>Start time: {{ execution.start_time | datetime }}</li>
+                    <li>End time: {{ execution.end_time | datetime }}</li>
+                    <li>Duration: {{ timedelta(execution.start_time, execution.end_time) }}</li>
                 </ul>
-                {% if 'error' in execution %}
+                {% if execution.workflow_failed() %}
                     Error<br/>
-                    {{ execution['error'] }}
+                    {{ execution_tracebacks[loop.index - 1] }}
                 {% endif %}
 
                 <button class="collapsible">Logs</button>


### PR DESCRIPTION
This is the first part of the improvements planned for `EOExecutor`. This one makes updates related to changes in `EOWorkflow` structure:

- `WorkflowResults` are now always returned for each workflow execution,
- error handling now happens in `EOWorkflow` and not in `EOExecutor` and `EOTask`,
- logs report error stack trace,
- avoiding memory leaks by preventing `EOExecutor` to keep `EOWorkflow` outputs, ...

 The next part will be mostly about improving `EOExecutor` itself and its report.