### PR TITLE
Extended is_discrete_type function and wrote unit tests for it

### DIFF
--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -17,9 +17,12 @@ import warnings
 from collections import defaultdict
 
 import fs
+import fs.move
 import geopandas as gpd
 import numpy as np
 import pandas as pd
+from fs.base import FS
+from fs.osfs import OSFS
 from fs.tempfs import TempFS
 from geopandas import GeoDataFrame, GeoSeries
 
@@ -233,7 +236,7 @@ def _to_lowercase(ftype, fname, *_):
 class FeatureIO:
     """A class that handles the saving and loading process of a single feature at a given location."""
 
-    def __init__(self, feature_type: FeatureType, path: str, filesystem: fs.base.FS):
+    def __init__(self, feature_type: FeatureType, path: str, filesystem: FS):
         """
         :param feature_type: A feature type
         :param path: A path in the filesystem
@@ -270,7 +273,7 @@ class FeatureIO:
         gz_extension = ("." + MimeType.GZIP.extension) if compress_level else ""
         path = f"{self.path}.{file_format.extension}{gz_extension}"
 
-        if isinstance(self.filesystem, (fs.osfs.OSFS, TempFS)):
+        if isinstance(self.filesystem, (OSFS, TempFS)):
             with TempFS(temp_dir=self.filesystem.root_path) as tempfs:
                 self._save(tempfs, data, "tmp_feature", file_format, compress_level)
                 fs.move.move_file(tempfs, "tmp_feature", self.filesystem, path)

--- a/core/eolearn/core/eoexecution.py
+++ b/core/eolearn/core/eoexecution.py
@@ -26,6 +26,7 @@ from logging import Filter, Handler, Logger
 from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple, TypeVar, cast
 
 import fs
+from fs.base import FS
 from tqdm.auto import tqdm
 
 from .eonode import EONode
@@ -82,7 +83,7 @@ class EOExecutor:
         execution_names: Optional[List[str]] = None,
         save_logs: bool = False,
         logs_folder: str = ".",
-        filesystem: Optional[fs.base.FS] = None,
+        filesystem: Optional[FS] = None,
         logs_filter: Optional[Filter] = None,
         logs_handler_factory: _HandlerFactoryType = logging.FileHandler,
     ):
@@ -141,7 +142,7 @@ class EOExecutor:
         return execution_names
 
     @staticmethod
-    def _parse_logs_filesystem(filesystem: Optional[fs.base.FS], logs_folder: str) -> Tuple[fs.base.FS, str]:
+    def _parse_logs_filesystem(filesystem: Optional[FS], logs_folder: str) -> Tuple[FS, str]:
         """Ensures a filesystem and a file path relative to it."""
         if filesystem is None:
             return get_base_filesystem_and_path(logs_folder)

--- a/core/eolearn/core/utils/common.py
+++ b/core/eolearn/core/utils/common.py
@@ -14,6 +14,7 @@ file in the root directory of this source tree.
 """
 
 import uuid
+from typing import Union
 
 import geopandas as gpd
 import numpy as np
@@ -149,6 +150,7 @@ def generate_uid(prefix: str):
     return f"{prefix}-{time_uid}-{random_uid}"
 
 
-def is_discrete_type(number_dtype: np.dtype) -> bool:
-    """Checks if the given `numpy` number dtype is discrete"""
-    return issubclass(number_dtype.type, (np.integer, bool, np.bool_, np.bool8))
+def is_discrete_type(number_type: Union[np.dtype, type]) -> bool:
+    """Checks if a given `numpy` type is a discrete numerical type."""
+    number_dtype = np.dtype(number_type)
+    return issubclass(number_dtype.type, (np.integer, np.bool_))

--- a/core/eolearn/core/utils/fs.py
+++ b/core/eolearn/core/utils/fs.py
@@ -14,12 +14,13 @@ from typing import Optional, Tuple
 
 import fs
 from boto3 import Session
+from fs.base import FS
 from fs_s3fs import S3FS
 
 from sentinelhub import SHConfig
 
 
-def get_filesystem(path: str, create: bool = False, config: Optional[SHConfig] = None, **kwargs) -> fs.base.FS:
+def get_filesystem(path: str, create: bool = False, config: Optional[SHConfig] = None, **kwargs) -> FS:
     """A utility function for initializing any type of filesystem object with PyFilesystem2 package.
 
     :param path: A filesystem path
@@ -41,7 +42,7 @@ def get_filesystem(path: str, create: bool = False, config: Optional[SHConfig] =
     return fs.open_fs(path, create=create, **kwargs)
 
 
-def get_base_filesystem_and_path(*path_parts: str, **kwargs) -> Tuple[fs.base.FS, str]:
+def get_base_filesystem_and_path(*path_parts: str, **kwargs) -> Tuple[FS, str]:
     """Parses multiple strings that define a filesystem path and returns a filesystem object with a relative path
     on the filesystem.
 
@@ -123,7 +124,7 @@ def get_aws_credentials(aws_profile: str, config: Optional[SHConfig] = None) -> 
     return config
 
 
-def get_full_path(filesystem: fs.base.FS, relative_path: str) -> str:
+def get_full_path(filesystem: FS, relative_path: str) -> str:
     """Given a filesystem object and a path, relative to the filesystem it provides a full path."""
     if isinstance(filesystem, S3FS):
         # pylint: disable=protected-access

--- a/core/eolearn/tests/test_utils/test_common.py
+++ b/core/eolearn/tests/test_utils/test_common.py
@@ -1,0 +1,47 @@
+"""
+Credits:
+Copyright (c) 2017-2022 Matej Aleksandrov, Žiga Lukšič (Sinergise)
+
+This source code is licensed under the MIT license found in the LICENSE
+file in the root directory of this source tree.
+"""
+
+import numpy as np
+import pytest
+
+from eolearn.core.utils.common import is_discrete_type
+
+
+@pytest.mark.parametrize(
+    "number_type, is_discrete",
+    [
+        (int, True),
+        (bool, True),
+        (float, False),
+        (str, False),
+        (bytes, False),
+        (complex, False),
+        (np.number, False),
+        (np.int, True),
+        (np.byte, True),
+        (np.bool_, True),
+        (np.bool, True),
+        (np.bool8, True),
+        (np.integer, True),
+        (np.dtype("uint16"), True),
+        (np.int8, True),
+        (np.longlong, True),
+        (np.int64, True),
+        (np.double, False),
+        (np.float64, False),
+        (np.datetime64, False),
+        (np.object_, False),
+        (np.generic, False),
+    ],
+)
+def test_is_discrete_type(number_type, is_discrete):
+    """Checks the given type and its numpy dtype against the expected answer."""
+    assert is_discrete_type(number_type) is is_discrete
+
+    numpy_dtype = np.dtype(number_type)
+    assert is_discrete_type(numpy_dtype) is is_discrete


### PR DESCRIPTION
I extended `is_discrete_type` function so that it works both with `type` and `numpy.dtype` objects (because `numpy` also works with both). Then I wrote precise unit tests for it.

More info about type hierarchy can be found in [`numpy` docs](https://numpy.org/doc/stable/reference/arrays.scalars.html).