### PR TITLE
Patched issue with saving existing EOPatch features locally

### DIFF
--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -276,6 +276,8 @@ class FeatureIO:
         if isinstance(self.filesystem, (OSFS, TempFS)):
             with TempFS(temp_dir=self.filesystem.root_path) as tempfs:
                 self._save(tempfs, data, "tmp_feature", file_format, compress_level)
+                if fs.__version__ == "2.4.16" and self.filesystem.exists(path):  # An issue in the fs version
+                    self.filesystem.remove(path)
                 fs.move.move_file(tempfs, "tmp_feature", self.filesystem, path)
             return
         self._save(self.filesystem, data, path, file_format, compress_level)


### PR DESCRIPTION
The latest version `fs==2.4.16` introduced an issue that is described in https://github.com/PyFilesystem/pyfilesystem2/issues/535. 

It seems very likely that the issue will be fixed in the next version of `fs` package release. Therefore this PR only patches the issue for this specific `fs` version. The additional check happens only when saving EOPatches locally but in order to conserve the amount of unnecessary IO operations I wouldn't call it for other `fs` versions because it is unnecessary.