### PR TITLE
Filesystem upgrade and serialization

### DIFF
--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -75,6 +75,7 @@ class IOTask(EOTask, metaclass=ABCMeta):
         if self._pickled_filesystem is None:
             filesystem = get_filesystem(self.path, create=self._create_path, config=self.config)
             self._pickled_filesystem = pickle_fs(filesystem)
+            return filesystem
 
         return unpickle_fs(self._pickled_filesystem)
 

--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -66,14 +66,14 @@ class IOTask(EOTask, metaclass=ABCMeta):
         self.filesystem_path = "/" if filesystem is None else self.path
 
         self._pickled_filesystem = None if filesystem is None else pickle_fs(filesystem)
-        self._create = create
+        self._create_path = create
         self.config = config
 
     @property
     def filesystem(self):
         """A filesystem property that unpickles an existing filesystem definition or creates a new one."""
         if self._pickled_filesystem is None:
-            filesystem = get_filesystem(self.path, create=self._create, config=self.config)
+            filesystem = get_filesystem(self.path, create=self._create_path, config=self.config)
             self._pickled_filesystem = pickle_fs(filesystem)
 
         return unpickle_fs(self._pickled_filesystem)

--- a/core/eolearn/core/utils/fs.py
+++ b/core/eolearn/core/utils/fs.py
@@ -67,7 +67,7 @@ def get_base_filesystem_and_path(*path_parts: str, **kwargs: Any) -> Tuple[FS, s
 
 
 def load_s3_filesystem(
-    path: str, strict: bool = False, config: Optional[SHConfig] = None, aws_profile: Optional[str] = None
+    path: str, strict: bool = False, config: Optional[SHConfig] = None, aws_profile: Optional[str] = None, **kwargs: Any
 ) -> S3FS:
     """Loads AWS s3 filesystem from a path.
 
@@ -76,6 +76,8 @@ def load_s3_filesystem(
     :param config: A configuration object with AWS credentials. By default, is set to None and in this case the default
         configuration will be taken.
     :param aws_profile: A name of AWS profile. If given, AWS credentials will be taken from there.
+    :param kwargs: Additional keyword arguments that will be used to initialize `fs_s3fs.S3FS` object, e.g. `acl`,
+        `upload_args`, `download_args`, etc.
     :return: A S3 filesystem object
     """
     if not is_s3_path(path):
@@ -96,6 +98,7 @@ def load_s3_filesystem(
         aws_secret_access_key=config.aws_secret_access_key or None,
         aws_session_token=config.aws_session_token or None,
         strict=strict,
+        **kwargs,
     )
 
 

--- a/core/eolearn/core/utils/fs.py
+++ b/core/eolearn/core/utils/fs.py
@@ -127,8 +127,8 @@ def get_aws_credentials(aws_profile: str, config: Optional[SHConfig] = None) -> 
 
 
 def pickle_fs(filesystem: FS) -> bytes:
-    """By default, filesystem objects cannot be pickled because they contain thread locks and similar unserializable
-    objects. This function removes the before pickling the filesystem object.
+    """By default, a filesystem object cannot be pickled because it contains a thread lock and optionally some other
+    unserializable objects. This function removes all unserializable objects before pickling the filesystem object.
 
     :param filesystem: A filesystem object to pickle.
     :return: A pickle of a filesystem object in bytes.

--- a/core/eolearn/core/utils/fs.py
+++ b/core/eolearn/core/utils/fs.py
@@ -19,6 +19,7 @@ import fs
 from boto3 import Session
 from fs.base import FS
 from fs.memoryfs import MemoryFS
+from fs.tempfs import TempFS
 from fs_s3fs import S3FS
 
 from sentinelhub import SHConfig
@@ -143,6 +144,11 @@ def pickle_fs(filesystem: FS) -> bytes:
         filesystem._tlocal = None
     if isinstance(filesystem, MemoryFS):
         filesystem.root.lock = None
+    if isinstance(filesystem, TempFS):
+        # The filesystem object is a copy of the original and isn't referenced outside this function. If we don't
+        # deactivate auto-cleaning it will delete the temporary folder at the end of this function just before it
+        # gets deleted by the garbage collector.
+        filesystem._auto_clean = False
 
     try:
         return pickle.dumps(filesystem)

--- a/core/eolearn/tests/test_core_tasks.py
+++ b/core/eolearn/tests/test_core_tasks.py
@@ -12,10 +12,13 @@ file in the root directory of this source tree.
 
 import copy
 import datetime
+import pickle
 
 import numpy as np
 import pytest
+from fs.osfs import OSFS
 from fs.tempfs import TempFS
+from fs_s3fs import S3FS
 
 from sentinelhub import CRS
 
@@ -129,6 +132,16 @@ def test_save_nothing(patch):
 
         assert not temp_fs.exists(temp_path)
         assert output == patch
+
+
+@pytest.mark.parametrize("filesystem", [OSFS("."), S3FS("s3://fake-bucket/"), TempFS()])
+@pytest.mark.parametrize("task_class", [LoadTask, SaveTask])
+def test_io_task_pickling(filesystem, task_class):
+    task = task_class("/", filesystem=filesystem)
+
+    pickled_task = pickle.dumps(task)
+    unpickled_task = pickle.loads(pickled_task)
+    assert isinstance(unpickled_task, task_class)
 
 
 def test_add_rename_remove_feature(patch):

--- a/core/eolearn/tests/test_utils/test_fs.py
+++ b/core/eolearn/tests/test_utils/test_fs.py
@@ -105,7 +105,7 @@ def test_get_aws_credentials(mocked_copy):
     "filesystem, compare_params",
     [
         (OSFS("."), ["root_path"]),
-        (TempFS(identifier="test"), ["identifier", "_temp_dir", "_auto_clean"]),
+        (TempFS(identifier="test"), ["identifier", "_temp_dir"]),
         (MemoryFS(), []),
         (
             S3FS("s3://fake-bucket/", strict=False, acl="public-read"),
@@ -122,6 +122,17 @@ def test_filesystem_serialization(filesystem: FS, compare_params: List[str]):
     assert isinstance(unpickled_filesystem._lock, RLock)
     for param in compare_params:
         assert getattr(filesystem, param) == getattr(unpickled_filesystem, param)
+
+
+def test_tempfs_serialization():
+    with TempFS() as filesystem:
+        pickled_filesystem = pickle_fs(filesystem)
+        assert filesystem.exists("/")
+
+        unpickled_filesystem = unpickle_fs(pickled_filesystem)
+        assert filesystem.exists("/")
+
+    assert not unpickled_filesystem.exists("/")
 
 
 @pytest.mark.parametrize(

--- a/core/eolearn/tests/test_utils/test_fs.py
+++ b/core/eolearn/tests/test_utils/test_fs.py
@@ -66,6 +66,20 @@ def test_s3_filesystem(aws_session_token):
         assert filesystem.aws_session_token == aws_session_token
 
 
+@pytest.mark.parametrize("s3fs_function", [get_filesystem, load_s3_filesystem])
+def test_s3fs_keyword_arguments(s3fs_function):
+    filesystem = s3fs_function("s3://dummy-bucket/", acl="bucket-owner-full-control")
+    assert isinstance(filesystem, S3FS)
+    assert filesystem.upload_args == {"ACL": "bucket-owner-full-control"}
+
+    upload_args = {"test": "upload"}
+    download_args = {"test": "download"}
+    filesystem = s3fs_function("s3://dummy-bucket/", upload_args=upload_args, download_args=download_args)
+    assert isinstance(filesystem, S3FS)
+    assert filesystem.upload_args == upload_args
+    assert filesystem.download_args == download_args
+
+
 @mock.patch("eolearn.core.utils.fs.Session")
 def test_get_aws_credentials(mocked_copy):
     fake_credentials = Credentials(access_key="my-aws-access-key", secret_key="my-aws-secret-key")

--- a/core/eolearn/tests/test_utils/test_fs.py
+++ b/core/eolearn/tests/test_utils/test_fs.py
@@ -8,19 +8,24 @@ file in the root directory of this source tree.
 """
 import os
 import unittest.mock as mock
+from _thread import RLock
 from pathlib import Path
+from typing import List
 
 import pytest
 from botocore.credentials import Credentials
+from fs.base import FS
 from fs.errors import CreateFailed
+from fs.memoryfs import MemoryFS
 from fs.osfs import OSFS
+from fs.tempfs import TempFS
 from fs_s3fs import S3FS
 from moto import mock_s3
 
 from sentinelhub import SHConfig
 
 from eolearn.core import get_filesystem, load_s3_filesystem
-from eolearn.core.utils.fs import get_aws_credentials, get_full_path, join_path
+from eolearn.core.utils.fs import get_aws_credentials, get_full_path, join_path, pickle_fs, unpickle_fs
 
 
 def test_get_local_filesystem(tmp_path):
@@ -94,6 +99,29 @@ def test_get_aws_credentials(mocked_copy):
     config = get_aws_credentials("default", config=default_config)
     assert config.aws_access_key_id != default_config.aws_access_key_id
     assert config.aws_secret_access_key != default_config.aws_secret_access_key
+
+
+@pytest.mark.parametrize(
+    "filesystem, compare_params",
+    [
+        (OSFS("."), ["root_path"]),
+        (TempFS(identifier="test"), ["identifier", "_temp_dir", "_auto_clean"]),
+        (MemoryFS(), []),
+        (
+            S3FS("s3://fake-bucket/", strict=False, acl="public-read"),
+            ["_bucket_name", "dir_path", "strict", "upload_args"],
+        ),
+    ],
+)
+def test_filesystem_serialization(filesystem: FS, compare_params: List[str]):
+    pickled_filesystem = pickle_fs(filesystem)
+    assert isinstance(pickled_filesystem, bytes)
+
+    unpickled_filesystem = unpickle_fs(pickled_filesystem)
+    assert filesystem is not unpickled_filesystem
+    assert isinstance(unpickled_filesystem._lock, RLock)
+    for param in compare_params:
+        assert getattr(filesystem, param) == getattr(unpickled_filesystem, param)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The main use case for this is that we'll be able to first define a filesystem object with all parameters (e.g. credentials, ACL settings, ... ) and then pass it as an init parameter to IO tasks. This was solved by custom pickling and unpickling functions for filesystem objects.

Notes: 

- we still have to update IO tasks from `eolearn.io` subpackage. This will be done in next PRs.
- CI is still failing but only because of an unrelated `rasterio` issue.