### PR TITLE
Add isort to eolearn

### DIFF
--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -7,18 +7,31 @@ on:
 
 jobs:
 
-  check-code-formatting:
+  check-code-black:
     runs-on: ubuntu-latest
     steps:
       - name: Check out current branch
         if: github.event_name == 'push'
         uses: actions/checkout@v2
 
-      - name: Check code is compliant with black formatter
+      - name: Check code compliance with black
         if: github.event_name == 'push'
-        uses: rickstaa/action-black@v1
-        with:
-          black_args: ". --line-length 120 --check --experimental-string-processing"
+        run: |
+          pip install black[jupyter]
+          black . --check --diff
+
+  check-code-isort:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out current branch
+        if: github.event_name == 'push'
+        uses: actions/checkout@v2
+
+      - name: Check code compliance with isort
+        if: github.event_name == 'push'
+        run: |
+          pip install isort
+          isort **/*.py --check --diff
 
   test-on-github:
     runs-on: ubuntu-latest

--- a/core/eolearn/core/__init__.py
+++ b/core/eolearn/core/__init__.py
@@ -2,34 +2,32 @@
 The following objects and functions are the core of eo-learn package
 """
 from .constants import FeatureType, FeatureTypeSet, OverwritePermission
-from .eodata import EOPatch
-from .eotask import EOTask
-from .eonode import EONode, linearly_connect_tasks
-from .eoworkflow import EOWorkflow, WorkflowResults
-from .eoworkflow_tasks import OutputTask
-from .eoexecution import EOExecutor, execute_with_mp_lock
-
 from .core_tasks import (
-    CopyTask,
-    DeepCopyTask,
-    SaveTask,
-    LoadTask,
     AddFeatureTask,
+    CopyTask,
+    CreateEOPatchTask,
+    DeepCopyTask,
+    DuplicateFeatureTask,
+    ExtractBandsTask,
+    InitializeFeatureTask,
+    LoadTask,
+    MapFeatureTask,
+    MergeEOPatchesTask,
+    MergeFeatureTask,
+    MoveFeatureTask,
     RemoveFeatureTask,
     RenameFeatureTask,
-    DuplicateFeatureTask,
-    InitializeFeatureTask,
-    MoveFeatureTask,
-    MergeFeatureTask,
-    MapFeatureTask,
+    SaveTask,
     ZipFeatureTask,
-    ExtractBandsTask,
-    CreateEOPatchTask,
-    MergeEOPatchesTask,
 )
-
+from .eodata import EOPatch
+from .eoexecution import EOExecutor, execute_with_mp_lock
+from .eonode import EONode, linearly_connect_tasks
+from .eotask import EOTask
+from .eoworkflow import EOWorkflow, WorkflowResults
+from .eoworkflow_tasks import OutputTask
+from .utils.common import constant_pad, deep_eq
 from .utils.fs import get_filesystem, load_s3_filesystem
 from .utils.parsing import FeatureParser
-from .utils.common import deep_eq, constant_pad
 
 __version__ = "1.0.0"

--- a/core/eolearn/core/constants.py
+++ b/core/eolearn/core/constants.py
@@ -10,8 +10,8 @@ Copyright (c) 2017-2019 Blaž Sovdat, Andrej Burja (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-from typing import Optional
 from enum import Enum
+from typing import Optional
 
 from sentinelhub import BBox, MimeType
 

--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -12,7 +12,7 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 import copy
-from abc import abstractmethod, ABCMeta
+from abc import ABCMeta, abstractmethod
 
 import fs
 import numpy as np

--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -13,25 +13,24 @@ file in the root directory of this source tree.
 """
 from __future__ import annotations
 
-import logging
 import copy
 import datetime
-from typing import Tuple, Union, List, Optional, TYPE_CHECKING
+import logging
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import attr
 import dateutil.parser
-import numpy as np
 import geopandas as gpd
+import numpy as np
 
-from sentinelhub import BBox, CRS
+from sentinelhub import CRS, BBox
 
 from .constants import FeatureType, OverwritePermission
-from .eodata_io import save_eopatch, load_eopatch, FeatureIO
+from .eodata_io import FeatureIO, load_eopatch, save_eopatch
 from .eodata_merge import merge_eopatches
-from .utils.fs import get_filesystem
 from .utils.common import deep_eq, is_discrete_type
+from .utils.fs import get_filesystem
 from .utils.parsing import parse_features
-
 
 LOGGER = logging.getLogger(__name__)
 

--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -9,21 +9,21 @@ Copyright (c) 2017-2019 Blaž Sovdat, Andrej Burja (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+import concurrent.futures
+import gzip
 import json
 import pickle
-import gzip
 import warnings
-import concurrent.futures
 from collections import defaultdict
 
 import fs
-from fs.tempfs import TempFS
+import geopandas as gpd
 import numpy as np
 import pandas as pd
-import geopandas as gpd
+from fs.tempfs import TempFS
 from geopandas import GeoDataFrame, GeoSeries
 
-from sentinelhub import Geometry, CRS, MimeType
+from sentinelhub import CRS, Geometry, MimeType
 from sentinelhub.exceptions import SHUserWarning
 from sentinelhub.os_utils import sys_is_windows
 

--- a/core/eolearn/core/eodata_merge.py
+++ b/core/eolearn/core/eodata_merge.py
@@ -10,8 +10,8 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 import functools
-import warnings
 import itertools as it
+import warnings
 from collections.abc import Callable
 
 import numpy as np

--- a/core/eolearn/core/eoexecution.py
+++ b/core/eolearn/core/eoexecution.py
@@ -23,17 +23,7 @@ import warnings
 from dataclasses import dataclass
 from enum import Enum
 from logging import Filter, Handler, Logger
-from typing import (
-    Callable,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    TypeVar,
-    cast,
-)
+from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple, TypeVar, cast
 
 import fs
 from tqdm.auto import tqdm

--- a/core/eolearn/core/eoexecution.py
+++ b/core/eolearn/core/eoexecution.py
@@ -14,16 +14,26 @@ Copyright (c) 2017-2019 Blaž Sovdat, Andrej Burja (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-import logging
-import threading
 import concurrent.futures
 import datetime as dt
+import logging
 import multiprocessing
+import threading
 import warnings
-from enum import Enum
-from logging import Logger, Handler, Filter
 from dataclasses import dataclass
-from typing import Sequence, List, Tuple, Dict, Optional, Callable, Iterable, TypeVar, cast
+from enum import Enum
+from logging import Filter, Handler, Logger
+from typing import (
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    cast,
+)
 
 import fs
 from tqdm.auto import tqdm

--- a/core/eolearn/core/eonode.py
+++ b/core/eolearn/core/eonode.py
@@ -10,7 +10,7 @@ file in the root directory of this source tree.
 
 import datetime as dt
 from dataclasses import dataclass, field
-from typing import Sequence, Optional, List, Tuple, Union, Set, Dict, cast
+from typing import Dict, List, Optional, Sequence, Set, Tuple, Union, cast
 
 from .eotask import EOTask
 from .utils.common import generate_uid

--- a/core/eolearn/core/eotask.py
+++ b/core/eolearn/core/eotask.py
@@ -21,13 +21,7 @@ from dataclasses import dataclass
 from typing import Dict, Iterable, Optional
 
 from .constants import FeatureType
-from .utils.parsing import (
-    FeatureParser,
-    parse_feature,
-    parse_features,
-    parse_renamed_feature,
-    parse_renamed_features,
-)
+from .utils.parsing import FeatureParser, parse_feature, parse_features, parse_renamed_feature, parse_renamed_features
 
 LOGGER = logging.getLogger(__name__)
 

--- a/core/eolearn/core/eotask.py
+++ b/core/eolearn/core/eotask.py
@@ -17,15 +17,15 @@ file in the root directory of this source tree.
 import inspect
 import logging
 from abc import ABCMeta, abstractmethod
-from typing import Dict, Iterable, Optional
 from dataclasses import dataclass
+from typing import Dict, Iterable, Optional
 
 from .constants import FeatureType
 from .utils.parsing import (
     FeatureParser,
     parse_feature,
-    parse_renamed_feature,
     parse_features,
+    parse_renamed_feature,
     parse_renamed_features,
 )
 

--- a/core/eolearn/core/eoworkflow.py
+++ b/core/eolearn/core/eoworkflow.py
@@ -20,18 +20,17 @@ Copyright (c) 2017-2019 Blaž Sovdat, Andrej Burja (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+import datetime as dt
 import logging
 import traceback
-import datetime as dt
-from typing import Dict, List, Optional, Sequence, Tuple, Set, cast
 from dataclasses import dataclass, field, fields
+from typing import Dict, List, Optional, Sequence, Set, Tuple, cast
 
 from .eodata import EOPatch
 from .eonode import EONode, NodeStats
 from .eotask import EOTask
 from .eoworkflow_tasks import OutputTask
 from .graph import DirectedGraph
-
 
 LOGGER = logging.getLogger(__name__)
 

--- a/core/eolearn/core/eoworkflow_tasks.py
+++ b/core/eolearn/core/eoworkflow_tasks.py
@@ -8,8 +8,9 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 from typing import Optional
-from .eotask import EOTask
+
 from .eodata import EOPatch
+from .eotask import EOTask
 from .utils.common import generate_uid
 
 

--- a/core/eolearn/core/extra/ray.py
+++ b/core/eolearn/core/extra/ray.py
@@ -17,7 +17,7 @@ except ImportError as exception:
     raise ImportError("This module requires an installation of Ray Python package") from exception
 from tqdm.auto import tqdm
 
-from ..eoexecution import EOExecutor, _ProcessingType, _ProcessingData
+from ..eoexecution import EOExecutor, _ProcessingData, _ProcessingType
 from ..eoworkflow import WorkflowResults
 
 

--- a/core/eolearn/core/graph.py
+++ b/core/eolearn/core/graph.py
@@ -13,7 +13,7 @@ file in the root directory of this source tree.
 
 import collections
 import copy
-from typing import List, Dict, Optional, Any, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 
 class CyclicDependencyError(ValueError):

--- a/core/eolearn/core/utils/common.py
+++ b/core/eolearn/core/utils/common.py
@@ -14,8 +14,9 @@ file in the root directory of this source tree.
 """
 
 import uuid
-import numpy as np
+
 import geopandas as gpd
+import numpy as np
 from geopandas.testing import assert_geodataframe_equal
 
 

--- a/core/eolearn/core/utils/fs.py
+++ b/core/eolearn/core/utils/fs.py
@@ -13,8 +13,8 @@ from pathlib import Path, PurePath
 from typing import Optional, Tuple
 
 import fs
-from fs_s3fs import S3FS
 from boto3 import Session
+from fs_s3fs import S3FS
 
 from sentinelhub import SHConfig
 

--- a/core/eolearn/core/utils/logging.py
+++ b/core/eolearn/core/utils/logging.py
@@ -17,7 +17,6 @@ import logging
 from logging import Filter, LogRecord
 from typing import Optional
 
-
 LOGGER = logging.getLogger(__name__)
 
 

--- a/core/eolearn/core/utils/parsing.py
+++ b/core/eolearn/core/utils/parsing.py
@@ -14,8 +14,7 @@ file in the root directory of this source tree.
 from __future__ import annotations
 
 from itertools import repeat
-from typing import Optional, Union, Tuple, Sequence, Iterable, List, cast, TYPE_CHECKING
-
+from typing import TYPE_CHECKING, Iterable, List, Optional, Sequence, Tuple, Union, cast
 
 from ..constants import FeatureType
 

--- a/core/eolearn/tests/test_core_tasks.py
+++ b/core/eolearn/tests/test_core_tasks.py
@@ -10,30 +10,31 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import datetime
 import copy
+import datetime
 
-import pytest
 import numpy as np
+import pytest
 
 from sentinelhub import CRS
+
 from eolearn.core import (
-    EOPatch,
-    FeatureType,
-    CopyTask,
-    DeepCopyTask,
     AddFeatureTask,
+    CopyTask,
+    CreateEOPatchTask,
+    DeepCopyTask,
+    DuplicateFeatureTask,
+    EOPatch,
+    ExtractBandsTask,
+    FeatureType,
+    InitializeFeatureTask,
+    MapFeatureTask,
+    MergeEOPatchesTask,
+    MergeFeatureTask,
+    MoveFeatureTask,
     RemoveFeatureTask,
     RenameFeatureTask,
-    DuplicateFeatureTask,
-    InitializeFeatureTask,
-    MoveFeatureTask,
-    MergeFeatureTask,
-    MapFeatureTask,
     ZipFeatureTask,
-    ExtractBandsTask,
-    CreateEOPatchTask,
-    MergeEOPatchesTask,
 )
 
 

--- a/core/eolearn/tests/test_eodata.py
+++ b/core/eolearn/tests/test_eodata.py
@@ -11,12 +11,13 @@ file in the root directory of this source tree.
 """
 import datetime
 
-import pytest
 import numpy as np
+import pytest
+from geopandas import GeoDataFrame, GeoSeries
 from numpy.testing import assert_array_equal
-from geopandas import GeoSeries, GeoDataFrame
 
-from sentinelhub import BBox, CRS
+from sentinelhub import CRS, BBox
+
 from eolearn.core import EOPatch, FeatureType, FeatureTypeSet
 from eolearn.core.eodata_io import FeatureIO
 

--- a/core/eolearn/tests/test_eodata_io.py
+++ b/core/eolearn/tests/test_eodata_io.py
@@ -10,18 +10,19 @@ import datetime
 import os
 import tempfile
 
-import pytest
-import numpy as np
+import boto3
 import fs
+import numpy as np
+import pytest
 from fs.errors import CreateFailed, ResourceNotFound
 from fs.tempfs import TempFS
 from fs_s3fs import S3FS
 from geopandas import GeoDataFrame
 from moto import mock_s3
-import boto3
 
-from sentinelhub import BBox, CRS
-from eolearn.core import EOPatch, FeatureType, OverwritePermission, SaveTask, LoadTask
+from sentinelhub import CRS, BBox
+
+from eolearn.core import EOPatch, FeatureType, LoadTask, OverwritePermission, SaveTask
 
 
 @mock_s3

--- a/core/eolearn/tests/test_eodata_merge.py
+++ b/core/eolearn/tests/test_eodata_merge.py
@@ -9,11 +9,12 @@ file in the root directory of this source tree.
 """
 import datetime as dt
 
-import pytest
 import numpy as np
+import pytest
 from geopandas import GeoDataFrame
 
-from sentinelhub import BBox, CRS
+from sentinelhub import CRS, BBox
+
 from eolearn.core import EOPatch, FeatureType
 from eolearn.core.eodata_io import FeatureIO
 from eolearn.core.exceptions import EORuntimeWarning

--- a/core/eolearn/tests/test_eoexecutor.py
+++ b/core/eolearn/tests/test_eoexecutor.py
@@ -19,15 +19,7 @@ import time
 
 import pytest
 
-from eolearn.core import (
-    EOExecutor,
-    EONode,
-    EOTask,
-    EOWorkflow,
-    OutputTask,
-    WorkflowResults,
-    execute_with_mp_lock,
-)
+from eolearn.core import EOExecutor, EONode, EOTask, EOWorkflow, OutputTask, WorkflowResults, execute_with_mp_lock
 
 
 class ExampleTask(EOTask):

--- a/core/eolearn/tests/test_eoexecutor.py
+++ b/core/eolearn/tests/test_eoexecutor.py
@@ -9,17 +9,25 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import os
-import logging
-import tempfile
-import datetime
 import concurrent.futures
+import datetime
+import logging
 import multiprocessing
+import os
+import tempfile
 import time
 
 import pytest
 
-from eolearn.core import EOTask, EOWorkflow, EONode, EOExecutor, WorkflowResults, execute_with_mp_lock, OutputTask
+from eolearn.core import (
+    EOExecutor,
+    EONode,
+    EOTask,
+    EOWorkflow,
+    OutputTask,
+    WorkflowResults,
+    execute_with_mp_lock,
+)
 
 
 class ExampleTask(EOTask):

--- a/core/eolearn/tests/test_eonode.py
+++ b/core/eolearn/tests/test_eonode.py
@@ -5,7 +5,7 @@ Copyright (c) 2021-2022 Matej Aleksandrov, Matej Batič, Miha Kadunc, Žiga Luk�
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-from eolearn.core import EOTask, EONode, linearly_connect_tasks, OutputTask
+from eolearn.core import EONode, EOTask, OutputTask, linearly_connect_tasks
 
 
 class InputTask(EOTask):

--- a/core/eolearn/tests/test_eoworkflow.py
+++ b/core/eolearn/tests/test_eoworkflow.py
@@ -10,20 +10,20 @@ file in the root directory of this source tree.
 import concurrent.futures
 import datetime as dt
 
-import pytest
 import numpy as np
+import pytest
 
 from eolearn.core import (
+    CreateEOPatchTask,
+    EONode,
     EOPatch,
     EOTask,
-    EONode,
     EOWorkflow,
-    OutputTask,
-    WorkflowResults,
     FeatureType,
     InitializeFeatureTask,
+    OutputTask,
     RemoveFeatureTask,
-    CreateEOPatchTask,
+    WorkflowResults,
 )
 from eolearn.core.eoworkflow import NodeStats
 

--- a/core/eolearn/tests/test_eoworkflow_tasks.py
+++ b/core/eolearn/tests/test_eoworkflow_tasks.py
@@ -7,7 +7,7 @@ Copyright (c) 2021-2022 Matej Aleksandrov, Matej Batič, Miha Kadunc, Žiga Luk�
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-from eolearn.core import EOTask, EOWorkflow, FeatureType, LoadTask, OutputTask, EONode
+from eolearn.core import EONode, EOTask, EOWorkflow, FeatureType, LoadTask, OutputTask
 from eolearn.core.eoworkflow_tasks import InputTask
 
 

--- a/core/eolearn/tests/test_extra/test_ray.py
+++ b/core/eolearn/tests/test_extra/test_ray.py
@@ -6,15 +6,15 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import os
-import logging
-import tempfile
 import datetime
+import logging
+import os
+import tempfile
 
 import pytest
 import ray
 
-from eolearn.core import EOTask, EOWorkflow, EOExecutor, EONode, WorkflowResults
+from eolearn.core import EOExecutor, EONode, EOTask, EOWorkflow, WorkflowResults
 from eolearn.core.eoworkflow_tasks import OutputTask
 from eolearn.core.extra.ray import RayExecutor
 

--- a/core/eolearn/tests/test_fs_utils.py
+++ b/core/eolearn/tests/test_fs_utils.py
@@ -7,17 +7,18 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 import os
+import unittest.mock as mock
 from pathlib import Path
 
 import pytest
-import unittest.mock as mock
 from botocore.credentials import Credentials
-from fs.osfs import OSFS
 from fs.errors import CreateFailed
+from fs.osfs import OSFS
 from fs_s3fs import S3FS
 from moto import mock_s3
 
 from sentinelhub import SHConfig
+
 from eolearn.core import get_filesystem, load_s3_filesystem
 from eolearn.core.utils.fs import get_aws_credentials, get_full_path, join_path
 

--- a/core/eolearn/tests/test_graph.py
+++ b/core/eolearn/tests/test_graph.py
@@ -10,9 +10,10 @@ file in the root directory of this source tree.
 import functools
 
 import pytest
-from hypothesis import given, strategies as st
+from hypothesis import given
+from hypothesis import strategies as st
 
-from eolearn.core.graph import DirectedGraph, CyclicDependencyError
+from eolearn.core.graph import CyclicDependencyError, DirectedGraph
 
 
 @pytest.fixture(name="test_graph")

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -1,9 +1,9 @@
 attrs>=19.2.0
-python-dateutil
-numpy>=1.20.0
-geopandas>=0.8.1
-sentinelhub>=3.4.3
-tqdm>=4.27
 boto3
 fs
 fs-s3fs
+geopandas>=0.8.1
+numpy>=1.20.0
+python-dateutil
+sentinelhub>=3.4.3
+tqdm>=4.27

--- a/core/setup.py
+++ b/core/setup.py
@@ -1,5 +1,6 @@
 import os
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 
 def get_long_description():

--- a/coregistration/eolearn/coregistration/__init__.py
+++ b/coregistration/eolearn/coregistration/__init__.py
@@ -3,10 +3,10 @@ A collection of tools and EOTasks for image co-registration
 """
 
 from .coregistration import (
-    RegistrationTask,
-    InterpolationType,
     ECCRegistrationTask,
+    InterpolationType,
     PointBasedRegistrationTask,
+    RegistrationTask,
     ThunderRegistrationTask,
 )
 

--- a/coregistration/eolearn/coregistration/coregistration.py
+++ b/coregistration/eolearn/coregistration/coregistration.py
@@ -20,10 +20,10 @@ from enum import Enum
 import cv2
 import numpy as np
 import registration
-from eolearn.core import EOTask
-from eolearn.core.exceptions import EORuntimeWarning
 
 from .utils import EstimateEulerTransformModel, ransac
+from eolearn.core import EOTask
+from eolearn.core.exceptions import EORuntimeWarning
 
 LOGGER = logging.getLogger(__name__)
 

--- a/coregistration/eolearn/coregistration/coregistration.py
+++ b/coregistration/eolearn/coregistration/coregistration.py
@@ -21,9 +21,10 @@ import cv2
 import numpy as np
 import registration
 
-from .utils import EstimateEulerTransformModel, ransac
 from eolearn.core import EOTask
 from eolearn.core.exceptions import EORuntimeWarning
+
+from .utils import EstimateEulerTransformModel, ransac
 
 LOGGER = logging.getLogger(__name__)
 

--- a/coregistration/eolearn/tests/test_coregistration.py
+++ b/coregistration/eolearn/tests/test_coregistration.py
@@ -11,8 +11,9 @@ file in the root directory of this source tree.
 
 import logging
 
-import pytest
 import numpy as np
+import pytest
+
 from eolearn.core import EOPatch, FeatureType
 from eolearn.coregistration import ECCRegistrationTask, InterpolationType
 

--- a/coregistration/setup.py
+++ b/coregistration/setup.py
@@ -1,5 +1,6 @@
 import os
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 
 def get_long_description():

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,6 @@ import eolearn.ml_tools
 import eolearn.visualization
 from eolearn.core import EOTask
 
-
 # -- Project information -----------------------------------------------------
 
 # General information about the project.

--- a/examples/io/SentinelHubIO.ipynb
+++ b/examples/io/SentinelHubIO.ipynb
@@ -460,7 +460,7 @@
     }
    ],
    "source": [
-    "eopatch.plot((FeatureType.DATA, \"L1C_data\"), times=[3], rgb=[3,2,1])\n",
+    "eopatch.plot((FeatureType.DATA, \"L1C_data\"), times=[3], rgb=[3, 2, 1])\n",
     "plt.axis(False);"
    ]
   },
@@ -544,7 +544,7 @@
     }
    ],
    "source": [
-    "eopatch.plot((FeatureType.DATA, \"L2A_data\"), times=[3], rgb=[3,2,1])\n",
+    "eopatch.plot((FeatureType.DATA, \"L2A_data\"), times=[3], rgb=[3, 2, 1])\n",
     "plt.axis(False);"
    ]
   },

--- a/features/eolearn/features/__init__.py
+++ b/features/eolearn/features/__init__.py
@@ -2,46 +2,45 @@
 A collection of EOTasks for feature manipulation
 """
 
-from .temporal_features import (
-    AddSpatioTemporalFeaturesTask,
-    AddMaxMinTemporalIndicesTask,
-    AddMaxMinNDVISlopeIndicesTask,
-)
-from .interpolation import (
-    InterpolationTask,
-    ResamplingTask,
-    LinearInterpolationTask,
-    CubicInterpolationTask,
-    SplineInterpolationTask,
-    BSplineInterpolationTask,
-    AkimaInterpolationTask,
-    NearestResamplingTask,
-    LinearResamplingTask,
-    CubicResamplingTask,
-    KrigingInterpolationTask,
-)
+from .bands_extraction import EuclideanNormTask, NormalizedDifferenceIndexTask
+from .blob import BlobTask, DoGBlobTask, DoHBlobTask, LoGBlobTask
+from .clustering import ClusteringTask
+from .doubly_logistic_approximation import DoublyLogisticApproximationTask
 from .feature_manipulation import (
-    SimpleFilterTask,
     FilterTimeSeriesTask,
-    ValueFilloutTask,
     LinearFunctionTask,
+    SimpleFilterTask,
+    ValueFilloutTask,
 )
 from .haralick import HaralickTask
+from .hog import HOGTask
+from .interpolation import (
+    AkimaInterpolationTask,
+    BSplineInterpolationTask,
+    CubicInterpolationTask,
+    CubicResamplingTask,
+    InterpolationTask,
+    KrigingInterpolationTask,
+    LinearInterpolationTask,
+    LinearResamplingTask,
+    NearestResamplingTask,
+    ResamplingTask,
+    SplineInterpolationTask,
+)
+from .local_binary_pattern import LocalBinaryPatternTask
 from .radiometric_normalization import (
-    ReferenceScenesTask,
-    HistogramMatchingTask,
     BlueCompositingTask,
+    HistogramMatchingTask,
     HOTCompositingTask,
     MaxNDVICompositingTask,
     MaxNDWICompositingTask,
     MaxRatioCompositingTask,
+    ReferenceScenesTask,
 )
-from .blob import BlobTask, DoGBlobTask, DoHBlobTask, LoGBlobTask
-from .hog import HOGTask
-from .local_binary_pattern import LocalBinaryPatternTask
-from .bands_extraction import EuclideanNormTask, NormalizedDifferenceIndexTask
-from .clustering import ClusteringTask
-from .doubly_logistic_approximation import DoublyLogisticApproximationTask
-
+from .temporal_features import (
+    AddMaxMinNDVISlopeIndicesTask,
+    AddMaxMinTemporalIndicesTask,
+    AddSpatioTemporalFeaturesTask,
+)
 
 __version__ = "1.0.0"

--- a/features/eolearn/features/__init__.py
+++ b/features/eolearn/features/__init__.py
@@ -6,12 +6,7 @@ from .bands_extraction import EuclideanNormTask, NormalizedDifferenceIndexTask
 from .blob import BlobTask, DoGBlobTask, DoHBlobTask, LoGBlobTask
 from .clustering import ClusteringTask
 from .doubly_logistic_approximation import DoublyLogisticApproximationTask
-from .feature_manipulation import (
-    FilterTimeSeriesTask,
-    LinearFunctionTask,
-    SimpleFilterTask,
-    ValueFilloutTask,
-)
+from .feature_manipulation import FilterTimeSeriesTask, LinearFunctionTask, SimpleFilterTask, ValueFilloutTask
 from .haralick import HaralickTask
 from .hog import HOGTask
 from .interpolation import (

--- a/features/eolearn/features/blob.py
+++ b/features/eolearn/features/blob.py
@@ -11,8 +11,8 @@ file in the root directory of this source tree.
 
 from math import sqrt
 
-import skimage.feature
 import numpy as np
+import skimage.feature
 
 from eolearn.core import EOTask
 

--- a/features/eolearn/features/clustering.py
+++ b/features/eolearn/features/clustering.py
@@ -12,6 +12,7 @@ file in the root directory of this source tree.
 import numpy as np
 from sklearn.cluster import AgglomerativeClustering
 from sklearn.feature_extraction.image import grid_to_graph
+
 from eolearn.core import EOTask, FeatureType
 
 

--- a/features/eolearn/features/doubly_logistic_approximation.py
+++ b/features/eolearn/features/doubly_logistic_approximation.py
@@ -9,8 +9,10 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 import itertools as it
+
 import numpy as np
 from scipy.optimize import curve_fit
+
 from eolearn.core import EOTask, FeatureType
 
 

--- a/features/eolearn/features/feature_manipulation.py
+++ b/features/eolearn/features/feature_manipulation.py
@@ -12,14 +12,13 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import logging
 import datetime as dt
+import logging
 from typing import Optional
 
 import numpy as np
 
 from eolearn.core import EOTask, FeatureType, MapFeatureTask
-
 
 LOGGER = logging.getLogger(__name__)
 

--- a/features/eolearn/features/haralick.py
+++ b/features/eolearn/features/haralick.py
@@ -9,11 +9,11 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import warnings
 import itertools as it
+import warnings
 
-import skimage.feature
 import numpy as np
+import skimage.feature
 
 from eolearn.core import EOTask
 from eolearn.core.exceptions import EOUserWarning

--- a/features/eolearn/features/hog.py
+++ b/features/eolearn/features/hog.py
@@ -9,8 +9,8 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import skimage.feature
 import numpy as np
+import skimage.feature
 
 from eolearn.core import EOTask, FeatureType
 

--- a/features/eolearn/features/interpolation.py
+++ b/features/eolearn/features/interpolation.py
@@ -12,17 +12,17 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import warnings
 import datetime as dt
 import inspect
+import warnings
 from functools import partial
 
 import dateutil
-import scipy.interpolate
 import numpy as np
+import scipy.interpolate
 from sklearn.gaussian_process import GaussianProcessRegressor
 
-from eolearn.core import EOTask, EOPatch, FeatureType, FeatureTypeSet
+from eolearn.core import EOPatch, EOTask, FeatureType, FeatureTypeSet
 from eolearn.core.exceptions import EOUserWarning
 
 try:

--- a/features/eolearn/features/local_binary_pattern.py
+++ b/features/eolearn/features/local_binary_pattern.py
@@ -9,8 +9,8 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import skimage.feature
 import numpy as np
+import skimage.feature
 
 from eolearn.core import EOTask
 

--- a/features/eolearn/tests/conftest.py
+++ b/features/eolearn/tests/conftest.py
@@ -3,11 +3,10 @@ Module with global fixtures
 """
 import os
 
-import pytest
 import numpy as np
+import pytest
 
 from eolearn.core import EOPatch
-
 
 EXAMPLE_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "..", "example_data")
 EXAMPLE_EOPATCH_PATH = os.path.join(EXAMPLE_DATA_PATH, "TestEOPatch")

--- a/features/eolearn/tests/test_bands_extraction.py
+++ b/features/eolearn/tests/test_bands_extraction.py
@@ -9,12 +9,11 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import pytest
 import numpy as np
+import pytest
 
 from eolearn.core import EOPatch, FeatureType
 from eolearn.features import EuclideanNormTask, NormalizedDifferenceIndexTask
-
 
 INPUT_FEATURE = (FeatureType.DATA, "TEST")
 

--- a/features/eolearn/tests/test_blob.py
+++ b/features/eolearn/tests/test_blob.py
@@ -11,16 +11,15 @@ file in the root directory of this source tree.
 import copy
 import sys
 
-import pytest
-from pytest import approx
 import numpy as np
+import pytest
 from numpy.testing import assert_array_equal
+from pytest import approx
 from skimage.feature import blob_dog
 
 from eolearn.core import FeatureType
 from eolearn.core.eodata_io import FeatureIO
-from eolearn.features import BlobTask, DoGBlobTask, LoGBlobTask, DoHBlobTask
-
+from eolearn.features import BlobTask, DoGBlobTask, DoHBlobTask, LoGBlobTask
 
 FEATURE = (FeatureType.DATA, "NDVI", "blob")
 

--- a/features/eolearn/tests/test_doubly_logistic_approximation.py
+++ b/features/eolearn/tests/test_doubly_logistic_approximation.py
@@ -11,9 +11,7 @@ import numpy as np
 from pytest import approx
 
 from eolearn.core import EOPatch, FeatureType
-from eolearn.features.doubly_logistic_approximation import (
-    DoublyLogisticApproximationTask,
-)
+from eolearn.features.doubly_logistic_approximation import DoublyLogisticApproximationTask
 
 
 def test_double_logistic_approximation(example_eopatch):

--- a/features/eolearn/tests/test_doubly_logistic_approximation.py
+++ b/features/eolearn/tests/test_doubly_logistic_approximation.py
@@ -7,11 +7,13 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-from pytest import approx
 import numpy as np
+from pytest import approx
 
 from eolearn.core import EOPatch, FeatureType
-from eolearn.features.doubly_logistic_approximation import DoublyLogisticApproximationTask
+from eolearn.features.doubly_logistic_approximation import (
+    DoublyLogisticApproximationTask,
+)
 
 
 def test_double_logistic_approximation(example_eopatch):

--- a/features/eolearn/tests/test_feature_manipulation.py
+++ b/features/eolearn/tests/test_feature_manipulation.py
@@ -11,12 +11,12 @@ file in the root directory of this source tree.
 
 import datetime
 
-import pytest
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 
-from eolearn.features import FilterTimeSeriesTask, ValueFilloutTask, LinearFunctionTask
 from eolearn.core import EOPatch, FeatureType
+from eolearn.features import FilterTimeSeriesTask, LinearFunctionTask, ValueFilloutTask
 
 
 def test_content_after_timefilter():

--- a/features/eolearn/tests/test_haralick.py
+++ b/features/eolearn/tests/test_haralick.py
@@ -8,15 +8,14 @@ file in the root directory of this source tree.
 """
 import copy
 
-import pytest
-from pytest import approx
 import numpy as np
+import pytest
 from numpy.testing import assert_array_equal
+from pytest import approx
 
 from eolearn.core import FeatureType
 from eolearn.core.eodata_io import FeatureIO
 from eolearn.features import HaralickTask
-
 
 FEATURE = (FeatureType.DATA, "NDVI", "haralick")
 

--- a/features/eolearn/tests/test_hog.py
+++ b/features/eolearn/tests/test_hog.py
@@ -8,10 +8,10 @@ file in the root directory of this source tree.
 """
 import copy
 
-import pytest
-from pytest import approx
 import numpy as np
+import pytest
 from numpy.testing import assert_array_equal
+from pytest import approx
 
 from eolearn.core import FeatureType
 from eolearn.core.eodata_io import FeatureIO

--- a/features/eolearn/tests/test_interpolation.py
+++ b/features/eolearn/tests/test_interpolation.py
@@ -9,8 +9,8 @@ Copyright (c) 2018-2019 William Ouellette
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-from datetime import datetime
 import dataclasses
+from datetime import datetime
 from typing import Optional
 
 import numpy as np
@@ -19,15 +19,15 @@ from pytest import approx
 
 from eolearn.core import EOTask, FeatureType
 from eolearn.features import (
-    LinearInterpolationTask,
-    CubicInterpolationTask,
-    SplineInterpolationTask,
-    BSplineInterpolationTask,
     AkimaInterpolationTask,
-    LinearResamplingTask,
+    BSplineInterpolationTask,
+    CubicInterpolationTask,
     CubicResamplingTask,
-    NearestResamplingTask,
     KrigingInterpolationTask,
+    LinearInterpolationTask,
+    LinearResamplingTask,
+    NearestResamplingTask,
+    SplineInterpolationTask,
 )
 
 

--- a/features/eolearn/tests/test_local_binary_pattern.py
+++ b/features/eolearn/tests/test_local_binary_pattern.py
@@ -9,10 +9,10 @@ file in the root directory of this source tree.
 
 import copy
 
-import pytest
-from pytest import approx
 import numpy as np
+import pytest
 from numpy.testing import assert_array_equal
+from pytest import approx
 
 from eolearn.core import FeatureType
 from eolearn.core.eodata_io import FeatureIO

--- a/features/eolearn/tests/test_radiometric_normalization.py
+++ b/features/eolearn/tests/test_radiometric_normalization.py
@@ -6,26 +6,26 @@ Copyright (c) 2017-2022 Matej Aleksandrov, Matic Lubej, Devis Peressutti, Žiga 
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-from datetime import datetime
 import copy
+from datetime import datetime
 
 import numpy as np
-from numpy.testing import assert_array_equal
 import pytest
+from numpy.testing import assert_array_equal
 from pytest import approx
 
 from eolearn.core import FeatureType
 from eolearn.core.eodata_io import FeatureIO
-from eolearn.mask import MaskFeatureTask
 from eolearn.features import (
-    ReferenceScenesTask,
     BlueCompositingTask,
+    HistogramMatchingTask,
     HOTCompositingTask,
     MaxNDVICompositingTask,
     MaxNDWICompositingTask,
     MaxRatioCompositingTask,
-    HistogramMatchingTask,
+    ReferenceScenesTask,
 )
+from eolearn.mask import MaskFeatureTask
 
 
 @pytest.fixture(name="eopatch")

--- a/features/eolearn/tests/test_temporal_features.py
+++ b/features/eolearn/tests/test_temporal_features.py
@@ -15,7 +15,11 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from eolearn.core import EOPatch, FeatureType
-from eolearn.features import AddMaxMinNDVISlopeIndicesTask, AddMaxMinTemporalIndicesTask, AddSpatioTemporalFeaturesTask
+from eolearn.features import (
+    AddMaxMinNDVISlopeIndicesTask,
+    AddMaxMinTemporalIndicesTask,
+    AddSpatioTemporalFeaturesTask,
+)
 
 
 def test_temporal_indices():

--- a/features/eolearn/tests/test_temporal_features.py
+++ b/features/eolearn/tests/test_temporal_features.py
@@ -15,11 +15,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from eolearn.core import EOPatch, FeatureType
-from eolearn.features import (
-    AddMaxMinNDVISlopeIndicesTask,
-    AddMaxMinTemporalIndicesTask,
-    AddSpatioTemporalFeaturesTask,
-)
+from eolearn.features import AddMaxMinNDVISlopeIndicesTask, AddMaxMinTemporalIndicesTask, AddSpatioTemporalFeaturesTask
 
 
 def test_temporal_indices():

--- a/features/requirements.txt
+++ b/features/requirements.txt
@@ -1,7 +1,7 @@
 eo-learn-core
+numba>=0.53.0
 numpy
-scipy
 python-dateutil
 scikit-image>=0.19.0
 scikit-learn
-numba>=0.53.0
+scipy

--- a/features/setup.py
+++ b/features/setup.py
@@ -1,5 +1,6 @@
 import os
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 
 def get_long_description():

--- a/geometry/eolearn/geometry/__init__.py
+++ b/geometry/eolearn/geometry/__init__.py
@@ -2,12 +2,7 @@
 Subpackage containing EOTasks for geometrical transformations
 """
 
-from .morphology import (
-    ErosionTask,
-    MorphologicalFilterTask,
-    MorphologicalOperations,
-    MorphologicalStructFactory,
-)
+from .morphology import ErosionTask, MorphologicalFilterTask, MorphologicalOperations, MorphologicalStructFactory
 from .superpixel import (
     FelzenszwalbSegmentationTask,
     MarkSegmentationBoundariesTask,

--- a/geometry/eolearn/geometry/__init__.py
+++ b/geometry/eolearn/geometry/__init__.py
@@ -9,11 +9,11 @@ from .morphology import (
     MorphologicalStructFactory,
 )
 from .superpixel import (
-    SuperpixelSegmentationTask,
     FelzenszwalbSegmentationTask,
-    SlicSegmentationTask,
     MarkSegmentationBoundariesTask,
+    SlicSegmentationTask,
+    SuperpixelSegmentationTask,
 )
-from .transformations import VectorToRasterTask, RasterToVectorTask
+from .transformations import RasterToVectorTask, VectorToRasterTask
 
 __version__ = "1.0.0"

--- a/geometry/eolearn/geometry/morphology.py
+++ b/geometry/eolearn/geometry/morphology.py
@@ -12,11 +12,11 @@ file in the root directory of this source tree.
 """
 import itertools as it
 from enum import Enum
-from typing import Optional, Callable, Union
+from typing import Callable, Optional, Union
 
-import skimage.morphology
-import skimage.filters.rank
 import numpy as np
+import skimage.filters.rank
+import skimage.morphology
 
 from eolearn.core import EOTask, MapFeatureTask
 

--- a/geometry/eolearn/geometry/superpixel.py
+++ b/geometry/eolearn/geometry/superpixel.py
@@ -12,8 +12,8 @@ file in the root directory of this source tree.
 import logging
 import warnings
 
-import skimage.segmentation
 import numpy as np
+import skimage.segmentation
 
 from eolearn.core import EOTask, FeatureType, FeatureTypeSet
 from eolearn.core.exceptions import EORuntimeWarning

--- a/geometry/eolearn/geometry/transformations.py
+++ b/geometry/eolearn/geometry/transformations.py
@@ -22,9 +22,10 @@ import rasterio.transform
 import shapely.geometry
 import shapely.ops
 import shapely.wkt
-from geopandas import GeoSeries, GeoDataFrame
+from geopandas import GeoDataFrame, GeoSeries
 
 from sentinelhub import CRS, bbox_to_dimensions
+
 from eolearn.core import EOTask, FeatureType, FeatureTypeSet
 from eolearn.core.exceptions import EORuntimeWarning
 

--- a/geometry/eolearn/tests/conftest.py
+++ b/geometry/eolearn/tests/conftest.py
@@ -7,7 +7,6 @@ import pytest
 
 from eolearn.core import EOPatch
 
-
 EXAMPLE_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "..", "example_data")
 TEST_EOPATCH_PATH = os.path.join(EXAMPLE_DATA_PATH, "TestEOPatch")
 

--- a/geometry/eolearn/tests/test_morphology.py
+++ b/geometry/eolearn/tests/test_morphology.py
@@ -8,13 +8,17 @@ Copyright (c) 2017-2019 Blaž Sovdat, Andrej Burja (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-import pytest
 import numpy as np
+import pytest
 from numpy.testing import assert_array_equal
 
 from eolearn.core import EOPatch, FeatureType
-from eolearn.geometry import ErosionTask, MorphologicalFilterTask, MorphologicalOperations, MorphologicalStructFactory
-
+from eolearn.geometry import (
+    ErosionTask,
+    MorphologicalFilterTask,
+    MorphologicalOperations,
+    MorphologicalStructFactory,
+)
 
 CLASSES = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 MASK_FEATURE = FeatureType.MASK, "mask"

--- a/geometry/eolearn/tests/test_morphology.py
+++ b/geometry/eolearn/tests/test_morphology.py
@@ -13,12 +13,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from eolearn.core import EOPatch, FeatureType
-from eolearn.geometry import (
-    ErosionTask,
-    MorphologicalFilterTask,
-    MorphologicalOperations,
-    MorphologicalStructFactory,
-)
+from eolearn.geometry import ErosionTask, MorphologicalFilterTask, MorphologicalOperations, MorphologicalStructFactory
 
 CLASSES = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 MASK_FEATURE = FeatureType.MASK, "mask"

--- a/geometry/eolearn/tests/test_superpixel.py
+++ b/geometry/eolearn/tests/test_superpixel.py
@@ -10,11 +10,7 @@ import numpy as np
 import pytest
 
 from eolearn.core import FeatureType
-from eolearn.geometry import (
-    FelzenszwalbSegmentationTask,
-    SlicSegmentationTask,
-    SuperpixelSegmentationTask,
-)
+from eolearn.geometry import FelzenszwalbSegmentationTask, SlicSegmentationTask, SuperpixelSegmentationTask
 
 SUPERPIXEL_FEATURE = FeatureType.MASK_TIMELESS, "SP_FEATURE"
 

--- a/geometry/eolearn/tests/test_superpixel.py
+++ b/geometry/eolearn/tests/test_superpixel.py
@@ -10,8 +10,11 @@ import numpy as np
 import pytest
 
 from eolearn.core import FeatureType
-from eolearn.geometry import SuperpixelSegmentationTask, FelzenszwalbSegmentationTask, SlicSegmentationTask
-
+from eolearn.geometry import (
+    FelzenszwalbSegmentationTask,
+    SlicSegmentationTask,
+    SuperpixelSegmentationTask,
+)
 
 SUPERPIXEL_FEATURE = FeatureType.MASK_TIMELESS, "SP_FEATURE"
 

--- a/geometry/eolearn/tests/test_transformations.py
+++ b/geometry/eolearn/tests/test_transformations.py
@@ -7,20 +7,19 @@ Copyright (c) 2017-2019 Blaž Sovdat, Andrej Burja (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-from functools import partial
 import dataclasses
+from functools import partial
 from typing import Any
 
+import numpy as np
 import pytest
 import shapely
-import numpy as np
+from conftest import TEST_EOPATCH_PATH
 from numpy.testing import assert_array_equal
-
-from eolearn.core import EOTask, EOPatch, FeatureType
-from eolearn.geometry import VectorToRasterTask, RasterToVectorTask
 from shapely.geometry import Polygon
 
-from conftest import TEST_EOPATCH_PATH
+from eolearn.core import EOPatch, EOTask, FeatureType
+from eolearn.geometry import RasterToVectorTask, VectorToRasterTask
 
 VECTOR_FEATURE = FeatureType.VECTOR_TIMELESS, "LULC"
 RASTER_FEATURE = FeatureType.MASK_TIMELESS, "RASTERIZED_LULC"

--- a/geometry/requirements.txt
+++ b/geometry/requirements.txt
@@ -1,6 +1,6 @@
-eo-learn-core
-shapely
-geopandas>=0.8.1
 descartes
+eo-learn-core
+geopandas>=0.8.1
 rasterio>=1.2.7
 scikit-image>=0.15.0
+shapely

--- a/geometry/setup.py
+++ b/geometry/setup.py
@@ -1,5 +1,6 @@
 import os
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 
 def get_long_description():

--- a/install_all.py
+++ b/install_all.py
@@ -2,9 +2,8 @@
 A script for installing all subpackages at once
 """
 
-import sys
 import subprocess
-
+import sys
 
 SUBPACKAGE_LIST = [
     "core",

--- a/io/eolearn/io/__init__.py
+++ b/io/eolearn/io/__init__.py
@@ -2,9 +2,9 @@
 A collection of input and output EOTasks
 """
 
+from .geometry_io import GeopediaVectorImportTask, VectorImportTask
 from .geopedia import AddGeopediaFeatureTask
 from .local_io import ExportToTiffTask, ImportFromTiffTask
-from .geometry_io import VectorImportTask, GeopediaVectorImportTask
 from .sentinelhub_process import (
     SentinelHubDemTask,
     SentinelHubEvalscriptTask,

--- a/io/eolearn/io/extra/geodb.py
+++ b/io/eolearn/io/extra/geodb.py
@@ -11,6 +11,7 @@ file in the root directory of this source tree.
 """
 
 from sentinelhub import CRS
+
 from ..geometry_io import _BaseVectorImportTask
 
 

--- a/io/eolearn/io/extra/meteoblue.py
+++ b/io/eolearn/io/extra/meteoblue.py
@@ -28,8 +28,9 @@ try:
 except ImportError as exception:
     raise ImportError("This module requires an installation of meteoblue_dataset_sdk package") from exception
 
-from sentinelhub import parse_time_interval, serialize_time, Geometry, CRS
-from eolearn.core import EOTask, EOPatch
+from sentinelhub import CRS, Geometry, parse_time_interval, serialize_time
+
+from eolearn.core import EOPatch, EOTask
 
 
 class BaseMeteoblueTask(EOTask):

--- a/io/eolearn/io/geometry_io.py
+++ b/io/eolearn/io/geometry_io.py
@@ -17,6 +17,7 @@ import geopandas as gpd
 from fiona.session import AWSSession
 
 from sentinelhub import CRS, GeopediaFeatureIterator, SHConfig
+
 from eolearn.core import EOPatch, EOTask, FeatureTypeSet
 
 LOGGER = logging.getLogger(__name__)

--- a/io/eolearn/io/geopedia.py
+++ b/io/eolearn/io/geopedia.py
@@ -14,7 +14,8 @@ import logging
 import numpy as np
 import rasterio.transform
 import rasterio.warp
-from sentinelhub import MimeType, CRS, GeopediaWmsRequest
+
+from sentinelhub import CRS, GeopediaWmsRequest, MimeType
 
 from eolearn.core import EOTask, FeatureType
 

--- a/io/eolearn/io/local_io.py
+++ b/io/eolearn/io/local_io.py
@@ -17,11 +17,12 @@ from abc import ABCMeta
 
 import dateutil
 import fs
-import rasterio
 import numpy as np
+import rasterio
+
 from sentinelhub import CRS, BBox
 
-from eolearn.core import EOTask, EOPatch
+from eolearn.core import EOPatch, EOTask
 from eolearn.core.exceptions import EORuntimeWarning
 from eolearn.core.utils.fs import get_base_filesystem_and_path
 

--- a/io/eolearn/io/sentinelhub_process.py
+++ b/io/eolearn/io/sentinelhub_process.py
@@ -12,26 +12,27 @@ file in the root directory of this source tree.
 
 import datetime as dt
 import logging
-from typing import Optional, Tuple, List
+from typing import List, Optional, Tuple
 
 import numpy as np
-from eolearn.core import EOPatch, EOTask, FeatureType, FeatureTypeSet
 
 from sentinelhub import (
+    Band,
+    BBox,
     DataCollection,
     MimeType,
-    SHConfig,
-    BBox,
     SentinelHubCatalog,
     SentinelHubDownloadClient,
     SentinelHubRequest,
+    SHConfig,
+    Unit,
     bbox_to_dimensions,
     filter_times,
     parse_time_interval,
     serialize_time,
-    Band,
-    Unit,
 )
+
+from eolearn.core import EOPatch, EOTask, FeatureType, FeatureTypeSet
 
 LOGGER = logging.getLogger(__name__)
 

--- a/io/eolearn/tests/conftest.py
+++ b/io/eolearn/tests/conftest.py
@@ -4,10 +4,11 @@ Module with global fixtures
 import os
 
 import boto3
-from botocore.exceptions import ClientError, NoCredentialsError
 import pytest
+from botocore.exceptions import ClientError, NoCredentialsError
 
 from sentinelhub import SHConfig
+
 from eolearn.core import EOPatch
 
 EXAMPLE_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "..", "example_data")

--- a/io/eolearn/tests/test_extra/test_geodb.py
+++ b/io/eolearn/tests/test_extra/test_geodb.py
@@ -8,6 +8,7 @@ file in the root directory of this source tree.
 import pytest
 
 from sentinelhub import BBox
+
 from eolearn.core import FeatureType
 from eolearn.io.extra.geodb import GeoDBVectorImportTask
 

--- a/io/eolearn/tests/test_extra/test_meteoblue.py
+++ b/io/eolearn/tests/test_extra/test_meteoblue.py
@@ -7,16 +7,16 @@ Copyright (c) 2021-2022 Patrick Zippenfenig (Meteoblue), Matej Aleksandrov (Sine
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-import os
 import datetime as dt
+import os
 
 import numpy as np
-from sentinelhub import BBox, CRS
 from meteoblue_dataset_sdk.protobuf.dataset_pb2 import DatasetApiProtobuf
 
-from eolearn.core import FeatureType, EOPatch
-from eolearn.io.extra.meteoblue import MeteoblueVectorTask, MeteoblueRasterTask
+from sentinelhub import CRS, BBox
 
+from eolearn.core import EOPatch, FeatureType
+from eolearn.io.extra.meteoblue import MeteoblueRasterTask, MeteoblueVectorTask
 
 RASTER_QUERY = {
     "domain": "NEMS4",

--- a/io/eolearn/tests/test_geometry_io.py
+++ b/io/eolearn/tests/test_geometry_io.py
@@ -7,7 +7,8 @@ file in the root directory of this source tree.
 """
 import pytest
 
-from sentinelhub import BBox, CRS
+from sentinelhub import CRS, BBox
+
 from eolearn.core import FeatureType
 from eolearn.io import GeopediaVectorImportTask, VectorImportTask
 

--- a/io/eolearn/tests/test_local_io.py
+++ b/io/eolearn/tests/test_local_io.py
@@ -9,26 +9,26 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 import copy
+import dataclasses
 import datetime
 import logging
 import os
 import tempfile
-import dataclasses
 from typing import Optional, Union
 
 import boto3
 import numpy as np
-from numpy.testing import assert_array_equal
+import pytest
+from conftest import TEST_EOPATCH_PATH
 from fs.errors import ResourceNotFound
 from moto import mock_s3
-import pytest
+from numpy.testing import assert_array_equal
 
-from eolearn.core import EOPatch, FeatureType
-from eolearn.io import ExportToTiffTask, ImportFromTiffTask
 from sentinelhub import read_data
 from sentinelhub.time_utils import serialize_time
 
-from conftest import TEST_EOPATCH_PATH
+from eolearn.core import EOPatch, FeatureType
+from eolearn.io import ExportToTiffTask, ImportFromTiffTask
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/io/eolearn/tests/test_sentinelhub_process.py
+++ b/io/eolearn/tests/test_sentinelhub_process.py
@@ -7,19 +7,20 @@ Copyright (c) 2019-2021 Beno Šircelj
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+import dataclasses
 import datetime as dt
 import os
 import shutil
-import dataclasses
 from concurrent import futures
-from typing import Optional, Any
+from typing import Any, Optional
 
+import numpy as np
 import pytest
 from pytest import approx
-import numpy as np
 
-from sentinelhub import BBox, CRS, DataCollection, SHConfig, Band, Unit
-from eolearn.core import EOPatch, FeatureType, EOTask
+from sentinelhub import CRS, Band, BBox, DataCollection, SHConfig, Unit
+
+from eolearn.core import EOPatch, EOTask, FeatureType
 from eolearn.io import (
     SentinelHubDemTask,
     SentinelHubEvalscriptTask,

--- a/io/requirements-geodb.txt
+++ b/io/requirements-geodb.txt
@@ -1,2 +1,2 @@
-xcube-geodb @ git+git://github.com/dcs4cop/xcube-geodb.git
 python-dotenv
+xcube-geodb @ git+git://github.com/dcs4cop/xcube-geodb.git

--- a/io/requirements.txt
+++ b/io/requirements.txt
@@ -1,7 +1,7 @@
+boto3
 eo-learn-core
-sentinelhub>=3.4.0
+fiona>=1.8.18
+geopandas>=0.8.1
 rasterio>=1.2.7
 rtree
-geopandas>=0.8.1
-fiona>=1.8.18
-boto3
+sentinelhub>=3.4.0

--- a/io/setup.py
+++ b/io/setup.py
@@ -1,5 +1,6 @@
 import os
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 
 def get_long_description():

--- a/mask/eolearn/mask/__init__.py
+++ b/mask/eolearn/mask/__init__.py
@@ -3,9 +3,9 @@ Public classes and functions of mask subpackage
 """
 
 from .cloud_mask import CloudMaskTask
-from .masking import MaskFeatureTask, JoinMasksTask
+from .mask_counting import ClassFrequencyTask
+from .masking import JoinMasksTask, MaskFeatureTask
 from .snow_mask import SnowMaskTask, TheiaSnowMaskTask
 from .utils import resize_images
-from .mask_counting import ClassFrequencyTask
 
 __version__ = "1.0.0"

--- a/mask/eolearn/mask/cloud_mask.py
+++ b/mask/eolearn/mask/cloud_mask.py
@@ -21,8 +21,9 @@ from skimage.morphology import disk
 
 from sentinelhub import bbox_to_resolution
 
-from .utils import map_over_axis, resize_images
 from eolearn.core import EOTask, FeatureType, execute_with_mp_lock
+
+from .utils import map_over_axis, resize_images
 
 LOGGER = logging.getLogger(__name__)
 

--- a/mask/eolearn/mask/cloud_mask.py
+++ b/mask/eolearn/mask/cloud_mask.py
@@ -20,9 +20,9 @@ from lightgbm import Booster
 from skimage.morphology import disk
 
 from sentinelhub import bbox_to_resolution
-from eolearn.core import EOTask, FeatureType, execute_with_mp_lock
 
 from .utils import map_over_axis, resize_images
+from eolearn.core import EOTask, FeatureType, execute_with_mp_lock
 
 LOGGER = logging.getLogger(__name__)
 

--- a/mask/eolearn/mask/masking.py
+++ b/mask/eolearn/mask/masking.py
@@ -11,7 +11,7 @@ Copyright (c) 2018-2019 Johannes Schmid (GeoVille)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-from typing import Union, Callable
+from typing import Callable, Union
 
 import numpy as np
 

--- a/mask/eolearn/mask/snow_mask.py
+++ b/mask/eolearn/mask/snow_mask.py
@@ -11,15 +11,14 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import logging
 import itertools
+import logging
 
 import numpy as np
-from skimage.morphology import disk, binary_dilation
+from skimage.morphology import binary_dilation, disk
 
-from eolearn.core import EOTask, FeatureType
 from .utils import resize_images
-
+from eolearn.core import EOTask, FeatureType
 
 LOGGER = logging.getLogger(__name__)
 

--- a/mask/eolearn/mask/snow_mask.py
+++ b/mask/eolearn/mask/snow_mask.py
@@ -17,8 +17,9 @@ import logging
 import numpy as np
 from skimage.morphology import binary_dilation, disk
 
-from .utils import resize_images
 from eolearn.core import EOTask, FeatureType
+
+from .utils import resize_images
 
 LOGGER = logging.getLogger(__name__)
 

--- a/mask/eolearn/mask/utils.py
+++ b/mask/eolearn/mask/utils.py
@@ -11,8 +11,8 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import numpy as np
 import cv2
+import numpy as np
 
 
 def map_over_axis(data, func, axis=0):

--- a/mask/eolearn/tests/conftest.py
+++ b/mask/eolearn/tests/conftest.py
@@ -7,7 +7,6 @@ import pytest
 
 from eolearn.core import EOPatch
 
-
 EXAMPLE_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "..", "example_data")
 TEST_EOPATCH_PATH = os.path.join(EXAMPLE_DATA_PATH, "TestEOPatch")
 

--- a/mask/eolearn/tests/test_cloud_mask.py
+++ b/mask/eolearn/tests/test_cloud_mask.py
@@ -9,10 +9,10 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import pytest
-from pytest import approx
 import numpy as np
+import pytest
 from numpy.testing import assert_array_equal
+from pytest import approx
 
 from eolearn.core import FeatureType
 from eolearn.mask import CloudMaskTask

--- a/mask/eolearn/tests/test_mask_counting.py
+++ b/mask/eolearn/tests/test_mask_counting.py
@@ -8,11 +8,11 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import pytest
 import numpy as np
+import pytest
 
-from eolearn.mask import ClassFrequencyTask
 from eolearn.core import EOPatch, FeatureType
+from eolearn.mask import ClassFrequencyTask
 
 IN_FEATURE = (FeatureType.MASK, "TEST")
 OUT_FEATURE = (FeatureType.DATA_TIMELESS, "FREQ")

--- a/mask/eolearn/tests/test_masking.py
+++ b/mask/eolearn/tests/test_masking.py
@@ -7,12 +7,11 @@ Copyright (c) 2019-2020 Jernej Puc, Lojze Žust (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-import pytest
 import numpy as np
+import pytest
 
-from eolearn.core import FeatureType, EOPatch
-from eolearn.mask import MaskFeatureTask, JoinMasksTask
-
+from eolearn.core import EOPatch, FeatureType
+from eolearn.mask import JoinMasksTask, MaskFeatureTask
 
 BANDS_FEATURE = FeatureType.DATA, "BANDS-S2-L1C"
 NDVI_FEATURE = FeatureType.DATA, "NDVI"

--- a/mask/eolearn/tests/test_snow_mask.py
+++ b/mask/eolearn/tests/test_snow_mask.py
@@ -8,8 +8,8 @@ Copyright (c) 2017-2019 Blaž Sovdat, Andrej Burja, Eva Erzin (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-import pytest
 import numpy as np
+import pytest
 
 from eolearn.core import FeatureType
 from eolearn.mask import SnowMaskTask, TheiaSnowMaskTask

--- a/mask/requirements.txt
+++ b/mask/requirements.txt
@@ -1,6 +1,6 @@
 eo-learn-core
+lightgbm>=2.0.11
 numpy
-sentinelhub
 opencv-contrib-python-headless
 scikit-image>=0.13.0
-lightgbm>=2.0.11
+sentinelhub

--- a/mask/setup.py
+++ b/mask/setup.py
@@ -1,5 +1,6 @@
 import os
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 
 def get_long_description():

--- a/ml_tools/eolearn/ml_tools/__init__.py
+++ b/ml_tools/eolearn/ml_tools/__init__.py
@@ -2,7 +2,12 @@
 Public classes and functions of ml_tools subpackage
 """
 
-from .sampling import sample_by_values, BlockSamplingTask, FractionSamplingTask, GridSamplingTask
+from .sampling import (
+    BlockSamplingTask,
+    FractionSamplingTask,
+    GridSamplingTask,
+    sample_by_values,
+)
 from .train_test_split import TrainTestSplitTask
 
 __version__ = "1.0.0"

--- a/ml_tools/eolearn/ml_tools/__init__.py
+++ b/ml_tools/eolearn/ml_tools/__init__.py
@@ -2,12 +2,7 @@
 Public classes and functions of ml_tools subpackage
 """
 
-from .sampling import (
-    BlockSamplingTask,
-    FractionSamplingTask,
-    GridSamplingTask,
-    sample_by_values,
-)
+from .sampling import BlockSamplingTask, FractionSamplingTask, GridSamplingTask, sample_by_values
 from .train_test_split import TrainTestSplitTask
 
 __version__ = "1.0.0"

--- a/ml_tools/eolearn/ml_tools/extra/plotting.py
+++ b/ml_tools/eolearn/ml_tools/extra/plotting.py
@@ -11,6 +11,7 @@ file in the root directory of this source tree.
 """
 
 import itertools
+
 import numpy as np
 
 try:

--- a/ml_tools/eolearn/ml_tools/sampling.py
+++ b/ml_tools/eolearn/ml_tools/sampling.py
@@ -12,12 +12,12 @@ file in the root directory of this source tree.
 from abc import ABCMeta
 from math import sqrt
 from numbers import Number
-from typing import Dict, Tuple, List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 from shapely.geometry import Point, Polygon
 
-from eolearn.core import EOTask, EOPatch, FeatureType, FeatureTypeSet
+from eolearn.core import EOPatch, EOTask, FeatureType, FeatureTypeSet
 
 _FractionType = Union[Number, Dict[int, Number]]
 

--- a/ml_tools/eolearn/ml_tools/train_test_split.py
+++ b/ml_tools/eolearn/ml_tools/train_test_split.py
@@ -11,6 +11,7 @@ file in the root directory of this source tree.
 """
 
 from enum import Enum
+
 import numpy as np
 
 from eolearn.core import EOTask, FeatureType

--- a/ml_tools/eolearn/tests/conftest.py
+++ b/ml_tools/eolearn/tests/conftest.py
@@ -7,7 +7,6 @@ import pytest
 
 from eolearn.core import EOPatch
 
-
 EXAMPLE_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "..", "example_data")
 TEST_EOPATCH_PATH = os.path.join(EXAMPLE_DATA_PATH, "TestEOPatch")
 

--- a/ml_tools/eolearn/tests/test_sampling.py
+++ b/ml_tools/eolearn/tests/test_sampling.py
@@ -11,12 +11,17 @@ import copy
 from typing import Tuple
 
 import numpy as np
-from numpy.testing import assert_array_equal
 import pytest
+from numpy.testing import assert_array_equal
 from pytest import approx
 
 from eolearn.core import EOPatch, FeatureType
-from eolearn.ml_tools import sample_by_values, BlockSamplingTask, FractionSamplingTask, GridSamplingTask
+from eolearn.ml_tools import (
+    BlockSamplingTask,
+    FractionSamplingTask,
+    GridSamplingTask,
+    sample_by_values,
+)
 from eolearn.ml_tools.sampling import expand_to_grids
 
 

--- a/ml_tools/eolearn/tests/test_sampling.py
+++ b/ml_tools/eolearn/tests/test_sampling.py
@@ -16,12 +16,7 @@ from numpy.testing import assert_array_equal
 from pytest import approx
 
 from eolearn.core import EOPatch, FeatureType
-from eolearn.ml_tools import (
-    BlockSamplingTask,
-    FractionSamplingTask,
-    GridSamplingTask,
-    sample_by_values,
-)
+from eolearn.ml_tools import BlockSamplingTask, FractionSamplingTask, GridSamplingTask, sample_by_values
 from eolearn.ml_tools.sampling import expand_to_grids
 
 

--- a/ml_tools/eolearn/tests/test_train_split.py
+++ b/ml_tools/eolearn/tests/test_train_split.py
@@ -8,11 +8,11 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import pytest
 import numpy as np
+import pytest
 from numpy.testing import assert_array_equal
 
-from eolearn.core import FeatureType, EOPatch
+from eolearn.core import EOPatch, FeatureType
 from eolearn.ml_tools import TrainTestSplitTask
 
 INPUT_FEATURE = (FeatureType.MASK_TIMELESS, "TEST")

--- a/ml_tools/setup.py
+++ b/ml_tools/setup.py
@@ -1,5 +1,6 @@
 import os
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 
 def get_long_description():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,12 @@
 [tool.black]
 line-length = 120
-experimental-string-processing = true
+preview = true
+
+[tool.isort]
+profile = "black"
+known_local_folder = "eolearn"
+known_first_party = ["sentinelhub"]
+sections = ["FUTURE","STDLIB","THIRDPARTY","FIRSTPARTY","LOCALFOLDER"]
 
 [tool.pytest.ini_options]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ profile = "black"
 known_local_folder = "eolearn"
 known_first_party = ["sentinelhub"]
 sections = ["FUTURE","STDLIB","THIRDPARTY","FIRSTPARTY","LOCALFOLDER"]
+line_length = 120
 
 [tool.pytest.ini_options]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ preview = true
 
 [tool.isort]
 profile = "black"
-known_local_folder = "eolearn"
-known_first_party = ["sentinelhub"]
-sections = ["FUTURE","STDLIB","THIRDPARTY","FIRSTPARTY","LOCALFOLDER"]
+known_first_party = "sentinelhub"
+known_absolute = "eolearn"
+sections = ["FUTURE","STDLIB","THIRDPARTY","FIRSTPARTY","ABSOLUTE","LOCALFOLDER"]
 line_length = 120
 
 [tool.pytest.ini_options]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
-pytest>=6.0.0
-pytest-mock
-pytest-cov
 codecov
-pylint>=2.12.2
 hypothesis
-twine
-nbval
 moto
+nbval
+pylint>=2.12.2
+pytest-cov
+pytest-mock
+pytest>=6.0.0
 ray[default]
+twine

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black>=22.1.0
+black[jupyter]>=22.1.0
 codecov
 hypothesis
 isort

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,7 @@
+black>=22.1.0
 codecov
 hypothesis
+isort
 moto
 nbval
 pylint>=2.12.2

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,9 +1,9 @@
-Sphinx~=4.0
-sphinx-rtd-theme
-nbsphinx
 jupyter
 m2r2
+nbsphinx
 ray
+sphinx-rtd-theme
+Sphinx~=4.0
 
 -e ./core
 -e ./coregistration

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+
 from setuptools import setup
 
 

--- a/visualization/eolearn/tests/test_eoexecutor.py
+++ b/visualization/eolearn/tests/test_eoexecutor.py
@@ -10,14 +10,13 @@ This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
 
-import os
 import logging
+import os
 import tempfile
 
 import pytest
 
-from eolearn.core import EOTask, EOWorkflow, EONode, EOExecutor
-
+from eolearn.core import EOExecutor, EONode, EOTask, EOWorkflow
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/visualization/eolearn/tests/test_eopatch.py
+++ b/visualization/eolearn/tests/test_eopatch.py
@@ -10,8 +10,8 @@ file in the root directory of this source tree.
 """
 import os
 
-import pytest
 import numpy as np
+import pytest
 
 from eolearn.core import EOPatch, FeatureType
 from eolearn.visualization import PlotConfig

--- a/visualization/eolearn/tests/test_eoworkflow.py
+++ b/visualization/eolearn/tests/test_eoworkflow.py
@@ -12,7 +12,7 @@ file in the root directory of this source tree.
 import pytest
 from graphviz import Digraph
 
-from eolearn.core import EOTask, EOWorkflow, EONode
+from eolearn.core import EONode, EOTask, EOWorkflow
 
 
 class FooTask(EOTask):

--- a/visualization/eolearn/visualization/eoexecutor.py
+++ b/visualization/eolearn/visualization/eoexecutor.py
@@ -10,12 +10,12 @@ Copyright (c) 2017-2019 Blaž Sovdat, Andrej Burja (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-import os
-import importlib
-import inspect
-import warnings
 import base64
 import datetime as dt
+import importlib
+import inspect
+import os
+import warnings
 from collections import defaultdict
 from typing import DefaultDict, List, Tuple
 
@@ -24,8 +24,8 @@ import graphviz
 import matplotlib.pyplot as plt
 import pygments
 import pygments.lexers
-from pygments.formatters.html import HtmlFormatter
 from jinja2 import Environment, FileSystemLoader
+from pygments.formatters.html import HtmlFormatter
 
 from eolearn.core import EOExecutor
 from eolearn.core.exceptions import EOUserWarning

--- a/visualization/eolearn/visualization/eopatch.py
+++ b/visualization/eolearn/visualization/eopatch.py
@@ -19,8 +19,9 @@ import numpy as np
 from geopandas import GeoDataFrame
 from pyproj import CRS
 
-from .eopatch_base import BaseEOPatchVisualization, BasePlotConfig
 from eolearn.core import EOPatch, FeatureType
+
+from .eopatch_base import BaseEOPatchVisualization, BasePlotConfig
 
 
 class PlotBackend(Enum):

--- a/visualization/eolearn/visualization/eopatch.py
+++ b/visualization/eolearn/visualization/eopatch.py
@@ -12,16 +12,15 @@ import datetime as dt
 import itertools as it
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional, Union, Dict, List, cast
+from typing import Dict, List, Optional, Union, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
 from geopandas import GeoDataFrame
 from pyproj import CRS
 
-from eolearn.core import FeatureType, EOPatch
-
-from .eopatch_base import BasePlotConfig, BaseEOPatchVisualization
+from .eopatch_base import BaseEOPatchVisualization, BasePlotConfig
+from eolearn.core import EOPatch, FeatureType
 
 
 class PlotBackend(Enum):

--- a/visualization/eolearn/visualization/eopatch_base.py
+++ b/visualization/eolearn/visualization/eopatch_base.py
@@ -11,7 +11,7 @@ file in the root directory of this source tree.
 import abc
 import datetime as dt
 from dataclasses import dataclass
-from typing import Optional, List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 from geopandas import GeoDataFrame

--- a/visualization/eolearn/visualization/eoworkflow.py
+++ b/visualization/eolearn/visualization/eoworkflow.py
@@ -10,7 +10,7 @@ Copyright (c) 2017-2019 Blaž Sovdat, Andrej Burja (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-from typing import Sequence, Optional, Dict
+from typing import Dict, Optional, Sequence
 
 from graphviz import Digraph
 

--- a/visualization/eolearn/visualization/extra/hvplot.py
+++ b/visualization/eolearn/visualization/extra/hvplot.py
@@ -35,10 +35,11 @@ except ImportError as exception:
 
 from sentinelhub import CRS, BBox
 
-from ..eopatch_base import BaseEOPatchVisualization, BasePlotConfig
-from .xarray import array_to_dataframe, get_new_coordinates, string_to_variable
 from eolearn.core import EOPatch, FeatureType, FeatureTypeSet
 from eolearn.core.utils.parsing import parse_feature
+
+from ..eopatch_base import BaseEOPatchVisualization, BasePlotConfig
+from .xarray import array_to_dataframe, get_new_coordinates, string_to_variable
 
 
 @dataclasses.dataclass

--- a/visualization/eolearn/visualization/extra/hvplot.py
+++ b/visualization/eolearn/visualization/extra/hvplot.py
@@ -12,7 +12,7 @@ file in the root directory of this source tree.
 """
 import dataclasses
 import datetime as dt
-from typing import Optional, List, cast
+from typing import List, Optional, cast
 
 import numpy as np
 import pandas as pd
@@ -20,12 +20,12 @@ from geopandas import GeoDataFrame
 from shapely.geometry import Polygon
 
 try:
-    import xarray as xr
-    import holoviews as hv
     import geoviews as gv
+    import holoviews as hv
     import hvplot  # pylint: disable=unused-import
-    import hvplot.xarray  # pylint: disable=unused-import
     import hvplot.pandas  # pylint: disable=unused-import
+    import hvplot.xarray  # pylint: disable=unused-import
+    import xarray as xr
     from cartopy import crs as ccrs
 except ImportError as exception:
     raise ImportError(
@@ -33,12 +33,12 @@ except ImportError as exception:
         "pip install eo-learn-visualization[HVPLOT]"
     ) from exception
 
-from sentinelhub import BBox, CRS
+from sentinelhub import CRS, BBox
+
+from ..eopatch_base import BaseEOPatchVisualization, BasePlotConfig
+from .xarray import array_to_dataframe, get_new_coordinates, string_to_variable
 from eolearn.core import EOPatch, FeatureType, FeatureTypeSet
 from eolearn.core.utils.parsing import parse_feature
-
-from .xarray import array_to_dataframe, get_new_coordinates, string_to_variable
-from ..eopatch_base import BasePlotConfig, BaseEOPatchVisualization
 
 
 @dataclasses.dataclass

--- a/visualization/eolearn/visualization/extra/xarray.py
+++ b/visualization/eolearn/visualization/extra/xarray.py
@@ -20,6 +20,7 @@ except ImportError as exception:
     raise ImportError("This module requires an installation of xarray package") from exception
 
 from sentinelhub import BBox
+
 from eolearn.core import FeatureTypeSet
 from eolearn.core.utils.parsing import parse_feature
 

--- a/visualization/requirements.txt
+++ b/visualization/requirements.txt
@@ -1,6 +1,6 @@
 eo-learn-core
-pydot
 graphviz>=0.10.1
-matplotlib
 jinja2
+matplotlib
+pydot
 pygments

--- a/visualization/setup.py
+++ b/visualization/setup.py
@@ -1,5 +1,6 @@
 import os
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 
 def get_long_description():


### PR DESCRIPTION
Changes:
- sorted the packages in the requirements files alphabetically
- `black` was missing from the `requirements-dev.txt`
- added also `isort` and ran it on the repo
  - `sentinelhub` was added as a first party package - higher than local, lower than third party