### PR TITLE
Add optional input to Load task

### DIFF
--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -146,20 +146,25 @@ class LoadTask(IOTask):
         self.kwargs = kwargs
         super().__init__(path, filesystem=filesystem, create=False, config=config)
 
-    def execute(self, *, eopatch_folder=""):
+    def execute(self, eopatch=None, *, eopatch_folder=""):
         """Loads the EOPatch from disk: `folder/eopatch_folder`.
 
+        :param eopatch: Optional input EOPatch. If given the loaded features are merged onto it, otherwise a new EOPatch
+            is created.
         :param eopatch_folder: Name of EOPatch folder containing data. If `None` is given it will return an empty
-            `EOPatch`.
+            or modified `EOPatch` (depending on the task input).
         :type eopatch_folder: str or None
         :return: EOPatch loaded from disk
         :rtype: EOPatch
         """
         if eopatch_folder is None:
-            return EOPatch()
+            return eopatch or EOPatch()
 
         path = fs.path.combine(self.filesystem_path, eopatch_folder)
-        return EOPatch.load(path, filesystem=self.filesystem, **self.kwargs)
+        loaded_patch = EOPatch.load(path, filesystem=self.filesystem, **self.kwargs)
+        if eopatch is None:
+            return loaded_patch
+        return eopatch.merge(loaded_patch)
 
 
 class AddFeatureTask(EOTask):

--- a/core/eolearn/tests/test_core_tasks.py
+++ b/core/eolearn/tests/test_core_tasks.py
@@ -98,6 +98,22 @@ def test_partial_copy(patch):
     assert partial_deepcopy == expected_patch, "Partial deep copying was not successful"
 
 
+def test_load_task(test_eopatch_path):
+    full_load = LoadTask(test_eopatch_path)
+    full_patch = full_load.execute(eopatch_folder=".")
+    assert len(full_patch.get_feature_list()) == 30
+
+    partial_load = LoadTask(test_eopatch_path, features=[FeatureType.BBOX, FeatureType.MASK_TIMELESS])
+    partial_patch = partial_load.execute(eopatch_folder=".")
+
+    assert FeatureType.BBOX in partial_patch and FeatureType.TIMESTAMP not in partial_patch
+
+    load_more = LoadTask(test_eopatch_path, features=[FeatureType.TIMESTAMP])
+    upgraded_partial_patch = load_more.execute(partial_patch, eopatch_folder=".")
+    assert FeatureType.BBOX in upgraded_partial_patch and FeatureType.TIMESTAMP in upgraded_partial_patch
+    assert FeatureType.DATA not in upgraded_partial_patch
+
+
 def test_load_nothing():
     load = LoadTask("./some/fake/path")
     eopatch = load.execute(eopatch_folder=None)


### PR DESCRIPTION
I believe this to be a good addition because it allows loading from multiple folders in a linear (sub)workflow. This allows more control over execution order and also simplifies certain workflows (no need for an explicit merge task).

If you feel like this functionality is not desired I would remove it, but keep part of the tests, since they are related to the LoadTask as it is. 