### PR TITLE
Support AWS session tokens

### DIFF
--- a/core/eolearn/core/fs_utils.py
+++ b/core/eolearn/core/fs_utils.py
@@ -95,5 +95,6 @@ def load_s3_filesystem(path, strict=False, config=None):
         dir_path=dir_path,
         aws_access_key_id=config.aws_access_key_id if config.aws_access_key_id else None,
         aws_secret_access_key=config.aws_secret_access_key if config.aws_secret_access_key else None,
+        aws_session_token=config.aws_session_token if config.aws_session_token else None,
         strict=strict
     )

--- a/core/eolearn/tests/test_fs_utils.py
+++ b/core/eolearn/tests/test_fs_utils.py
@@ -64,6 +64,29 @@ class TestFilesystemUtils(unittest.TestCase):
             self.assertTrue(isinstance(filesystem, S3FS))
             self.assertEqual(filesystem.aws_access_key_id, custom_config.aws_access_key_id)
             self.assertEqual(filesystem.aws_secret_access_key, custom_config.aws_secret_access_key)
+            self.assertEqual(filesystem.aws_session_token, None)
+
+    @mock_s3
+    def test_s3_filesystem_with_session_token(self):
+        folder_name = 'my_folder'
+        s3_url = f's3://test-eo-bucket/{folder_name}'
+
+        filesystem = get_filesystem(s3_url)
+        self.assertTrue(isinstance(filesystem, S3FS))
+        self.assertEqual(filesystem.dir_path, folder_name)
+
+        custom_config = SHConfig()
+        custom_config.aws_access_key_id = 'fake-key'
+        custom_config.aws_secret_access_key = 'fake-secret'
+        custom_config.aws_session_token = 'fake-session-token'
+        filesystem1 = load_s3_filesystem(s3_url, strict=False, config=custom_config)
+        filesystem2 = get_filesystem(s3_url, config=custom_config)
+
+        for filesystem in [filesystem1, filesystem2]:
+            self.assertTrue(isinstance(filesystem, S3FS))
+            self.assertEqual(filesystem.aws_access_key_id, custom_config.aws_access_key_id)
+            self.assertEqual(filesystem.aws_secret_access_key, custom_config.aws_secret_access_key)
+            self.assertEqual(filesystem.aws_session_token, custom_config.aws_session_token)
 
 
 if __name__ == '__main__':

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -2,7 +2,7 @@ attrs>=19.2.0
 python-dateutil
 numpy>=1.19.0
 geopandas>=0.5.0,!=0.8.0
-sentinelhub>=3.1.0
+sentinelhub>=3.4.4
 tqdm>=4.27
 boto3
 fs

--- a/io/eolearn/io/geometry_io.py
+++ b/io/eolearn/io/geometry_io.py
@@ -116,6 +116,7 @@ class VectorImportTask(_BaseVectorImportTask):
             if self.config and self.config.aws_access_key_id and self.config.aws_secret_access_key:
                 session_credentials['aws_access_key_id'] = self.config.aws_access_key_id
                 session_credentials['aws_secret_access_key'] = self.config.aws_secret_access_key
+                session_credentials['aws_session_token'] = self.config.aws_session_token
 
             boto_session = boto3.session.Session(**session_credentials)
             self._aws_session = AWSSession(boto_session)

--- a/io/requirements.txt
+++ b/io/requirements.txt
@@ -1,5 +1,5 @@
 eo-learn-core
-sentinelhub>=3.4.0
+sentinelhub>=3.4.4
 rasterio>=1.2.7
 rtree
 geopandas>=0.5.0,!=0.8.0


### PR DESCRIPTION
Use a config parameter `aws_session_token` introduced with [sentinelhub-py 3.4.4](https://github.com/sentinel-hub/sentinelhub-py/releases/tag/v3.4.4) that allows configuring libraries with SHConfig instances with temporary IAM credentials that are usually used at EC2 machines (access id, key and STS token are all required to initialize boto3).