### PR TITLE
Add image resizing utility function with better support

### DIFF
--- a/mask/eolearn/mask/utils.py
+++ b/mask/eolearn/mask/utils.py
@@ -61,6 +61,7 @@ class ResizeMethod(Enum):
 
 
 class ResizeLib(Enum):
+    """Backends available for spatial resizing of data."""
     PIL = "PIL"
     CV2 = "cv2"
 
@@ -192,7 +193,7 @@ def resize_images(
                           One of 'nearest', 'linear', 'cubic'. Default is 'linear'.
     """
     warnings.warn(
-        f"The function `resize_images` is deprecated and will be removed. Please switch to `spatially_resize_image`.",
+        "The function `resize_images` is deprecated and will be removed. Please switch to `spatially_resize_image`.",
         EODeprecationWarning,
     )
     inter_methods = {"nearest": cv2.INTER_NEAREST, "linear": cv2.INTER_LINEAR, "cubic": cv2.INTER_CUBIC}

--- a/mask/eolearn/mask/utils.py
+++ b/mask/eolearn/mask/utils.py
@@ -10,23 +10,70 @@ Copyright (c) 2017-2019 Blaž Sovdat, Andrej Burja (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+import warnings
+from enum import Enum
+from functools import partial
+from typing import Any, Callable, Optional, Tuple
 
 import cv2
 import numpy as np
+from PIL import Image
+
+from eolearn.core.exceptions import EODeprecationWarning
 
 
-def map_over_axis(data, func, axis=0):
+class ResizeMethod(Enum):
+    """Methods available for spatial resizing of data."""
+
+    NEAREST = "nearest"
+    LINEAR = "linear"
+    CUBIC = "cubic"
+
+    def get_cv2_method(self, dtype: Any) -> int:
+        """Obtain the constant specifying the interpolation method for the CV2 library."""
+        if np.issubdtype(dtype, np.floating):
+            choices = {
+                ResizeMethod.NEAREST: cv2.INTER_NEAREST,
+                ResizeMethod.LINEAR: cv2.INTER_LINEAR,
+                ResizeMethod.CUBIC: cv2.INTER_CUBIC,
+            }
+            return choices[self]
+        if np.issubdtype(dtype, np.integer):
+            choices = {
+                ResizeMethod.NEAREST: cv2.INTER_NEAREST_EXACT,
+                ResizeMethod.LINEAR: cv2.INTER_LINEAR_EXACT,
+            }
+            if self not in choices:
+                raise ValueError(
+                    f"The {self.value} interpolation method cannot be used for integers with the CV2 backend."
+                )
+            return choices[self]
+        raise ValueError(f"The dtype {dtype} cannot be processed with the CV2 backend.")
+
+    def get_pil_method(self) -> Image.Resampling:
+        """Obtain the constant specifying the interpolation method for the PIL library."""
+        choices = {
+            ResizeMethod.NEAREST: Image.Resampling.NEAREST,
+            ResizeMethod.LINEAR: Image.Resampling.BILINEAR,
+            ResizeMethod.CUBIC: Image.Resampling.BICUBIC,
+        }
+        return choices[self]
+
+
+class ResizeLib(Enum):
+    PIL = "PIL"
+    CV2 = "cv2"
+
+
+def map_over_axis(data: np.ndarray, func: Callable[[np.ndarray], np.ndarray], axis: int = 0) -> np.ndarray:
     """Map function func over each slice along axis.
     If func changes the number of dimensions, mapping axis is moved to the front.
 
     Returns a new array with the combined results of mapping.
 
     :param data: input array
-    :type data: np.array
     :param func: Mapping function that is applied on each slice. Outputs must have the same shape for every slice.
-    :type func: function np.array -> np.array
     :param axis: Axis over which to map the function.
-    :type axis: int
 
     :example:
 
@@ -38,49 +85,127 @@ def map_over_axis(data, func, axis=0):
     """
     # Move axis to front
     data = np.moveaxis(data, axis, 0)
-
-    res_mapped = [func(slice) for slice in data]
-    res = np.stack(res_mapped)
+    mapped_data = np.stack([func(data_slice) for data_slice in data])
 
     # Move axis back if number of dimensions stays the same
-    if data.ndim == res.ndim:
-        res = np.moveaxis(res, 0, axis)
+    if data.ndim == mapped_data.ndim:
+        mapped_data = np.moveaxis(mapped_data, 0, axis)
 
-    return res
+    return mapped_data
 
 
-def resize_images(data, new_size=None, scale_factors=None, anti_alias=True, interpolation="linear"):
+def spatially_resize_image(
+    data: np.ndarray,
+    new_size: Optional[Tuple[int, int]] = None,
+    scale_factors: Optional[Tuple[float, float]] = None,
+    spatial_axes: Optional[Tuple[int, int]] = None,
+    resize_method: ResizeMethod = ResizeMethod.LINEAR,
+    resize_library: ResizeLib = ResizeLib.PIL,
+) -> np.ndarray:
     """Resizes the image(s) according to given size or scale factors.
 
     To specify the new scale use one of `new_size` or `scale_factors` parameters.
 
     :param data: input image array
-    :type data: numpy array with shape (timestamps, height, width, channels),
-                (height, width, channels), or (height, width)
     :param new_size: New size of the data (height, width)
-    :type new_size: (int, int)
+    :param scale_factors: Factors (f_height, f_width) by which to resize the image
+    :param spatial_axes: Which two axes of input data represent height and width. If left as `None` they are selected
+        according to standards of eo-learn features.
+    :param resize_method: Interpolation method used for resizing.
+    :param resize_library: Which Pyhon library to use for resizing. Default is PIL, as it supports all dtypes and
+        features anti-aliasing. For cases where execution speed is crucial one can use CV2.
+    """
+
+    resize_method = ResizeMethod(resize_method)
+    resize_library = ResizeLib(resize_library)
+
+    if spatial_axes is None:
+        spatial_axes = (1, 2) if data.ndim == 4 else (0, 1)
+    elif len(spatial_axes) != 2 or spatial_axes[0] >= spatial_axes[1]:
+        raise ValueError(
+            "Spatial axes should be given as a pair of axis indices. We support only the case where the first axis is"
+            " lower than the second one, i.e. (0, 1) is ok but (1, 0) is not supported."
+        )
+
+    if new_size is not None and scale_factors is None:
+        height, width = new_size
+    elif scale_factors is not None and new_size is None:
+        f_y, f_x = scale_factors
+        old_height, old_width = data.shape[spatial_axes[0]], data.shape[spatial_axes[1]]
+        height, width = np.round(f_y * old_height), np.round(f_x * old_width)
+    else:
+        raise ValueError("Exactly one of the arguments new_size or scale_factors must be given.")
+
+    size = (width, height)
+    if resize_library is ResizeLib.CV2:
+        resize_function = partial(cv2.resize, dsize=size, interpolation=resize_method.get_cv2_method(data.dtype))
+    else:
+        resize_function = partial(_pil_resize_ndarray, size=size, method=resize_method.get_pil_method())
+
+    return _apply_to_spatial_axes(resize_function, data, spatial_axes)
+
+
+def _pil_resize_ndarray(image: np.ndarray, size: Tuple[int, int], method: Image.Resampling) -> np.ndarray:
+    return np.array(Image.fromarray(image).resize(size, method))
+
+
+def _apply_to_spatial_axes(
+    resize_function: Callable[[np.ndarray], np.ndarray], data: np.ndarray, spatial_axes: Tuple[int, int]
+) -> np.ndarray:
+    """Helper function for applying resizing to spatial axes
+
+    Recursively slices data into smaller-dimensional ones, until only the spatial axes remain. The indices of spatial
+    axes have to be adjusted if the recursion-axis is smaller than either one, e.g. spatial axes (1, 2) become (0, 1)
+    after splitting the 3D data along axis 0 into 2D arrays.
+
+    After achieving 2D data slices the resizing function is applied. The data is then reconstructed into original form.
+    """
+
+    if data.ndim <= 2:
+        return resize_function(data)
+
+    axis = next(i for i in range(data.ndim) if i not in spatial_axes)
+    data = np.moveaxis(data, axis, 0)
+
+    ax1, ax2 = (ax if axis > ax else ax - 1 for ax in spatial_axes)
+
+    mapped_slices = [_apply_to_spatial_axes(resize_function, data_slice, (ax1, ax2)) for data_slice in data]
+    return np.moveaxis(np.stack(mapped_slices), 0, axis)
+
+
+def resize_images(
+    data: np.ndarray,
+    new_size: Optional[Tuple[int, int]] = None,
+    scale_factors: Optional[Tuple[float, float]] = None,
+    anti_alias: bool = True,
+    interpolation: str = "linear",
+) -> np.ndarray:
+    """Resizes the image(s) according to given size or scale factors.
+
+    To specify the new scale use one of `new_size` or `scale_factors` parameters.
+
+    :param data: input image array
+    :param new_size: New size of the data (height, width)
     :param scale_factors: Factors (fy,fx) by which to resize the image
-    :type scale_factors: (float, float)
     :param anti_alias: Use anti aliasing smoothing operation when downsampling. Default is True.
-    :type anti_alias: bool
     :param interpolation: Interpolation method used for resampling.
                           One of 'nearest', 'linear', 'cubic'. Default is 'linear'.
-    :type interpolation: string
     """
+    warnings.warn(
+        f"The function `resize_images` is deprecated and will be removed. Please switch to `spatially_resize_image`.",
+        EODeprecationWarning,
+    )
     inter_methods = {"nearest": cv2.INTER_NEAREST, "linear": cv2.INTER_LINEAR, "cubic": cv2.INTER_CUBIC}
 
     # Number of dimensions of input data
     ndims = data.ndim
 
-    # Height and width axis indices for dimensionality
     height_width_axis = {2: (0, 1), 3: (0, 1), 4: (1, 2)}
 
     # Old height and width
     old_size = [data.shape[axis] for axis in height_width_axis[ndims]]
 
     if new_size is not None and scale_factors is None:
-        if len(new_size) != 2 or any(not isinstance(value, int) for value in new_size):
-            raise ValueError("new_size must be a pair of integers (height, width).")
         scale_factors = [new / old for old, new in zip(old_size, new_size)]
     elif scale_factors is not None and new_size is None:
         new_size = [int(size * factor) for size, factor in zip(old_size, scale_factors)]
@@ -94,7 +219,6 @@ def resize_images(data, new_size=None, scale_factors=None, anti_alias=True, inte
     downscaling = scale_factors[0] < 1 or scale_factors[1] < 1
 
     def _resize2d(image):
-        # Perform anti-alias smoothing if downscaling
         if downscaling and anti_alias:
             # Sigma computation based on skimage resize implementation
             sigmas = [((1 / s) - 1) / 2 for s in scale_factors]

--- a/mask/eolearn/tests/test_utils.py
+++ b/mask/eolearn/tests/test_utils.py
@@ -1,0 +1,79 @@
+import numpy as np
+import pytest
+
+from eolearn.mask.utils import ResizeLib, ResizeMethod, map_over_axis, spatially_resize_image
+
+
+@pytest.fixture(name="test_image", scope="module")
+def test_image_fixture():
+    """Image with a distinct value in each of the quadrants. In the bottom right quadrant there is a special layer."""
+    example = np.zeros((3, 100, 100, 4))
+    example[:, 50:, :50, :] = 1
+    example[:, :50, 50:, :] = 2
+    example[:, 50:, 50:, :] = 3
+    example[0, 50:, 50:, 0] = 10
+    example[0, 50:, 50:, 1] = 20
+    example[0, 50:, 50:, 2] = 30
+    example[0, 50:, 50:, 3] = 40
+    return example.astype(np.float32)
+
+
+def test_map_over_axis():
+    data = np.ones((5, 10, 10))
+    result = map_over_axis(data, lambda x: np.zeros((7, 20)), axis=0)
+    assert result.shape == (5, 7, 20)
+    result = map_over_axis(data, lambda x: np.zeros((7, 20)), axis=1)
+    assert result.shape == (7, 10, 20)
+    result = map_over_axis(data, lambda x: np.zeros((5, 10)), axis=1)
+    assert result.shape == (5, 10, 10)
+
+
+@pytest.mark.parametrize("method", ResizeMethod)
+@pytest.mark.parametrize("library", ResizeLib)
+@pytest.mark.parametrize("dtype", (np.float32, np.int32, bool))
+@pytest.mark.parametrize("new_size", [(50, 50), (35, 39), (271, 271)])
+def test_spatially_resize_image_new_size(method, library, dtype, new_size):
+    """Test that all methods and backends are able to downscale and upscale images of various dtypes."""
+    if library is ResizeLib.CV2:
+        if dtype == np.int32 and method is ResizeMethod.CUBIC or dtype == bool:
+            return
+
+    old_shape = (111, 111)
+    data_2d = np.arange(np.prod(old_shape)).astype(dtype).reshape(old_shape)
+    result = spatially_resize_image(data_2d, new_size, resize_method=method, resize_library=library)
+    assert result.shape == new_size
+
+    old_shape = (111, 111, 3)
+    data_3d = np.arange(np.prod(old_shape)).astype(dtype).reshape(old_shape)
+    result = spatially_resize_image(data_3d, new_size, resize_method=method, resize_library=library)
+    assert result.shape == (*new_size, 3)
+
+    old_shape = (5, 111, 111, 3)
+    data_4d = np.arange(np.prod(old_shape)).astype(dtype).reshape(old_shape)
+    result = spatially_resize_image(data_4d, new_size, resize_method=method, resize_library=library)
+    assert result.shape == (5, *new_size, 3)
+
+    old_shape = (2, 1, 111, 111, 3)
+    data_5d = np.arange(np.prod(old_shape)).astype(dtype).reshape(old_shape)
+    result = spatially_resize_image(
+        data_5d, new_size, resize_method=method, spatial_axes=(2, 3), resize_library=library
+    )
+    assert result.shape == (2, 1, *new_size, 3)
+
+
+@pytest.mark.parametrize("method", ResizeMethod)
+@pytest.mark.parametrize("library", ResizeLib)
+@pytest.mark.parametrize("new_size", [(50, 50), (217, 271)])
+def test_spatially_resize_image(method, library, new_size, test_image):
+    """Test that resizing is correct on a very basic example. It tests midpoints of the 4 quadrants."""
+    height, width = new_size
+    x1, x2 = width // 4, 3 * width // 4
+    y1, y2 = height // 4, 3 * height // 4
+
+    result = spatially_resize_image(test_image, new_size, resize_method=method, resize_library=library)
+    assert result.shape == (3, *new_size, 4)
+    assert result[1, x1, y1, :] == pytest.approx([0, 0, 0, 0])
+    assert result[2, x2, y1, :] == pytest.approx([1, 1, 1, 1])
+    assert result[1, x1, y2, :] == pytest.approx([2, 2, 2, 2])
+    assert result[0, x2, y2, :] == pytest.approx([10, 20, 30, 40]), "The first temporal layer of image is incorrect."
+    assert result[1, x2, y2, :] == pytest.approx([3, 3, 3, 3])


### PR DESCRIPTION
The new utility function supports both the CV2 and PIL backend. It tries to clarify certain CV2 errors by analyzing methods and dtypes, since CV2 errors are terrible.

The PIL backend is the default because the antialiasing ensures images are closer to expectations. It also works with all dtypes. For higher dimensional data (e.g. temporal features) using PIL is still about 3-4x slower than CV2, so it is available as the alternative.

It is hard to write precise tests due to antialiasing, but I included a rather basic test to check that they work properly.  