### PR TITLE
Parallelization utils

### DIFF
--- a/core/eolearn/core/__init__.py
+++ b/core/eolearn/core/__init__.py
@@ -28,7 +28,7 @@ from .eoworkflow import EOWorkflow, WorkflowResults
 from .eoworkflow_tasks import OutputTask
 from .utils.common import constant_pad, deep_eq
 from .utils.fs import get_filesystem, load_s3_filesystem
-from .utils.parallelize import execute_with_mp_lock
+from .utils.parallelize import execute_with_mp_lock, join_futures, join_futures_iter, parallelize
 from .utils.parsing import FeatureParser
 
 __version__ = "1.0.2"

--- a/core/eolearn/core/__init__.py
+++ b/core/eolearn/core/__init__.py
@@ -21,13 +21,14 @@ from .core_tasks import (
     ZipFeatureTask,
 )
 from .eodata import EOPatch
-from .eoexecution import EOExecutor, execute_with_mp_lock
+from .eoexecution import EOExecutor
 from .eonode import EONode, linearly_connect_tasks
 from .eotask import EOTask
 from .eoworkflow import EOWorkflow, WorkflowResults
 from .eoworkflow_tasks import OutputTask
 from .utils.common import constant_pad, deep_eq
 from .utils.fs import get_filesystem, load_s3_filesystem
+from .utils.parallelize import execute_with_mp_lock
 from .utils.parsing import FeatureParser
 
 __version__ = "1.0.2"

--- a/core/eolearn/core/eoexecution.py
+++ b/core/eolearn/core/eoexecution.py
@@ -17,40 +17,24 @@ file in the root directory of this source tree.
 import concurrent.futures
 import datetime as dt
 import logging
-import multiprocessing
 import threading
 import warnings
 from dataclasses import dataclass
-from enum import Enum
 from logging import Filter, Handler, Logger
-from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple, TypeVar, cast
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 import fs
 from fs.base import FS
-from tqdm.auto import tqdm
 
 from .eonode import EONode
 from .eoworkflow import EOWorkflow, WorkflowResults
 from .exceptions import EORuntimeWarning
 from .utils.fs import get_base_filesystem_and_path, get_full_path
 from .utils.logging import LogFileFilter
-
-LOGGER = logging.getLogger(__name__)
-MULTIPROCESSING_LOCK = None
+from .utils.parallelize import _ProcessingType, decide_processing_type, parallelize
 
 # pylint: disable=invalid-name
-_InputType = TypeVar("_InputType")
-_OutputType = TypeVar("_OutputType")
 _HandlerFactoryType = Callable[[str], Handler]
-
-
-class _ProcessingType(Enum):
-    """Type of EOExecutor processing"""
-
-    SINGLE_PROCESS = "single process"
-    MULTIPROCESSING = "multiprocessing"
-    MULTITHREADING = "multithreading"
-    RAY = "ray"
 
 
 @dataclass(frozen=True)
@@ -148,7 +132,7 @@ class EOExecutor:
             return get_base_filesystem_and_path(logs_folder)
         return filesystem, logs_folder
 
-    def run(self, workers: int = 1, multiprocess: bool = True) -> List[WorkflowResults]:
+    def run(self, workers: int = 1, multiprocess: bool = True, **tqdm_kwargs: Any) -> List[WorkflowResults]:
         """Runs the executor with n workers.
 
         :param workers: Maximum number of workflows which will be executed in parallel. Default value is `1` which will
@@ -161,6 +145,7 @@ class EOExecutor:
             This parameter is used especially because certain task cannot run with
             `concurrent.futures.ProcessPoolExecutor`.
             In case of `workers=1` this parameter is ignored and workflows will be executed consecutively.
+        :param tqdm_kwargs: Keyword arguments that will be propagated to `tqdm` progress bar.
         :return: A list of EOWorkflow results
         """
         self.start_time = dt.datetime.now()
@@ -173,7 +158,6 @@ class EOExecutor:
         log_paths = self.get_log_paths(full_path=True) if self.save_logs else [None] * len(self.execution_kwargs)
 
         filter_logs_by_thread = not multiprocess and workers > 1
