### PR TITLE
progress bar for ray now works for large number of eopatches.

### DIFF
--- a/core/eolearn/core/extra/ray.py
+++ b/core/eolearn/core/extra/ray.py
@@ -60,7 +60,7 @@ def _ray_workflow_executor(workflow_args: _ProcessingData) -> WorkflowResults:
     return RayExecutor._execute_workflow(workflow_args)
 
 
-def _progress_bar_iterator(futures: list, update_interval: float = 1) -> Generator:
+def _progress_bar_iterator(futures: list, update_interval: float = 0.5) -> Generator:
     """A utility to help tracking finished ray processes
 
     Note that using tqdm(futures) directly would cause memory problems and is not accurate


### PR DESCRIPTION
The previous version updated the progress bar one by one. However each time ray had to check entire list of futures. This caused MASSIVE slowdowns when working with many eopatches (300k), because the progress bar updating took >6h by itself.

It has now been improved to only check every now and then, but updates the bar for all futures that are done (and not just the next one). Works with large amount of eopatches and does not delay very fast executions. Updating is a bit less continuous but it's a small price.