### PR TITLE
Faster node hash

### DIFF
--- a/core/eolearn/core/eonode.py
+++ b/core/eolearn/core/eonode.py
@@ -50,7 +50,7 @@ class EONode:
         super().__setattr__("uid", generate_uid(self.task.__class__.__name__))
 
     def __hash__(self) -> int:
-        return self.uid.encode("utf-8").__hash__()
+        return self.uid.__hash__()
 
     def get_name(self, suffix_number: int = 0) -> str:
         """Provides node name according to the class of the contained task and a given number."""

--- a/core/eolearn/core/eonode.py
+++ b/core/eolearn/core/eonode.py
@@ -7,7 +7,7 @@ Copyright (c) 2021-2022 Matej Aleksandrov, Matej Batič, Miha Kadunc, Žiga Luk�
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-
+import binascii
 import datetime as dt
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Sequence, Set, Tuple, Union, cast
@@ -49,6 +49,9 @@ class EONode:
             super().__setattr__("name", self.task.__class__.__name__)
 
         super().__setattr__("uid", generate_uid(self.task.__class__.__name__))
+
+    def __hash__(self) -> int:
+        return int(binascii.hexlify(self.uid.encode("utf-8")), 16)
 
     def get_name(self, suffix_number: int = 0) -> str:
         """Provides node name according to the class of the contained task and a given number."""

--- a/core/eolearn/core/eonode.py
+++ b/core/eolearn/core/eonode.py
@@ -7,7 +7,6 @@ Copyright (c) 2021-2022 Matej Aleksandrov, Matej Batič, Miha Kadunc, Žiga Luk�
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-import binascii
 import datetime as dt
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Sequence, Set, Tuple, Union, cast
@@ -51,7 +50,7 @@ class EONode:
         super().__setattr__("uid", generate_uid(self.task.__class__.__name__))
 
     def __hash__(self) -> int:
-        return int(binascii.hexlify(self.uid.encode("utf-8")), 16)
+        return self.uid.encode("utf-8").__hash__()
 
     def get_name(self, suffix_number: int = 0) -> str:
         """Provides node name according to the class of the contained task and a given number."""

--- a/core/eolearn/tests/test_eonode.py
+++ b/core/eolearn/tests/test_eonode.py
@@ -5,6 +5,8 @@ Copyright (c) 2021-2022 Matej Aleksandrov, Matej Batič, Miha Kadunc, Žiga Luk�
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+import time
+
 from eolearn.core import EONode, EOTask, OutputTask, linearly_connect_tasks
 
 
@@ -30,6 +32,26 @@ def test_nodes_different_uids():
         uids.add(node.uid)
 
     assert len(uids) == 5000, "Different nodes should have different uids."
+
+
+def test_hashing():
+    {EONode(Inc()): "Can be hashed!"}
+
+    linear = EONode(Inc())
+    for _ in range(5000):
+        linear = EONode(Inc(), inputs=[linear])
+
+    branch_1, branch_2 = EONode(Inc()), EONode(Inc())
+    for _ in range(500):
+        branch_1 = EONode(DivideTask(), inputs=(branch_1, branch_2))
+        branch_2 = EONode(DivideTask(), inputs=(branch_2, EONode(Inc())))
+
+    t_start = time.time()
+    linear.__hash__()
+    branch_1.__hash__()
+    branch_2.__hash__()
+    t_end = time.time()
+    assert t_end - t_start < 5, "Assert hashing slows down for large workflows!"
 
 
 def test_get_dependencies():


### PR DESCRIPTION
Because EONode is a frozen dataclass the built-in hashing is done via structural recursion (apparently in a non-memoized way). The slowdown seems to be exponential and in workflows with over 120 nodes the time required becomes an enormous issue.

Since we use EONodes as keys in execution arguments (and in `from_endnodes` and possible elsewhere) this needs to be improved.

The suggested improvement instead hashes the EONodes uid, for which we already assume it's unique (and is often used as a key internally).