### PR TITLE
Fixed compatibility with geopandas 0.11.0 and suppressed all warnings in eolearn.core

### DIFF
--- a/core/eolearn/core/utils/common.py
+++ b/core/eolearn/core/utils/common.py
@@ -152,5 +152,4 @@ def generate_uid(prefix: str):
 
 def is_discrete_type(number_type: Union[np.dtype, type]) -> bool:
     """Checks if a given `numpy` type is a discrete numerical type."""
-    number_dtype = np.dtype(number_type)
-    return issubclass(number_dtype.type, (np.integer, np.bool_))
+    return np.issubdtype(number_type, np.integer) or np.issubdtype(number_type, bool)

--- a/core/eolearn/tests/test_utils/test_common.py
+++ b/core/eolearn/tests/test_utils/test_common.py
@@ -5,16 +5,16 @@ Copyright (c) 2017-2022 Matej Aleksandrov, Žiga Lukšič (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+import warnings
 
 import numpy as np
 import pytest
 
 from eolearn.core.utils.common import is_discrete_type
 
-
-@pytest.mark.parametrize(
-    "number_type, is_discrete",
-    [
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    DTYPE_TEST_CASES = [
         (int, True),
         (bool, True),
         (float, False),
@@ -37,11 +37,16 @@ from eolearn.core.utils.common import is_discrete_type
         (np.datetime64, False),
         (np.object_, False),
         (np.generic, False),
-    ],
-)
+    ]
+
+
+@pytest.mark.parametrize("number_type, is_discrete", DTYPE_TEST_CASES)
 def test_is_discrete_type(number_type, is_discrete):
     """Checks the given type and its numpy dtype against the expected answer."""
     assert is_discrete_type(number_type) is is_discrete
 
-    numpy_dtype = np.dtype(number_type)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        numpy_dtype = np.dtype(number_type)
+
     assert is_discrete_type(numpy_dtype) is is_discrete


### PR DESCRIPTION
It turned out that `gdf.to_file` method even in the older `geopandas` version could under some conditions also save index as a new column. Now that saving empty dataframes started to work in `0.11.0` such a condition was met and only in case of empty dataframes it was saving with an unnecessary `index` column. This shouldn't be a big problem for users but our tests reported that a sequence of save and load operation doesn't produce exactly the same results.

Changes:

- Prevented saving index column and suppressed a warning about saving an empty dataframe.
- Also suppressed warnings that were emitted by tests of `is_discrete_type` utility function. Now `eolearn.core` tests are free of warnings.
