### PR TITLE
fix: meteoblue y-axis orientation for MeteoblueRasterTask

### DIFF
--- a/io/eolearn/io/extra/meteoblue.py
+++ b/io/eolearn/io/extra/meteoblue.py
@@ -245,7 +245,11 @@ def meteoblue_to_numpy(result) -> np.ndarray:
         code_n_timesteps = code_data.size // n_locations // n_time_intervals
         code_data = code_data.reshape((n_time_intervals, geo_ny, geo_nx, code_n_timesteps))
 
-        return code_data.transpose((0, 3, 1, 2))
+        # transpose from shape (n_time_intervals, geo_ny, geo_nx, code_n_timesteps)
+        # to (n_time_intervals, code_n_timesteps, geo_ny, geo_nx)
+        # and flip the y-axis (meteoblue is using northward facing axis
+        # but the standard for EOPatch features is a southward facing axis)
+        return np.flip(code_data.transpose((0, 3, 1, 2)), axis=2)
 
     data = np.array(list(map(map_code, geometry.codes)))
 

--- a/io/eolearn/tests/test_extra/test_meteoblue.py
+++ b/io/eolearn/tests/test_extra/test_meteoblue.py
@@ -75,7 +75,7 @@ def test_meteoblue_raster_task(mocker):
 
     assert round(np.mean(data), 5) == 23.79214
     assert round(np.std(data), 5) == 0.3996
-    assert round(data[0, 0, 0, 0], 5) == 23.74646
+    assert round(data[0, -1, 0, 0], 5) == 23.74646
 
 
 def test_meteoblue_vector_task(mocker):


### PR DESCRIPTION
MeteoblueRasterTask was previously using northward facing y-axis in contrast to data coming from sentinelhub