-        processing_type = self._get_processing_type(workers, multiprocess)
         processing_args = [
             _ProcessingData(
                 workflow=self.workflow,
@@ -185,42 +169,20 @@ class EOExecutor:
             )
             for workflow_kwargs, log_path in zip(self.execution_kwargs, log_paths)
         ]
-
-        full_execution_results = self._run_execution(processing_args, workers, processing_type)
+        full_execution_results = self._run_execution(
+            processing_args, workers=workers, multiprocess=multiprocess, **tqdm_kwargs
+        )
 
         self.execution_results = [results.drop_outputs() for results in full_execution_results]
+        processing_type = self._get_processing_type(workers=workers, multiprocess=multiprocess)
         self.general_stats = self._prepare_general_stats(workers, processing_type)
 
         return full_execution_results
 
-    @staticmethod
-    def _get_processing_type(workers: int, multiprocess: bool) -> _ProcessingType:
-        """Decides processing type according to parameters."""
-        if workers == 1:
-            return _ProcessingType.SINGLE_PROCESS
-        if multiprocess:
-            return _ProcessingType.MULTIPROCESSING
-        return _ProcessingType.MULTITHREADING
-
-    def _run_execution(
-        self, processing_args: List[_ProcessingData], workers: int, processing_type: _ProcessingType
-    ) -> List[WorkflowResults]:
-        """Runs the execution for each item of processing_args list."""
-        if processing_type is _ProcessingType.SINGLE_PROCESS:
-            return list(tqdm(map(self._execute_workflow, processing_args), total=len(processing_args)))
-
-        if processing_type is _ProcessingType.MULTITHREADING:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as thread_executor:
-                return submit_and_monitor_execution(thread_executor, self._execute_workflow, processing_args)
-
-        # pylint: disable=global-statement
-        global MULTIPROCESSING_LOCK
-        try:
-            MULTIPROCESSING_LOCK = multiprocessing.Manager().Lock()
-            with concurrent.futures.ProcessPoolExecutor(max_workers=workers) as process_executor:
-                return submit_and_monitor_execution(process_executor, self._execute_workflow, processing_args)
-        finally:
-            MULTIPROCESSING_LOCK = None
+    @classmethod
+    def _run_execution(cls, processing_args: List[_ProcessingData], **kwargs: Any) -> List[WorkflowResults]:
+        """Parallelizes the execution for each item of processing_args list."""
+        return parallelize(cls._execute_workflow, processing_args, **kwargs)
 
     @classmethod
     def _try_add_logging(
@@ -286,6 +248,11 @@ class EOExecutor:
             handler.addFilter(logs_filter)
 
         return handler
+
+    @staticmethod
+    def _get_processing_type(workers: int, multiprocess: bool) -> _ProcessingType:
+        """Provides a type of processing according to given parameters."""
+        return decide_processing_type(workers=workers, multiprocess=multiprocess)
 
     def _prepare_general_stats(self, workers: int, processing_type: _ProcessingType) -> Dict[str, object]:
         """Prepares a dictionary with a general statistics about executions."""
@@ -377,44 +344,3 @@ class EOExecutor:
         except BaseException as exception:
             warnings.warn(f"Failed to load logs with exception: {repr(exception)}", category=EORuntimeWarning)
             return "Failed to load logs"
-
-
-def submit_and_monitor_execution(
-    executor: concurrent.futures.Executor,
-    function: Callable[[_InputType], _OutputType],
-    execution_params: Iterable[_InputType],
-) -> List[_OutputType]:
-    """Performs the execution parallelization and monitors the process using a progress bar.
-
-    :param executor: An object that performs parallelization.
-    :param function: A function to be parallelized.
-    :param execution_params: Each element in a sequence are parameters for a single call of `function`.
-    :return: A list of results in the same order as input parameters given by `executor_params`.
-    """
-    futures = [executor.submit(function, params) for params in execution_params]
-    future_order = {future: i for i, future in enumerate(futures)}
-
-    results: List[Optional[_OutputType]] = [None] * len(futures)
-    with tqdm(total=len(futures)) as pbar:
-        for future in concurrent.futures.as_completed(futures):
-            results[future_order[future]] = future.result()
-            pbar.update(1)
-
-    return cast(List[_OutputType], results)
-
-
-def execute_with_mp_lock(execution_function: Callable, *args, **kwargs) -> object:
-    """A helper utility function that executes a given function with multiprocessing lock if the process is being
-    executed in a multiprocessing mode.
-
-    :param execution_function: A function
-    :param args: Function's positional arguments
-    :param kwargs: Function's keyword arguments
-    :return: Function's results
-    """
-    if multiprocessing.current_process().name == "MainProcess" or MULTIPROCESSING_LOCK is None:
-        return execution_function(*args, **kwargs)
-
-    # pylint: disable=not-context-manager
-    with MULTIPROCESSING_LOCK:
-        return execution_function(*args, **kwargs)

--- a/core/eolearn/core/extra/ray.py
+++ b/core/eolearn/core/extra/ray.py
@@ -117,8 +117,8 @@ def join_ray_futures_iter(
     """
 
     def _ray_wait_function(
-        remaining_futures: Collection[ray.ObjectRef], timeout: float
+        remaining_futures: Collection[ray.ObjectRef],
     ) -> Tuple[Collection[ray.ObjectRef], Collection[ray.ObjectRef]]:
-        return ray.wait(remaining_futures, num_returns=len(remaining_futures), timeout=timeout)
+        return ray.wait(remaining_futures, num_returns=len(remaining_futures), timeout=float(update_interval))
 
-    return _base_join_futures_iter(_ray_wait_function, ray.get, futures, update_interval, **tqdm_kwargs)
+    return _base_join_futures_iter(_ray_wait_function, ray.get, futures, **tqdm_kwargs)

--- a/core/eolearn/core/extra/ray.py
+++ b/core/eolearn/core/extra/ray.py
@@ -76,7 +76,8 @@ def parallelize_with_ray(
     :param tqdm_kwargs: Keyword arguments that will be propagated to `tqdm` progress bar.
     :return: A list of results in the order that corresponds with the order of the given input `params`.
     """
-    ray.init(address="auto", ignore_reinit_error=True)
+    if not ray.is_initialized():
+        raise RuntimeError("Please initialize a Ray cluster before calling this method")
 
     ray_function = ray.remote(function)
     futures = [ray_function.remote(*function_params) for function_params in zip(*params)]

--- a/core/eolearn/core/extra/ray.py
+++ b/core/eolearn/core/extra/ray.py
@@ -17,8 +17,9 @@ except ImportError as exception:
     raise ImportError("This module requires an installation of Ray Python package") from exception
 from tqdm.auto import tqdm
 
-from ..eoexecution import EOExecutor, _ProcessingData, _ProcessingType
+from ..eoexecution import EOExecutor, _ProcessingData
 from ..eoworkflow import WorkflowResults
+from ..utils.parallelize import _ProcessingType
 
 # pylint: disable=invalid-name
 _T = TypeVar("_T")
@@ -42,16 +43,16 @@ class RayExecutor(EOExecutor):
         workers = ray.available_resources().get("CPU")
         return super().run(workers=workers, multiprocess=True)
 
-    @staticmethod
-    def _get_processing_type(*_, **__) -> _ProcessingType:
-        """Provides a type of processing for later references"""
-        return _ProcessingType.RAY
-
     @classmethod
     def _run_execution(cls, processing_args: List[_ProcessingData], *_, **__) -> List[WorkflowResults]:
         """Runs ray execution"""
         futures = [_ray_workflow_executor.remote(workflow_args) for workflow_args in processing_args]
         return join_ray_futures(futures)
+
+    @staticmethod
+    def _get_processing_type(*_, **__) -> _ProcessingType:
+        """Provides a type of processing for later references."""
+        return _ProcessingType.RAY
 
 
 @ray.remote

--- a/core/eolearn/core/extra/ray.py
+++ b/core/eolearn/core/extra/ray.py
@@ -9,7 +9,7 @@ Copyright (c) 2021-2022 Matej Aleksandrov, Žiga Lukšič (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-from typing import Generator, List
+from typing import Any, Callable, Generator, Iterable, List, Optional, Tuple, TypeVar, cast
 
 try:
     import ray
@@ -19,6 +19,11 @@ from tqdm.auto import tqdm
 
 from ..eoexecution import EOExecutor, _ProcessingData, _ProcessingType
 from ..eoworkflow import WorkflowResults
+
+# pylint: disable=invalid-name
+_T = TypeVar("_T")
+_InputType = TypeVar("_InputType")
+_OutputType = TypeVar("_OutputType")
 
 
 class RayExecutor(EOExecutor):
@@ -46,11 +51,7 @@ class RayExecutor(EOExecutor):
     def _run_execution(cls, processing_args: List[_ProcessingData], *_, **__) -> List[WorkflowResults]:
         """Runs ray execution"""
         futures = [_ray_workflow_executor.remote(workflow_args) for workflow_args in processing_args]
-
-        for _ in tqdm(_progress_bar_iterator(futures), total=len(futures)):
-            pass
-
-        return ray.get(futures)
+        return join_ray_futures(futures)
 
 
 @ray.remote
@@ -60,15 +61,71 @@ def _ray_workflow_executor(workflow_args: _ProcessingData) -> WorkflowResults:
     return RayExecutor._execute_workflow(workflow_args)
 
 
-def _progress_bar_iterator(futures: list, update_interval: float = 0.5) -> Generator:
-    """A utility to help track finished ray processes
+def parallelize_with_ray(
+    function: Callable[[_InputType], _OutputType], *params: Iterable[_InputType], **tqdm_kwargs: Any
+) -> List[_OutputType]:
+    """Parallelizes function execution with Ray.
 
-    Note that using tqdm(futures) directly would cause memory problems and is not accurate
-
-    :param futures: List of `ray` futures.
-    :param update_interval: How many seconds to wait before updating progress bar.
-    :return: A `None` value generator that accurately shows progress of futures.
+    :param function: A normal function that is not yet decorated by `ray.remote`.
+    :param params: Iterables of parameters that will be used with given function.
+    :param tqdm_kwargs: Keyword arguments that will be propagated to `tqdm` progress bar.
+    :return: A list of results in the order that corresponds with the order of the given input `params`.
     """
+    ray.init(address="auto", ignore_reinit_error=True)
+
+    ray_function = ray.remote(function)
+    futures = [ray_function.remote(*function_params) for function_params in zip(*params)]
+    return join_ray_futures(futures, **tqdm_kwargs)
+
+
+def join_ray_futures(futures: List[ray.ObjectRef], **tqdm_kwargs: Any) -> List[Any]:
+    """Resolves futures and returns a list of results.
+
+    :param futures: A list of futures to be joined. Note that this list will be reduced into an empty list as a side
+        effect of this function. This way Ray future objects will get cleared from memory already during the execution
+        and this will free memory from Ray Plasma store. But this can be achieved only if user doesn't keep future
+        objects in memory outside `futures` list.
+    :param tqdm_kwargs: Keyword arguments that will be propagated to `tqdm` progress bar.
+    :return: A list of results in the order that corresponds with the order of the given input `futures`.
+    """
+    results: List[Optional[Any]] = [None] * len(futures)
+    for position, result in join_ray_futures_iter(futures, **tqdm_kwargs):
+        results[position] = result
+
+    return cast(List[Any], results)
+
+
+def join_ray_futures_iter(
+    futures: List[ray.ObjectRef], update_interval: float = 0.5, **tqdm_kwargs: Any
+) -> Generator[Tuple[int, Any], None, None]:
+    """Resolves futures and iterates over results of futures.
+
+    :param futures: A list of futures to be joined. Note that this list will be reduced into an empty list as a side
+        effect of this function. This way Ray future objects will get cleared from memory already during the execution
+        and this will free memory from Ray Plasma store. But this can be achieved only if user doesn't keep future
+        objects in memory outside `futures` list.
+    :param update_interval: A number of seconds to wait between consecutive updates of a progress bar.
+    :param tqdm_kwargs: Keyword arguments that will be propagated to `tqdm` progress bar.
+    :return: A generator that will be returning pairs `(index, result)` where `index` will define the position of future
+        in the original list to which `result` belongs to.
+    """
+    futures = _make_copy_and_empty_given(futures)
+    id_to_position_map = {future.hex(): index for index, future in enumerate(futures)}
+
+    with tqdm(total=len(futures), **tqdm_kwargs) as pbar:
+        while futures:
+            done, futures = ray.wait(futures, num_returns=len(futures), timeout=float(update_interval))
+            for future, result in zip(done, ray.get(done)):
+                pbar.update(1)
+                yield id_to_position_map[future.hex()], result
+
+
+def _make_copy_and_empty_given(futures: List[_T]) -> List[_T]:
+    """Removes items from the given list and returns its copy. The side effect of removing items is intentional."""
+    if not isinstance(futures, list):
+        raise ValueError(f"Parameters 'futures' should be a list but {type(futures)} was given")
+
+    futures_copy = futures[:]
     while futures:
-        done, futures = ray.wait(futures, num_returns=len(futures), timeout=float(update_interval))
-        yield from (None for _ in done)
+        futures.pop()
+    return futures_copy

--- a/core/eolearn/core/utils/parallelize.py
+++ b/core/eolearn/core/utils/parallelize.py
@@ -1,0 +1,144 @@
+"""
+Utilities for a basic Python parallelization that build on top of `concurrent.futures` module from Standard Python
+library.
+
+Credits:
+Copyright (c) 2022 Matej Aleksandrov, Žiga Lukšič (Sinergise)
+
+This source code is licensed under the MIT license found in the LICENSE
+file in the root directory of this source tree.
+"""
+import concurrent.futures
+import multiprocessing
+from concurrent.futures import Future
+from enum import Enum
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    cast,
+)
+
+from tqdm.auto import tqdm
+
+if TYPE_CHECKING:
+    from threading import Lock
+
+    MULTIPROCESSING_LOCK: Optional[Lock] = None
+else:
+    MULTIPROCESSING_LOCK = None
+
+# pylint: disable=invalid-name
+_InputType = TypeVar("_InputType")
+_OutputType = TypeVar("_OutputType")
+
+
+class _ProcessingType(Enum):
+    """Type of EOExecutor processing"""
+
+    SINGLE_PROCESS = "single process"
+    MULTIPROCESSING = "multiprocessing"
+    MULTITHREADING = "multithreading"
+    RAY = "ray"
+
+
+def decide_processing_type(workers: int, multiprocess: bool) -> _ProcessingType:  # TODO: private or public??
+    """Decides processing type according to given parameters.
+
+    :param workers: A number of workers to be used (either threads or processes). If a single worker is given it will
+        always use the current thread and process.
+    :param multiprocess: A flag to decide between multiple processes and multiple threads in a single process.
+    :return: An enum defining a type of processing.
+    """
+    if workers == 1:
+        return _ProcessingType.SINGLE_PROCESS
+    if multiprocess:
+        return _ProcessingType.MULTIPROCESSING
+    return _ProcessingType.MULTITHREADING
+
+
+def parallelize(function: Callable, *params: Any, workers: int, multiprocess: bool = False, **tqdm_kwargs: Any) -> list:
+    """TODO"""
+    if not params:
+        raise ValueError(
+            "At least 1 list of parameters should be given. Otherwise it is not clear how many times the"
+            "function has to be executed."
+        )
+    processing_type = decide_processing_type(workers=workers, multiprocess=multiprocess)
+
+    if processing_type is _ProcessingType.SINGLE_PROCESS:
+        return list(tqdm(map(function, *params), total=len(params[0])))
+
+    if processing_type is _ProcessingType.MULTITHREADING:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as thread_executor:
+            return submit_and_monitor_execution(thread_executor, function, *params, **tqdm_kwargs)
+
+    # pylint: disable=global-statement
+    global MULTIPROCESSING_LOCK
+    try:
+        MULTIPROCESSING_LOCK = multiprocessing.Manager().Lock()
+        with concurrent.futures.ProcessPoolExecutor(max_workers=workers) as process_executor:
+            return submit_and_monitor_execution(process_executor, function, *params, **tqdm_kwargs)
+    finally:
+        MULTIPROCESSING_LOCK = None
+
+
+def submit_and_monitor_execution(
+    executor: concurrent.futures.Executor,
+    function: Callable[[_InputType], _OutputType],
+    *params: Iterable[_InputType],  # TODO
+    **tqdm_kwargs: Any,
+) -> List[_OutputType]:
+    """Performs the execution parallelization and monitors the process using a progress bar.
+
+    :param executor: An object that performs parallelization.
+    :param function: A function to be parallelized.
+    :param params: Each element in a sequence are parameters for a single call of `function`.
+    :return: A list of results in the same order as input parameters given by `executor_params`.
+    """
+    futures = [executor.submit(function, *function_params) for function_params in zip(*params)]
+    return join_futures(futures, **tqdm_kwargs)
+
+
+def join_futures(futures: List[Future], **tqdm_kwargs: Any) -> List[Any]:
+    results: List[Optional[Any]] = [None] * len(futures)
+    for position, result in join_futures_iter(futures, **tqdm_kwargs):
+        results[position] = result
+
+    return cast(List[Any], results)
+
+
+def join_futures_iter(futures: List[Future], **tqdm_kwargs: Any) -> Generator[Tuple[int, Any], None, None]:
+    id_to_position_map = {id(future): index for index, future in enumerate(futures)}
+
+    with tqdm(total=len(futures), **tqdm_kwargs) as pbar:
+        for future in concurrent.futures.as_completed(futures):  # TODO
+            result = future.result()
+            result_position = id_to_position_map[id(future)]
+            pbar.update(1)
+            yield result_position, result
+
+
+def execute_with_mp_lock(execution_function: Callable, *args, **kwargs) -> object:
+    """A helper utility function that executes a given function with multiprocessing lock if the process is being
+    executed in a multiprocessing mode.
+
+    :param execution_function: A function
+    :param args: Function's positional arguments
+    :param kwargs: Function's keyword arguments
+    :return: Function's results
+    """
+    if multiprocessing.current_process().name == "MainProcess" or MULTIPROCESSING_LOCK is None:
+        return execution_function(*args, **kwargs)
+
+    # pylint: disable=not-context-manager
+    with MULTIPROCESSING_LOCK:
+        return execution_function(*args, **kwargs)

--- a/core/eolearn/tests/test_extra/test_ray.py
+++ b/core/eolearn/tests/test_extra/test_ray.py
@@ -7,6 +7,7 @@ file in the root directory of this source tree.
 """
 
 import datetime
+import itertools as it
 import logging
 import os
 import tempfile
@@ -16,7 +17,7 @@ import ray
 
 from eolearn.core import EOExecutor, EONode, EOTask, EOWorkflow, WorkflowResults
 from eolearn.core.eoworkflow_tasks import OutputTask
-from eolearn.core.extra.ray import RayExecutor
+from eolearn.core.extra.ray import RayExecutor, join_ray_futures, join_ray_futures_iter, parallelize_with_ray
 
 
 class ExampleTask(EOTask):
@@ -212,3 +213,38 @@ def test_mix_with_eoexecutor(workflow, execution_kwargs, simple_cluster):
         eo_outputs = [results.outputs for results in eo_results]
 
         assert ray_outputs == eo_outputs
+
+
+def test_parallelize_with_ray():
+    def add(value1, value2):
+        return value1 + value2
+
+    results = parallelize_with_ray(add, range(3), range(1, 4), desc="Test progress")
+    assert results == list(range(1, 7, 2))
+
+    results = parallelize_with_ray(add, [0, 1, 2], it.repeat(0))
+    assert results == [0, 1, 2]
+
+
+@ray.remote
+def plus_one(value):
+    return value + 1
+
+
+def test_join_ray_futures(simple_cluster):
+    futures = [plus_one.remote(value) for value in range(5)]
+    results = join_ray_futures(futures)
+
+    assert results == list(range(1, 6))
+    assert futures == []
+
+
+def test_join_ray_futures_iter(simple_cluster):
+    futures = [plus_one.remote(value) for value in range(5)]
+
+    results = []
+    for value in join_ray_futures_iter(futures):
+        assert futures == []
+        results.append(value)
+
+    assert sorted(results) == [(num, num + 1) for num in range(5)]

--- a/core/eolearn/tests/test_extra/test_ray.py
+++ b/core/eolearn/tests/test_extra/test_ray.py
@@ -130,7 +130,7 @@ def test_read_logs(filter_logs, execution_names, workflow, execution_kwargs, sim
 def test_execution_results(workflow, execution_kwargs, simple_cluster):
     with tempfile.TemporaryDirectory() as tmp_dir_name:
         executor = RayExecutor(workflow, execution_kwargs, logs_folder=tmp_dir_name)
-        executor.run()
+        executor.run(desc="Test Ray")
 
         assert len(executor.execution_results) == 4
         for results in executor.execution_results:

--- a/core/eolearn/tests/test_extra/test_ray.py
+++ b/core/eolearn/tests/test_extra/test_ray.py
@@ -14,7 +14,7 @@ import tempfile
 
 import pytest
 import ray
-from ray.exceptions import TaskCancelledError, RayTaskError
+from ray.exceptions import RayTaskError, TaskCancelledError
 
 from eolearn.core import EOExecutor, EONode, EOTask, EOWorkflow, WorkflowResults
 from eolearn.core.eoworkflow_tasks import OutputTask

--- a/core/eolearn/tests/test_extra/test_ray.py
+++ b/core/eolearn/tests/test_extra/test_ray.py
@@ -88,9 +88,13 @@ def execution_kwargs_fixture(test_nodes):
 
 
 def test_fail_without_ray(workflow, execution_kwargs):
+    """This test passes because it happens before other tests where a connection with Ray is established."""
     executor = RayExecutor(workflow, execution_kwargs)
     with pytest.raises(RuntimeError):
         executor.run()
+
+    with pytest.raises(RuntimeError):
+        parallelize_with_ray(max, range(3), range(3))
 
 
 @pytest.mark.parametrize("filter_logs", [True, False])

--- a/core/eolearn/tests/test_utils/test_parallelize.py
+++ b/core/eolearn/tests/test_utils/test_parallelize.py
@@ -5,11 +5,61 @@ Copyright (c) 2022 Matej Aleksandrov, Žiga Lukšič (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+import itertools as it
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 
 import pytest
 
-from eolearn.core.utils.parallelize import join_futures, join_futures_iter
+from eolearn.core.utils.parallelize import (
+    _decide_processing_type,
+    _ProcessingType,
+    execute_with_mp_lock,
+    join_futures,
+    join_futures_iter,
+    parallelize,
+    submit_and_monitor_execution,
+)
+
+
+@pytest.mark.parametrize(
+    "workers, multiprocess, expected_type",
+    [
+        (1, False, _ProcessingType.SINGLE_PROCESS),
+        (1, True, _ProcessingType.SINGLE_PROCESS),
+        (3, False, _ProcessingType.MULTITHREADING),
+        (2, True, _ProcessingType.MULTIPROCESSING),
+    ],
+)
+def test_decide_processing_type(workers, multiprocess, expected_type):
+    processing_type = _decide_processing_type(workers=workers, multiprocess=multiprocess)
+    assert processing_type is expected_type
+
+
+def test_execute_with_mp_lock():
+    """For now just a basic dummy test."""
+    result = execute_with_mp_lock(sorted, range(10), key=lambda value: -value)
+    assert result == list(range(9, -1, -1))
+
+
+@pytest.mark.parametrize(
+    "workers, multiprocess",
+    [
+        (1, True),
+        (3, False),
+        (2, True),
+    ],
+)
+def test_parallelize(workers, multiprocess):
+    results = parallelize(max, range(10), it.repeat(5), workers=workers, multiprocess=multiprocess, desc="Test")
+    assert results == [5] * 5 + list(range(5, 10))
+
+
+@pytest.mark.parametrize("executor_class", [ThreadPoolExecutor, ProcessPoolExecutor])
+def test_submit_and_monitor_execution(executor_class):
+    with executor_class(max_workers=2) as executor:
+        results = submit_and_monitor_execution(executor, max, range(10), it.repeat(5))
+
+    assert results == [5] * 5 + list(range(5, 10))
 
 
 def plus_one(value):
@@ -23,7 +73,7 @@ def test_join_futures(executor_class):
         results = join_futures(futures)
 
     assert results == list(range(1, 6))
-    # assert futures == []
+    assert futures == []
 
 
 @pytest.mark.parametrize("executor_class", [ThreadPoolExecutor, ProcessPoolExecutor])
@@ -32,7 +82,7 @@ def test_join_futures_iter(executor_class):
         futures = [executor.submit(plus_one, value) for value in range(5)]
         results = []
         for value in join_futures_iter(futures):
-            # assert futures == []
+            assert futures == []
             results.append(value)
 
     assert sorted(results) == [(num, num + 1) for num in range(5)]

--- a/core/eolearn/tests/test_utils/test_parallelize.py
+++ b/core/eolearn/tests/test_utils/test_parallelize.py
@@ -1,0 +1,38 @@
+"""
+Credits:
+Copyright (c) 2022 Matej Aleksandrov, Žiga Lukšič (Sinergise)
+
+This source code is licensed under the MIT license found in the LICENSE
+file in the root directory of this source tree.
+"""
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+
+import pytest
+
+from eolearn.core.utils.parallelize import join_futures, join_futures_iter
+
+
+def plus_one(value):
+    return value + 1
+
+
+@pytest.mark.parametrize("executor_class", [ThreadPoolExecutor, ProcessPoolExecutor])
+def test_join_futures(executor_class):
+    with executor_class() as executor:
+        futures = [executor.submit(plus_one, value) for value in range(5)]
+        results = join_futures(futures)
+
+    assert results == list(range(1, 6))
+    # assert futures == []
+
+
+@pytest.mark.parametrize("executor_class", [ThreadPoolExecutor, ProcessPoolExecutor])
+def test_join_futures_iter(executor_class):
+    with executor_class() as executor:
+        futures = [executor.submit(plus_one, value) for value in range(5)]
+        results = []
+        for value in join_futures_iter(futures):
+            # assert futures == []
+            results.append(value)
+
+    assert sorted(results) == [(num, num + 1) for num in range(5)]

--- a/core/eolearn/tests/test_utils/test_parallelize.py
+++ b/core/eolearn/tests/test_utils/test_parallelize.py
@@ -57,7 +57,7 @@ def test_parallelize(workers, multiprocess):
 @pytest.mark.parametrize("executor_class", [ThreadPoolExecutor, ProcessPoolExecutor])
 def test_submit_and_monitor_execution(executor_class):
     with executor_class(max_workers=2) as executor:
-        results = submit_and_monitor_execution(executor, max, range(10), it.repeat(5))
+        results = submit_and_monitor_execution(executor, max, range(10), it.repeat(5), disable=True)
 
     assert results == [5] * 5 + list(range(5, 10))
 

--- a/docs/source/eolearn.core.rst
+++ b/docs/source/eolearn.core.rst
@@ -19,5 +19,6 @@ Submodules:
    eolearn.core.utils.common
    eolearn.core.utils.fs
    eolearn.core.utils.logging
+   eolearn.core.utils.parallelize
    eolearn.core.utils.parsing
    eolearn.core.extra.ray

--- a/docs/source/eolearn.core.utils.parallelize.rst
+++ b/docs/source/eolearn.core.utils.parallelize.rst
@@ -1,0 +1,7 @@
+eolearn.core.utils.parallelize
+==============================
+
+.. automodule:: eolearn.core.utils.parallelize
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
The code that deals with parallelization has been extracted from `EOExecutor` and `RayExecutor`, transformed into useful utility functions, and generalized. What I was able to achieve:

- Utility functions are ordered from a high level to low level, because different use cases require different levels of customization. Functions for users are:
  * `parallelize` and `parallelize_with_ray`,
  * `join_futures` and `join_ray_futures`,
  * `join_futures_iter` and `join_ray_futures_iter`
  
  In general I think these names make sense but feel free to add other suggestions.

- On a low level, the PR implements this functionality of early removal of finished future objects. This can be achieved only if there are no other references to future objects in the runtime which means we also have to remove them from `futures` list that is input to the lower level functions. Hence, we cannot avoid the side-effect of modifying an input object but at least it is documented.

- Progress bar is integrated in the low level functionalities. This PR makes it possible to customize its parameters but I think you cannot deactivate it. If ever needed, we could add a custom progress bar factory with extra parameters for deactivating it.

- At the end, I decided to make a generalization of the low-level process in `_base_join_futures_iter` to avoid code duplications. Mypy is still complaining a bit about my types but I'm not exactly sure how to improve that. The issue is also that I don't see how `concurrent.futures.Future` and `ray.ObjectRef` objects could be typed in a way that they would tell which objects they contain. E.g. `Future[_OutputType]` doesn't work. Maybe I'm missing something.
