### PR TITLE
Remove deprecated task names

### DIFF
--- a/core/eolearn/core/__init__.py
+++ b/core/eolearn/core/__init__.py
@@ -14,12 +14,6 @@ from .core_tasks import (
     DeepCopyTask,
     SaveTask,
     LoadTask,
-    AddFeature,
-    RemoveFeature,
-    RenameFeature,
-    DuplicateFeature,
-    InitializeFeature,
-    MoveFeature,
     AddFeatureTask,
     RemoveFeatureTask,
     RenameFeatureTask,
@@ -31,8 +25,6 @@ from .core_tasks import (
     ZipFeatureTask,
     ExtractBandsTask,
     CreateEOPatchTask,
-    SaveToDisk,
-    LoadFromDisk,
     MergeEOPatchesTask,
 )
 

--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -18,7 +18,6 @@ import numpy as np
 from .eodata import EOPatch
 from .eotask import EOTask
 from .fs_utils import get_filesystem
-from .utilities import renamed_and_deprecated
 
 
 class CopyTask(EOTask):
@@ -580,43 +579,3 @@ class MergeEOPatchesTask(EOTask):
             raise ValueError("At least one EOPatch should be given")
 
         return eopatches[0].merge(*eopatches[1:], **self.merge_kwargs)
-
-
-@renamed_and_deprecated
-class SaveToDisk(SaveTask):
-    """A deprecated version of SaveTask"""
-
-
-@renamed_and_deprecated
-class LoadFromDisk(LoadTask):
-    """A deprecated version of LoadTask"""
-
-
-@renamed_and_deprecated
-class AddFeature(AddFeatureTask):
-    """A deprecated version of AddFeatureTask"""
-
-
-@renamed_and_deprecated
-class RemoveFeature(RemoveFeatureTask):
-    """A deprecated version of RemoveFeatureTask"""
-
-
-@renamed_and_deprecated
-class RenameFeature(RenameFeatureTask):
-    """A deprecated version of RenameFeatureTask"""
-
-
-@renamed_and_deprecated
-class DuplicateFeature(DuplicateFeatureTask):
-    """A deprecated version of DuplicateFeatureTask"""
-
-
-@renamed_and_deprecated
-class InitializeFeature(InitializeFeatureTask):
-    """A deprecated version of InitializeFeatureTask"""
-
-
-@renamed_and_deprecated
-class MoveFeature(MoveFeatureTask):
-    """A deprecated version of MoveFeatureTask"""

--- a/coregistration/eolearn/coregistration/__init__.py
+++ b/coregistration/eolearn/coregistration/__init__.py
@@ -5,9 +5,6 @@ A collection of tools and EOTasks for image co-registration
 from .coregistration import (
     RegistrationTask,
     InterpolationType,
-    ECCRegistration,
-    PointBasedRegistration,
-    ThunderRegistration,
     ECCRegistrationTask,
     PointBasedRegistrationTask,
     ThunderRegistrationTask,

--- a/coregistration/eolearn/coregistration/coregistration.py
+++ b/coregistration/eolearn/coregistration/coregistration.py
@@ -21,7 +21,6 @@ import numpy as np
 import registration
 from eolearn.core import EOTask
 from eolearn.core.exceptions import EORuntimeWarning
-from eolearn.core.utilities import renamed_and_deprecated
 
 from .coregistration_utilities import EstimateEulerTransformModel, ransac
 
@@ -432,18 +431,3 @@ def get_gradient(src):
     # Combine the two gradients
     grad = cv2.addWeighted(np.absolute(grad_x), 0.5, np.absolute(grad_y), 0.5, 0)
     return grad
-
-
-@renamed_and_deprecated
-class ThunderRegistration(ThunderRegistrationTask):
-    """A deprecated version of ThunderRegistrationTask"""
-
-
-@renamed_and_deprecated
-class ECCRegistration(ECCRegistrationTask):
-    """A deprecated version of ECCRegistrationTask"""
-
-
-@renamed_and_deprecated
-class PointBasedRegistration(PointBasedRegistrationTask):
-    """A deprecated version of PointBasedRegistrationTask"""

--- a/features/eolearn/features/__init__.py
+++ b/features/eolearn/features/__init__.py
@@ -9,16 +9,7 @@ from .temporal_features import (
 )
 from .interpolation import (
     InterpolationTask,
-    LinearInterpolation,
-    CubicInterpolation,
-    SplineInterpolation,
-    BSplineInterpolation,
-    AkimaInterpolation,
     ResamplingTask,
-    NearestResampling,
-    LinearResampling,
-    CubicResampling,
-    KrigingInterpolation,
     LinearInterpolationTask,
     CubicInterpolationTask,
     SplineInterpolationTask,
@@ -33,19 +24,11 @@ from .feature_extractor import FeatureExtractionTask, FeatureExtendedExtractor
 from .feature_manipulation import (
     SimpleFilterTask,
     FilterTimeSeriesTask,
-    FilterTimeSeries,
     ValueFilloutTask,
     LinearFunctionTask,
 )
 from .haralick import HaralickTask
 from .radiometric_normalization import (
-    ReferenceScenes,
-    HistogramMatching,
-    BlueCompositing,
-    HOTCompositing,
-    MaxNDVICompositing,
-    MaxNDWICompositing,
-    MaxRatioCompositing,
     ReferenceScenesTask,
     HistogramMatchingTask,
     BlueCompositingTask,

--- a/features/eolearn/features/feature_manipulation.py
+++ b/features/eolearn/features/feature_manipulation.py
@@ -18,7 +18,6 @@ from typing import Optional
 import numpy as np
 
 from eolearn.core import EOTask, FeatureType, MapFeatureTask
-from eolearn.core.utilities import renamed_and_deprecated
 
 
 LOGGER = logging.getLogger(__name__)
@@ -230,8 +229,3 @@ class LinearFunctionTask(MapFeatureTask):
         """A method where feature is multiplied by a slope"""
         rescaled_feature = feature * slope + intercept
         return rescaled_feature if dtype is None else rescaled_feature.astype(dtype)
-
-
-@renamed_and_deprecated
-class FilterTimeSeries(FilterTimeSeriesTask):
-    """A deprecated version of FilterTimeSeriesTask"""

--- a/features/eolearn/features/interpolation.py
+++ b/features/eolearn/features/interpolation.py
@@ -24,7 +24,6 @@ from sklearn.gaussian_process import GaussianProcessRegressor
 
 from eolearn.core import EOTask, EOPatch, FeatureType, FeatureTypeSet
 from eolearn.core.exceptions import EOUserWarning
-from eolearn.core.utilities import renamed_and_deprecated
 
 try:
     import numba
@@ -674,48 +673,3 @@ class CubicResamplingTask(ResamplingTask):
 
     def __init__(self, feature, resample_range, **kwargs):
         super().__init__(feature, scipy.interpolate.interp1d, resample_range, kind="cubic", **kwargs)
-
-
-@renamed_and_deprecated
-class LinearInterpolation(LinearInterpolationTask):
-    """A deprecated version of LinearInterpolationTask"""
-
-
-@renamed_and_deprecated
-class CubicInterpolation(CubicInterpolationTask):
-    """A deprecated version of CubicInterpolationTask"""
-
-
-@renamed_and_deprecated
-class SplineInterpolation(SplineInterpolationTask):
-    """A deprecated version of SplineInterpolationTask"""
-
-
-@renamed_and_deprecated
-class BSplineInterpolation(BSplineInterpolationTask):
-    """A deprecated version of BSplineInterpolationTask"""
-
-
-@renamed_and_deprecated
-class AkimaInterpolation(AkimaInterpolationTask):
-    """A deprecated version of AkimaInterpolationTask"""
-
-
-@renamed_and_deprecated
-class KrigingInterpolation(KrigingInterpolationTask):
-    """A deprecated version of KrigingInterpolationTask"""
-
-
-@renamed_and_deprecated
-class NearestResampling(NearestResamplingTask):
-    """A deprecated version of NearestResamplingTask"""
-
-
-@renamed_and_deprecated
-class LinearResampling(LinearResamplingTask):
-    """A deprecated version of LinearResamplingTask"""
-
-
-@renamed_and_deprecated
-class CubicResampling(CubicResamplingTask):
-    """A deprecated version of CubicResamplingTask"""

--- a/features/eolearn/features/radiometric_normalization.py
+++ b/features/eolearn/features/radiometric_normalization.py
@@ -13,7 +13,6 @@ from abc import ABCMeta
 import numpy as np
 
 from eolearn.core import EOTask
-from eolearn.core.utilities import renamed_and_deprecated
 
 
 class ReferenceScenesTask(EOTask):
@@ -384,43 +383,3 @@ class HistogramMatchingTask(EOTask):
             )
 
         return eopatch
-
-
-@renamed_and_deprecated
-class ReferenceScenes(ReferenceScenesTask):
-    """A deprecated version of ReferenceScenesTask"""
-
-
-@renamed_and_deprecated
-class BaseCompositing(BaseCompositingTask, metaclass=ABCMeta):
-    """A deprecated version of BaseCompositingTask"""
-
-
-@renamed_and_deprecated
-class BlueCompositing(BlueCompositingTask):
-    """A deprecated version of BlueCompositingTask"""
-
-
-@renamed_and_deprecated
-class MaxNDVICompositing(MaxNDVICompositingTask):
-    """A deprecated version of MaxNDVICompositingTask"""
-
-
-@renamed_and_deprecated
-class MaxNDWICompositing(MaxNDWICompositingTask):
-    """A deprecated version of MaxNDWICompositingTask"""
-
-
-@renamed_and_deprecated
-class HOTCompositing(HOTCompositingTask):
-    """A deprecated version of HOTCompositingTask"""
-
-
-@renamed_and_deprecated
-class MaxRatioCompositing(MaxRatioCompositingTask):
-    """A deprecated version of MaxRatioCompositingTask"""
-
-
-@renamed_and_deprecated
-class HistogramMatching(HistogramMatchingTask):
-    """A deprecated version of HistogramMatchingTask"""

--- a/geometry/eolearn/geometry/__init__.py
+++ b/geometry/eolearn/geometry/__init__.py
@@ -8,11 +8,7 @@ from .superpixel import (
     FelzenszwalbSegmentationTask,
     SlicSegmentationTask,
     MarkSegmentationBoundariesTask,
-    SuperpixelSegmentation,
-    FelzenszwalbSegmentation,
-    SlicSegmentation,
-    MarkSegmentationBoundaries,
 )
-from .transformations import VectorToRasterTask, RasterToVectorTask, VectorToRaster, RasterToVector
+from .transformations import VectorToRasterTask, RasterToVectorTask
 
 __version__ = "1.0.0"

--- a/geometry/eolearn/geometry/superpixel.py
+++ b/geometry/eolearn/geometry/superpixel.py
@@ -18,7 +18,6 @@ import numpy as np
 
 from eolearn.core import EOTask, FeatureType, FeatureTypeSet
 from eolearn.core.exceptions import EORuntimeWarning
-from eolearn.core.utilities import renamed_and_deprecated
 
 LOGGER = logging.getLogger(__name__)
 
@@ -145,23 +144,3 @@ class MarkSegmentationBoundariesTask(EOTask):
         bounds_mask = bounds_mask[..., :1].astype(np.uint8)
         eopatch[self.new_feature[0]][self.new_feature[1]] = bounds_mask
         return eopatch
-
-
-@renamed_and_deprecated
-class SuperpixelSegmentation(SuperpixelSegmentationTask):
-    """A deprecated version of SuperpixelSegmentationTask"""
-
-
-@renamed_and_deprecated
-class FelzenszwalbSegmentation(FelzenszwalbSegmentationTask):
-    """A deprecated version of FelzenszwalbSegmentationTask"""
-
-
-@renamed_and_deprecated
-class SlicSegmentation(SlicSegmentationTask):
-    """A deprecated version of SlicSegmentationTask"""
-
-
-@renamed_and_deprecated
-class MarkSegmentationBoundaries(MarkSegmentationBoundariesTask):
-    """A deprecated version of MarkSegmentationBoundariesTask"""

--- a/geometry/eolearn/geometry/transformations.py
+++ b/geometry/eolearn/geometry/transformations.py
@@ -27,7 +27,6 @@ from geopandas import GeoSeries, GeoDataFrame
 from sentinelhub import CRS, bbox_to_dimensions
 from eolearn.core import EOTask, FeatureType, FeatureTypeSet
 from eolearn.core.exceptions import EORuntimeWarning
-from eolearn.core.utilities import renamed_and_deprecated
 
 LOGGER = logging.getLogger(__name__)
 
@@ -463,13 +462,3 @@ def _vector_is_timeless(vector_input):
 
     vector_type, _ = vector_input
     return vector_type.is_timeless()
-
-
-@renamed_and_deprecated
-class VectorToRaster(VectorToRasterTask):
-    """A deprecated version of VectorToRasterTask"""
-
-
-@renamed_and_deprecated
-class RasterToVector(RasterToVectorTask):
-    """A deprecated version of RasterToVectorTask"""

--- a/io/eolearn/io/__init__.py
+++ b/io/eolearn/io/__init__.py
@@ -2,8 +2,8 @@
 A collection of input and output EOTasks
 """
 
-from .geopedia import AddGeopediaFeature, AddGeopediaFeatureTask
-from .local_io import ExportToTiff, ImportFromTiff, ExportToTiffTask, ImportFromTiffTask
+from .geopedia import AddGeopediaFeatureTask
+from .local_io import ExportToTiffTask, ImportFromTiffTask
 from .geometry_io import VectorImportTask, GeopediaVectorImportTask
 from .sentinelhub_process import (
     SentinelHubDemTask,

--- a/io/eolearn/io/geopedia.py
+++ b/io/eolearn/io/geopedia.py
@@ -18,7 +18,6 @@ import rasterio.warp
 from sentinelhub import MimeType, CRS, GeopediaWmsRequest
 
 from eolearn.core import EOTask, FeatureType
-from eolearn.core.utilities import renamed_and_deprecated
 
 LOGGER = logging.getLogger(__name__)
 
@@ -174,8 +173,3 @@ class AddGeopediaFeatureTask(EOTask):
         eopatch[self.feature_type][self.feature_name] = raster
 
         return eopatch
-
-
-@renamed_and_deprecated
-class AddGeopediaFeature(AddGeopediaFeatureTask):
-    """A deprecated version of AddGeopediaFeatureTask"""

--- a/io/eolearn/io/local_io.py
+++ b/io/eolearn/io/local_io.py
@@ -25,7 +25,6 @@ from sentinelhub import CRS, BBox
 from eolearn.core import EOTask, EOPatch
 from eolearn.core.exceptions import EORuntimeWarning
 from eolearn.core.fs_utils import get_base_filesystem_and_path
-from eolearn.core.utilities import renamed_and_deprecated
 
 LOGGER = logging.getLogger(__name__)
 
@@ -486,18 +485,3 @@ class ImportFromTiffTask(BaseLocalIoTask):
         eopatch[feature_type][feature_name] = data
 
         return eopatch
-
-
-@renamed_and_deprecated
-class BaseLocalIo(BaseLocalIoTask, metaclass=ABCMeta):
-    """A deprecated version of BaseLocalIoTask"""
-
-
-@renamed_and_deprecated
-class ExportToTiff(ExportToTiffTask):
-    """A deprecated version of ExportToTiffTask"""
-
-
-@renamed_and_deprecated
-class ImportFromTiff(ImportFromTiffTask):
-    """A deprecated version of ImportFromTiffTask"""

--- a/mask/eolearn/mask/__init__.py
+++ b/mask/eolearn/mask/__init__.py
@@ -3,8 +3,8 @@ Public classes and functions of mask subpackage
 """
 
 from .cloud_mask import CloudMaskTask
-from .masking import AddValidDataMaskTask, MaskFeatureTask, MaskFeature, JoinMasksTask
-from .snow_mask import SnowMask, TheiaSnowMask, SnowMaskTask, TheiaSnowMaskTask
+from .masking import AddValidDataMaskTask, MaskFeatureTask, JoinMasksTask
+from .snow_mask import SnowMaskTask, TheiaSnowMaskTask
 from .utilities import resize_images
 from .mask_counting import ClassFrequencyTask
 

--- a/mask/eolearn/mask/masking.py
+++ b/mask/eolearn/mask/masking.py
@@ -15,7 +15,6 @@ from typing import Union, Callable
 import numpy as np
 
 from eolearn.core import EOTask, FeatureType, ZipFeatureTask
-from eolearn.core.utilities import renamed_and_deprecated
 
 
 class AddValidDataMaskTask(EOTask):
@@ -167,8 +166,3 @@ def apply_mask(data, mask, old_value, new_value, data_type, mask_type):
             f"Mask feature has {mask.shape[-1]} number of bands while data feature has {data.shape[-1]} number of bands"
         )
     return data
-
-
-@renamed_and_deprecated
-class MaskFeature(MaskFeatureTask):
-    """A deprecated version of MaskFeatureTask"""

--- a/mask/eolearn/mask/snow_mask.py
+++ b/mask/eolearn/mask/snow_mask.py
@@ -17,7 +17,6 @@ import numpy as np
 from skimage.morphology import disk, binary_dilation
 
 from eolearn.core import EOTask, FeatureType
-from eolearn.core.utilities import renamed_and_deprecated
 from .utilities import resize_images
 
 
@@ -305,13 +304,3 @@ class TheiaSnowMaskTask(BaseSnowMaskTask):
         eopatch[self.mask_feature] = snow_mask[..., np.newaxis].astype(bool)
 
         return eopatch
-
-
-@renamed_and_deprecated
-class SnowMask(SnowMaskTask):
-    """A deprecated version of SnowMaskTask"""
-
-
-@renamed_and_deprecated
-class TheiaSnowMask(TheiaSnowMaskTask):
-    """A deprecated version of TheiaSnowMaskTask"""


### PR DESCRIPTION
This is the perfect moment to remove the old names of tasks (before we started enforcing the `Task` suffix for our tasks).