### PR TITLE
Support AWS session tokens

### DIFF
--- a/core/eolearn/core/utils/fs.py
+++ b/core/eolearn/core/utils/fs.py
@@ -99,6 +99,7 @@ def load_s3_filesystem(
         dir_path=dir_path,
         aws_access_key_id=config.aws_access_key_id if config.aws_access_key_id else None,
         aws_secret_access_key=config.aws_secret_access_key if config.aws_secret_access_key else None,
+        aws_session_token=config.aws_session_token if config.aws_session_token else None,
         strict=strict,
     )
 
@@ -118,6 +119,7 @@ def get_aws_credentials(aws_profile: str, config: Optional[SHConfig] = None) -> 
 
     config.aws_access_key_id = aws_credentials.access_key
     config.aws_secret_access_key = aws_credentials.secret_key
+    config.aws_session_token = aws_credentials.token
     return config
 
 

--- a/core/eolearn/tests/test_fs_utils.py
+++ b/core/eolearn/tests/test_fs_utils.py
@@ -62,6 +62,7 @@ def test_s3_filesystem():
         assert filesystem.aws_secret_access_key == custom_config.aws_secret_access_key
         assert filesystem.aws_session_token is None
 
+
 @mock_s3
 def test_s3_filesystem_with_session_token():
     folder_name = "my_folder"

--- a/core/eolearn/tests/test_fs_utils.py
+++ b/core/eolearn/tests/test_fs_utils.py
@@ -60,6 +60,29 @@ def test_s3_filesystem():
         assert isinstance(filesystem, S3FS)
         assert filesystem.aws_access_key_id == custom_config.aws_access_key_id
         assert filesystem.aws_secret_access_key == custom_config.aws_secret_access_key
+        assert filesystem.aws_session_token is None
+
+@mock_s3
+def test_s3_filesystem_with_session_token():
+    folder_name = "my_folder"
+    s3_url = f"s3://test-eo-bucket/{folder_name}"
+
+    filesystem = get_filesystem(s3_url)
+    assert isinstance(filesystem, S3FS)
+    assert filesystem.dir_path == folder_name
+
+    custom_config = SHConfig()
+    custom_config.aws_access_key_id = "fake-key"
+    custom_config.aws_secret_access_key = "fake-secret"
+    custom_config.aws_session_token = "fake-session-token"
+    filesystem1 = load_s3_filesystem(s3_url, strict=False, config=custom_config)
+    filesystem2 = get_filesystem(s3_url, config=custom_config)
+
+    for filesystem in [filesystem1, filesystem2]:
+        assert isinstance(filesystem, S3FS)
+        assert filesystem.aws_access_key_id == custom_config.aws_access_key_id
+        assert filesystem.aws_secret_access_key == custom_config.aws_secret_access_key
+        assert filesystem.aws_session_token == custom_config.aws_session_token
 
 
 @mock.patch("eolearn.core.utils.fs.Session")

--- a/core/eolearn/tests/test_fs_utils.py
+++ b/core/eolearn/tests/test_fs_utils.py
@@ -42,7 +42,8 @@ def test_pathlib_support(tmp_path):
 
 
 @mock_s3
-def test_s3_filesystem():
+@pytest.mark.parametrize("aws_session_token", [None, "fake-session-token"])
+def test_s3_filesystem(aws_session_token):
     folder_name = "my_folder"
     s3_url = f"s3://test-eo-bucket/{folder_name}"
 
@@ -53,6 +54,7 @@ def test_s3_filesystem():
     custom_config = SHConfig()
     custom_config.aws_access_key_id = "fake-key"
     custom_config.aws_secret_access_key = "fake-secret"
+    custom_config.aws_session_token = aws_session_token
     filesystem1 = load_s3_filesystem(s3_url, strict=False, config=custom_config)
     filesystem2 = get_filesystem(s3_url, config=custom_config)
 
@@ -60,30 +62,7 @@ def test_s3_filesystem():
         assert isinstance(filesystem, S3FS)
         assert filesystem.aws_access_key_id == custom_config.aws_access_key_id
         assert filesystem.aws_secret_access_key == custom_config.aws_secret_access_key
-        assert filesystem.aws_session_token is None
-
-
-@mock_s3
-def test_s3_filesystem_with_session_token():
-    folder_name = "my_folder"
-    s3_url = f"s3://test-eo-bucket/{folder_name}"
-
-    filesystem = get_filesystem(s3_url)
-    assert isinstance(filesystem, S3FS)
-    assert filesystem.dir_path == folder_name
-
-    custom_config = SHConfig()
-    custom_config.aws_access_key_id = "fake-key"
-    custom_config.aws_secret_access_key = "fake-secret"
-    custom_config.aws_session_token = "fake-session-token"
-    filesystem1 = load_s3_filesystem(s3_url, strict=False, config=custom_config)
-    filesystem2 = get_filesystem(s3_url, config=custom_config)
-
-    for filesystem in [filesystem1, filesystem2]:
-        assert isinstance(filesystem, S3FS)
-        assert filesystem.aws_access_key_id == custom_config.aws_access_key_id
-        assert filesystem.aws_secret_access_key == custom_config.aws_secret_access_key
-        assert filesystem.aws_session_token == custom_config.aws_session_token
+        assert filesystem.aws_session_token == aws_session_token
 
 
 @mock.patch("eolearn.core.utils.fs.Session")

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -2,7 +2,7 @@ attrs>=19.2.0
 python-dateutil
 numpy>=1.20.0
 geopandas>=0.8.1
-sentinelhub>=3.4.3
+sentinelhub>=3.4.4
 tqdm>=4.27
 boto3
 fs

--- a/io/eolearn/io/geometry_io.py
+++ b/io/eolearn/io/geometry_io.py
@@ -121,6 +121,7 @@ class VectorImportTask(_BaseVectorImportTask):
             if self.config and self.config.aws_access_key_id and self.config.aws_secret_access_key:
                 session_credentials["aws_access_key_id"] = self.config.aws_access_key_id
                 session_credentials["aws_secret_access_key"] = self.config.aws_secret_access_key
+                session_credentials["aws_session_token"] = self.config.aws_session_token
 
             boto_session = boto3.session.Session(**session_credentials)
             self._aws_session = AWSSession(boto_session)

--- a/io/requirements.txt
+++ b/io/requirements.txt
@@ -1,5 +1,5 @@
 eo-learn-core
-sentinelhub>=3.4.0
+sentinelhub>=3.4.4
 rasterio>=1.2.7
 rtree
 geopandas>=0.8.1


### PR DESCRIPTION
Use a config parameter `aws_session_token` introduced with [sentinelhub-py 3.4.4](https://github.com/sentinel-hub/sentinelhub-py/releases/tag/v3.4.4) that allows configuring libraries with SHConfig instances with temporary IAM credentials that are usually used at EC2 machines (access id, key and STS token are all required to initialize boto3).