### PR TITLE
Typed feature dicts

### DIFF
--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -16,8 +16,9 @@ from __future__ import annotations
 import copy
 import datetime as dt
 import logging
+import sys
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Tuple, Type, TypeVar, Union, overload
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union, overload
 
 import attr
 import dateutil.parser
@@ -32,6 +33,11 @@ from .eodata_merge import merge_eopatches
 from .utils.common import deep_eq, is_discrete_type
 from .utils.fs import get_filesystem
 from .utils.parsing import parse_features
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Literal
+else:
+    from typing import Literal  # pylint: disable=ungrouped-imports
 
 _T = TypeVar("_T")
 _Self = TypeVar("_Self")

--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -94,6 +94,7 @@ class _FeatureDict(Dict[str, Union[_T, FeatureIO[_T]]], metaclass=ABCMeta):
         super().__setitem__(feature_name, value)
 
     def _check_feature_name(self, feature_name: str) -> None:
+        """Ensures that feature names are strings and do not contain forbidden characters."""
         if not isinstance(feature_name, str):
             raise ValueError(f"Feature name must be a string but an object of type {type(feature_name)} was given.")
 
@@ -184,7 +185,7 @@ class _FeatureDictGeoDf(_FeatureDict[gpd.GeoDataFrame]):
 
     def _parse_feature_value(self, value: object, feature_name: str) -> gpd.GeoDataFrame:
         if isinstance(value, gpd.GeoSeries):
-            value = gpd.GeoDataFrame(dict(geometry=value), crs=value.crs)
+            value = gpd.GeoDataFrame(geometry=value, crs=value.crs)
 
         if isinstance(value, gpd.GeoDataFrame):
             if self.feature_type is FeatureType.VECTOR and FeatureType.TIMESTAMP.value.upper() not in value:

--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -277,9 +277,7 @@ class EOPatch:
         :raises: TypeError, ValueError
         """
         if feature_type.has_dict() and isinstance(value, dict):
-            if not isinstance(value, _FeatureDict):
-                value = _create_feature_dict(feature_type, value)
-            return value
+            return value if isinstance(value, _FeatureDict) else _create_feature_dict(feature_type, value)
 
         if feature_type is FeatureType.BBOX:
             if value is None or isinstance(value, BBox):


### PR DESCRIPTION
Similar to `FeatureIO` the only proper way to bring some notion of types to `EOPatches` begins at making a generic `_FeatureDict` which is then properly sub-classed. Now `eopatch.data["name"]` is recognized as a numpy array. Can't do much about `eopatch[FeatureType.DATA, "name"]` without a massive amount of overloads.