### PR TITLE
separate FeatureIO into subclasses

### DIFF
--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -411,6 +411,7 @@ class FeatureIOjson(FeatureIO[_T]):
 
 class FeatureIObbox(FeatureIO[BBox]):
     """FeatureIO object specialized for BBox objects."""
+
     file_format = MimeType.GEOJSON
 
     def _read_from_file(self, file: Union[BinaryIO, gzip.GzipFile], _: str) -> BBox:

--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -326,7 +326,7 @@ class FeatureIONumpy(FeatureIO[np.ndarray]):
         return np.save(file, data)
 
 
-class FeatureIOgeodf(FeatureIO[gpd.GeoDataFrame]):
+class FeatureIOGeoDf(FeatureIO[gpd.GeoDataFrame]):
     """FeatureIO object specialized for GeoDataFrames."""
 
     file_format = MimeType.GPKG
@@ -437,5 +437,5 @@ def _create_feature_io(ftype: FeatureType, path: str, filesystem: FS) -> Feature
     if ftype in (FeatureType.TIMESTAMP, FeatureType.META_INFO):
         return FeatureIOJson(path, filesystem)
     if ftype in FeatureTypeSet.VECTOR_TYPES:
-        return FeatureIOgeodf(path, filesystem)
+        return FeatureIOGeoDf(path, filesystem)
     return FeatureIONumpy(path, filesystem)


### PR DESCRIPTION
FeatureIO seemed to be a 'swiss army knife' class, so I extracted the common behaviour into a generic class that is then specialized in subclasses. This also greatly improves type information. Sadly we currently cannot 100% guarantee type safety for JSON-like data (so timestamp and metainfo) and geodataframes (due to deprecated pickle functionality). I am considering further specializing json-like featureIO into specific ones for timestamps and metainfo, but it might cause some code duplication, since both are handled very similarly. Open to ideas. 