### PR TITLE
SH input tasks for cases with no data

### DIFF
--- a/io/eolearn/io/sentinelhub_process.py
+++ b/io/eolearn/io/sentinelhub_process.py
@@ -675,13 +675,13 @@ class SentinelHubSen2corTask(SentinelHubInputTask):
 
 
 def get_available_timestamps(
-        bbox: BBox,
-        data_collection: DataCollection,
-        *,
-        time_interval: Optional[Tuple[dt.datetime, dt.datetime]] = None,
-        time_difference: dt.timedelta = dt.timedelta(seconds=-1),
-        maxcc: Optional[float] = None,
-        config: Optional[SHConfig] = None,
+    bbox: BBox,
+    data_collection: DataCollection,
+    *,
+    time_interval: Optional[Tuple[dt.datetime, dt.datetime]] = None,
+    time_difference: dt.timedelta = dt.timedelta(seconds=-1),
+    maxcc: Optional[float] = None,
+    config: Optional[SHConfig] = None,
 ) -> List[dt.datetime]:
     """Helper function to search for all available timestamps, based on query parameters.
 
@@ -707,7 +707,7 @@ def get_available_timestamps(
 
     catalog = SentinelHubCatalog(config=config)
     search_iterator = catalog.search(
-        collection=data_collection, bbox=bbox, time=time_interval, query=query, #fields=fields
+        collection=data_collection, bbox=bbox, time=time_interval, query=query, fields=fields
     )
 
     all_timestamps = search_iterator.get_timestamps()

--- a/io/eolearn/tests/test_sentinelhub_process.py
+++ b/io/eolearn/tests/test_sentinelhub_process.py
@@ -57,13 +57,14 @@ class IoTestCase:
 
 def calculate_stats(array):
     time, height, width, _ = array.shape
-    edge1 = np.nanmean(array[int(time / 2) :, 0, 0, :])
-    edge2 = np.nanmean(array[: max(int(time / 2), 1), -1, -1, :])
-    edge3 = np.nanmean(array[:, int(height / 2), int(width / 2), :])
 
-    stats = np.round(np.array([edge1, edge2, edge3]), 4)
-
-    return stats
+    slices = [
+        array[int(time / 2):, 0, 0, :],
+        array[: max(int(time / 2), 1), -1, -1, :],
+        array[:, int(height / 2), int(width / 2), :]
+    ]
+    values = [(np.nanmean(slice) if not np.isnan(slice).all() else np.nan) for slice in slices]
+    return np.round(np.array(values), 4)
 
 
 @pytest.mark.sh_integration

--- a/io/eolearn/tests/test_sentinelhub_process.py
+++ b/io/eolearn/tests/test_sentinelhub_process.py
@@ -59,9 +59,9 @@ def calculate_stats(array):
     time, height, width, _ = array.shape
 
     slices = [
-        array[int(time / 2):, 0, 0, :],
+        array[int(time / 2) :, 0, 0, :],
         array[: max(int(time / 2), 1), -1, -1, :],
-        array[:, int(height / 2), int(width / 2), :]
+        array[:, int(height / 2), int(width / 2), :],
     ]
     values = [(np.nanmean(slice) if not np.isnan(slice).all() else np.nan) for slice in slices]
     return np.round(np.array(values), 4)
@@ -432,7 +432,7 @@ class TestProcessingIO:
             data_collection=DataCollection.SENTINEL2_L1C,
             features=[(FeatureType.DATA, "bands"), (FeatureType.MASK, "mask")],
             size=self.size,
-            maxcc=0.0
+            maxcc=0.0,
         )
 
         eopatch = task.execute(bbox=self.bbox, time_interval=("2021-01-01", "2021-01-20"))


### PR DESCRIPTION
 In case of no available data `SentinelHubInputTask` and `SentinelHubEvalscriptTask` now create arrays with time dimension 0 instead of raising an error.

Additionally, I've a few of minor improvements in `get_available_timestamps` and in tests.