### PR TITLE
Extra S3 filesystem pickling test

### DIFF
--- a/core/eolearn/tests/conftest.py
+++ b/core/eolearn/tests/conftest.py
@@ -2,17 +2,44 @@
 Module with global fixtures
 """
 import os
+from typing import Callable
 
+import boto3
 import pytest
+from fs_s3fs import S3FS
+from moto import mock_s3
 
 from eolearn.core import EOPatch
 
 
 @pytest.fixture(scope="session", name="test_eopatch_path")
-def test_eopatch_path_fixture():
+def test_eopatch_path_fixture() -> str:
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "..", "example_data", "TestEOPatch")
 
 
 @pytest.fixture(name="test_eopatch")
-def test_eopatch_fixture(test_eopatch_path):
+def test_eopatch_fixture(test_eopatch_path) -> EOPatch:
     return EOPatch.load(test_eopatch_path)
+
+
+@pytest.fixture(name="create_mocked_s3fs", scope="session")
+def s3_mocking_fixture() -> Callable[[str], S3FS]:
+    """Provides a function for mocking S3 buckets"""
+
+    @mock_s3
+    def create_mocked_s3fs(bucket_name: str = "mocked-test-bucket") -> S3FS:
+        """Creates a new empty mocked s3 bucket. If one such bucket already exists it deletes it first."""
+        s3resource = boto3.resource("s3", region_name="eu-central-1")
+
+        bucket = s3resource.Bucket(bucket_name)
+
+        if bucket.creation_date:  # If bucket already exists
+            for key in bucket.objects.all():
+                key.delete()
+            bucket.delete()
+
+        s3resource.create_bucket(Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": "eu-central-1"})
+
+        return S3FS(bucket_name=bucket_name)
+
+    return create_mocked_s3fs

--- a/core/eolearn/tests/test_eodata_io.py
+++ b/core/eolearn/tests/test_eodata_io.py
@@ -10,13 +10,11 @@ import datetime
 import os
 import tempfile
 
-import boto3
 import fs
 import numpy as np
 import pytest
 from fs.errors import CreateFailed, ResourceNotFound
 from fs.tempfs import TempFS
-from fs_s3fs import S3FS
 from geopandas import GeoDataFrame
 from moto import mock_s3
 
@@ -24,26 +22,7 @@ from sentinelhub import CRS, BBox
 
 from eolearn.core import EOPatch, FeatureType, LoadTask, OverwritePermission, SaveTask
 
-
-@mock_s3
-def _create_new_s3_fs():
-    """Creates a new empty mocked s3 bucket. If one such bucket already exists it deletes it first."""
-    bucket_name = "mocked-test-bucket"
-    s3resource = boto3.resource("s3", region_name="eu-central-1")
-
-    bucket = s3resource.Bucket(bucket_name)
-
-    if bucket.creation_date:  # If bucket already exists
-        for key in bucket.objects.all():
-            key.delete()
-        bucket.delete()
-
-    s3resource.create_bucket(Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": "eu-central-1"})
-
-    return S3FS(bucket_name=bucket_name)
-
-
-FS_LOADERS = [TempFS, _create_new_s3_fs]
+FS_LOADERS = [TempFS, pytest.lazy_fixture("create_mocked_s3fs")]
 
 
 @pytest.fixture(name="eopatch")

--- a/core/eolearn/tests/test_utils/test_fs.py
+++ b/core/eolearn/tests/test_utils/test_fs.py
@@ -13,7 +13,6 @@ from _thread import RLock
 from pathlib import Path
 from typing import List
 
-import boto3
 import pytest
 from botocore.credentials import Credentials
 from fs.base import FS
@@ -28,24 +27,6 @@ from sentinelhub import SHConfig
 
 from eolearn.core import get_filesystem, load_s3_filesystem
 from eolearn.core.utils.fs import get_aws_credentials, get_full_path, join_path, pickle_fs, unpickle_fs
-
-
-@mock_s3
-def _create_new_s3_fs() -> S3FS:
-    """Creates a new empty mocked s3 bucket. If one such bucket already exists it deletes it first."""
-    bucket_name = "mocked-test-bucket"
-    s3resource = boto3.resource("s3", region_name="eu-central-1")
-
-    bucket = s3resource.Bucket(bucket_name)
-
-    if bucket.creation_date:  # If bucket already exists
-        for key in bucket.objects.all():
-            key.delete()
-        bucket.delete()
-
-    s3resource.create_bucket(Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": "eu-central-1"})
-
-    return S3FS(bucket_name=bucket_name)
 
 
 def test_get_local_filesystem(tmp_path):
@@ -156,10 +137,10 @@ def test_tempfs_serialization():
 
 
 @mock_s3
-def test_s3fs_serialization():
+def test_s3fs_serialization(create_mocked_s3fs):
     """Makes sure that after serialization and deserialization filesystem object can still be used for reading,
     writing, and listing objects."""
-    filesystem = _create_new_s3_fs()
+    filesystem = create_mocked_s3fs()
     filename = "file.json"
     file_content = {"test": 42}
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,7 @@ pylint>=2.14.0
 pytest>=7.0.0
 pytest-cov
 pytest-mock
+pytest-lazy-fixture
 ray[default]
 responses
 twine


### PR DESCRIPTION
Changes:
- Added a test that makes sure `S3FS` is fully usable after being unpickled.
- Reduced code duplication by using a package `pytest-lazy-fixture`. If this works well I think we have a few more cases where such solution would be great.