### PR TITLE
Minor pytest updates

### DIFF
--- a/coregistration/eolearn/tests/test_coregistration.py
+++ b/coregistration/eolearn/tests/test_coregistration.py
@@ -15,6 +15,7 @@ import numpy as np
 import pytest
 
 from eolearn.core import EOPatch, FeatureType
+from eolearn.core.exceptions import EORuntimeWarning
 from eolearn.coregistration import ECCRegistrationTask, InterpolationType
 
 logging.basicConfig(level=logging.DEBUG)
@@ -46,7 +47,8 @@ def test_registration(eopatch):
         interpolation_type=InterpolationType.NEAREST,
         apply_to_features={FeatureType.DATA: ["bands", "ndvi"], FeatureType.MASK: ["cm"]},
     )
-    reopatch = reg(eopatch)
+    with pytest.warns(EORuntimeWarning):
+        reopatch = reg(eopatch)
 
     assert eopatch.data["bands"].shape == reopatch.data["bands"].shape, "Shapes of .data['bands'] do not match"
     assert eopatch.data["ndvi"].shape == reopatch.data["ndvi"].shape, "Shapes of .data['ndvi'] do not match"

--- a/io/eolearn/tests/conftest.py
+++ b/io/eolearn/tests/conftest.py
@@ -57,7 +57,7 @@ def s3_gpkg_example_file_fixture(config):
     try:
         client.head_bucket(Bucket="eolearn-io")
     except (ClientError, NoCredentialsError):
-        return pytest.skip(msg="No access to the bucket.")
+        return pytest.skip(reason="No access to the bucket.")
 
     return "s3://eolearn-io/import-gpkg-test.gpkg"
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,9 +5,9 @@ isort
 moto
 nbval
 pylint>=2.14.0
+pytest>=7.0.0
 pytest-cov
 pytest-mock
-pytest>=6.0.0
 ray[default]
 responses
 twine


### PR DESCRIPTION
- In `pytest>=7.0.0` a parameter of `pytest.skip` was renamed - this fixes it.
- Tests now make sure that EO warnings are being raised wherever expected and not raised otherwise.

These updates reduced a bit the number of warnings we get in tests. We still get a ton of warnings because of an issue in `geopandas` that will be fixed in the next `geopandas` version. We also get quite a number of warnings because a utility function in core intentionally tests deprecated numpy types.