### PR TITLE
Fixed BBox setting in ImportFromTiffTask

### DIFF
--- a/features/requirements.txt
+++ b/features/requirements.txt
@@ -1,7 +1,7 @@
 eo-learn-core
 numba>=0.53.0
 numpy
-pillow>=9.0.0
+pillow>=9.1.0
 python-dateutil
 scikit-image>=0.19.0
 scikit-learn

--- a/io/eolearn/tests/test_local_io.py
+++ b/io/eolearn/tests/test_local_io.py
@@ -178,6 +178,9 @@ def test_export_import(test_case, test_eopatch):
             expected_raster.dtype == new_eop[test_case.feature_type][test_case.name].dtype
         ), "Tiff imported into new EOPatch has different dtype as expected"
 
+        assert new_eop.bbox == test_eopatch.bbox
+        assert old_eop.bbox == test_eopatch.bbox
+
 
 def _execute_with_warning_control(
     export_task: ExportToTiffTask, warning: Optional[Type[Warning]], *args: Any, **kwargs: Any


### PR DESCRIPTION
In PR https://github.com/sentinel-hub/eo-learn/pull/416 I introduced a bug. In case input EOPatch didn't have a bounding box  `ImportFromTiffTask` should set a bounding box from the image to it. In the refactoring I forgot about this.

This is now fixed and I also added checks in tests that verify this.