### PR TITLE
VectorToRaster task for temporal vector features

### DIFF
--- a/geometry/eolearn/geometry/transformations.py
+++ b/geometry/eolearn/geometry/transformations.py
@@ -178,7 +178,7 @@ class VectorToRasterTask(EOTask):
         vector_data = vector_data[columns_to_keep]
 
         if self._rasterize_per_timestamp:
-            vector_data['TIMESTAMP'] = vector_data.TIMESTAMP.apply(parse_time)
+            vector_data["TIMESTAMP"] = vector_data.TIMESTAMP.apply(parse_time)
             vector_data = vector_data[vector_data.TIMESTAMP.isin(timestamps)]
 
         if self.values_column is not None and self.values is not None:

--- a/geometry/eolearn/geometry/transformations.py
+++ b/geometry/eolearn/geometry/transformations.py
@@ -24,7 +24,7 @@ import shapely.ops
 import shapely.wkt
 from geopandas import GeoDataFrame, GeoSeries
 
-from sentinelhub import CRS, bbox_to_dimensions
+from sentinelhub import CRS, bbox_to_dimensions, parse_time
 
 from eolearn.core import EOTask, FeatureType, FeatureTypeSet
 from eolearn.core.exceptions import EORuntimeWarning
@@ -178,6 +178,7 @@ class VectorToRasterTask(EOTask):
         vector_data = vector_data[columns_to_keep]
 
         if self._rasterize_per_timestamp:
+            vector_data['TIMESTAMP'] = vector_data.TIMESTAMP.apply(parse_time)
             vector_data = vector_data[vector_data.TIMESTAMP.isin(timestamps)]
 
         if self.values_column is not None and self.values is not None:


### PR DESCRIPTION
If the vector data is passed a string (e.g. path to a vector file), then the 'TIMESTAMP' column is an `object` instead of `datetime`. 

This PR reads the `TIMESTAMP` column into a pandas `datetime64` dtype, using `parse_time` from sentinelhub-py so that the resulting timestamps are created using the same procedure as the `timestamp` list in eo-patches.

A side note: in `FeatureIO`, in `_decode` method, the `TIMESTAMP` column (if exists) is parsed with `dataframe.TIMESTAMP = pd.to_datetime(dataframe.TIMESTAMP)`. I suggest to replace it with `dataframe.TIMESTAMP = pd.TIMESTAMP.apply(parse_time)` - again, to conform to the `timestamp` feature in eo-patches.