### PR TITLE
Option that LoadTask and SaveTask don't do anything

### DIFF
--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -112,13 +112,15 @@ class SaveTask(IOTask):
 
         :param eopatch: EOPatch which will be saved
         :type eopatch: EOPatch
-        :param eopatch_folder: name of EOPatch folder containing data
-        :type eopatch_folder: str
+        :param eopatch_folder: Name of EOPatch folder containing data. If `None` is given it won't save anything.
+        :type eopatch_folder: str or None
         :return: The same EOPatch
         :rtype: EOPatch
         """
-        path = fs.path.combine(self.filesystem_path, eopatch_folder)
+        if eopatch_folder is None:
+            return eopatch
 
+        path = fs.path.combine(self.filesystem_path, eopatch_folder)
         eopatch.save(path, filesystem=self.filesystem, **self.kwargs)
         return eopatch
 
@@ -147,13 +149,16 @@ class LoadTask(IOTask):
     def execute(self, *, eopatch_folder=""):
         """Loads the EOPatch from disk: `folder/eopatch_folder`.
 
-        :param eopatch_folder: name of EOPatch folder containing data
-        :type eopatch_folder: str
+        :param eopatch_folder: Name of EOPatch folder containing data. If `None` is given it will return an empty
+            `EOPatch`.
+        :type eopatch_folder: str or None
         :return: EOPatch loaded from disk
         :rtype: EOPatch
         """
-        path = fs.path.combine(self.filesystem_path, eopatch_folder)
+        if eopatch_folder is None:
+            return EOPatch()
 
+        path = fs.path.combine(self.filesystem_path, eopatch_folder)
         return EOPatch.load(path, filesystem=self.filesystem, **self.kwargs)
 
 

--- a/core/eolearn/tests/test_core_tasks.py
+++ b/core/eolearn/tests/test_core_tasks.py
@@ -15,6 +15,7 @@ import datetime
 
 import numpy as np
 import pytest
+from fs.tempfs import TempFS
 
 from sentinelhub import CRS
 
@@ -28,12 +29,14 @@ from eolearn.core import (
     ExtractBandsTask,
     FeatureType,
     InitializeFeatureTask,
+    LoadTask,
     MapFeatureTask,
     MergeEOPatchesTask,
     MergeFeatureTask,
     MoveFeatureTask,
     RemoveFeatureTask,
     RenameFeatureTask,
+    SaveTask,
     ZipFeatureTask,
 )
 
@@ -93,6 +96,23 @@ def test_partial_copy(patch):
     partial_deepcopy = DeepCopyTask(features=[FeatureType.TIMESTAMP, (FeatureType.SCALAR, "values")]).execute(patch)
     expected_patch = EOPatch(scalar=patch.scalar, timestamp=patch.timestamp)
     assert partial_deepcopy == expected_patch, "Partial deep copying was not successful"
+
+
+def test_load_nothing():
+    load = LoadTask("./some/fake/path")
+    eopatch = load.execute(eopatch_folder=None)
+
+    assert eopatch == EOPatch()
+
+
+def test_save_nothing(patch):
+    temp_path = "/some/fake/path"
+    with TempFS() as temp_fs:
+        save = SaveTask(temp_path, filesystem=temp_fs)
+        output = save.execute(patch, eopatch_folder=None)
+
+        assert not temp_fs.exists(temp_path)
+        assert output == patch
 
 
 def test_add_rename_remove_feature(patch):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,5 +9,5 @@ pytest-cov
 pytest-mock
 pytest>=6.0.0
 ray[default]
-responses<0.19.0
+responses
 twine


### PR DESCRIPTION
This adds an option that by setting `eopatch_folder=None` these 2 task won't save or load anything. This way we can use execution arguments to handle cases where we know that no data exists to be loaded or no data needs to be saved.