### PR TITLE
Docs build fix - mocking problematic imports

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -101,8 +101,14 @@ pygments_style = "sphinx"
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
 
-# Mock modules
-# autodoc_mock_imports = ["eolearn"]
+# Mock imports that won't and don't have to be installed in ReadTheDocs environment
+autodoc_mock_imports = [
+    "ray",
+    "geoviews",
+    "hvplot",
+    "pyepsg",
+    "xarray",
+]
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,7 +1,6 @@
 jupyter
 m2r2
 nbsphinx
-ray
 sphinx-rtd-theme
 Sphinx~=4.0
 


### PR DESCRIPTION
Same trick as we started to use in `sentinelhub-py`.