### PR TITLE
Fix image in core example notebook

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ sphinx:
   configuration: docs/source/conf.py
 
 python:
-  version: 3.7
+  version: "3.7"
 
 build:
   os: "ubuntu-20.04"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,9 +3,6 @@ version: 2
 sphinx:
   configuration: docs/source/conf.py
 
-python:
-  version: "3.7"
-
 build:
   os: "ubuntu-20.04"
   tools:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,5 +6,10 @@ sphinx:
 python:
   version: 3.7
 
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "mambaforge-4.10"
+
 conda:
   environment: docs/environment.yml

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -243,9 +243,9 @@ def copy_documentation_examples(source_folder, target_folder):
             if line.startswith("examples/"):
                 files_to_include.append(line.split("/", 1)[1])
 
-    for notebook in files_to_include:
-        source_path = os.path.join(source_folder, notebook)
-        target_path = os.path.join(target_folder, notebook)
+    for file in files_to_include:
+        source_path = os.path.join(source_folder, file)
+        target_path = os.path.join(target_folder, file)
         os.makedirs(os.path.dirname(target_path), exist_ok=True)
         shutil.copyfile(source_path, target_path)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -232,7 +232,7 @@ MARKDOWNS_FOLDER = "./markdowns"
 
 def copy_documentation_examples(source_folder, target_folder):
     """Makes sure to copy only notebooks that are actually included in the documentation"""
-    notebooks_to_include = []
+    files_to_include = ["core/images/eopatch.png"]
 
     for rst_file in ["examples.rst", "index.rst"]:
         with open(rst_file, "r") as fp:
@@ -241,9 +241,9 @@ def copy_documentation_examples(source_folder, target_folder):
         for line in content.split("\n"):
             line = line.strip(" \t")
             if line.startswith("examples/"):
-                notebooks_to_include.append(line.split("/", 1)[1])
+                files_to_include.append(line.split("/", 1)[1])
 
-    for notebook in notebooks_to_include:
+    for notebook in files_to_include:
         source_path = os.path.join(source_folder, notebook)
         target_path = os.path.join(target_folder, notebook)
         os.makedirs(os.path.dirname(target_path), exist_ok=True)


### PR DESCRIPTION
The process now explicitly copies the image for the core overview notebook.

Read-the-docs started crashing due to conda being too slow (over 300 seconds to build the env :scream_cat: ) so as suggested by ReadTheDocs I switched over to using Mamba. This moves the python version of docbuilding from 3.7 to a special mamba 3.10, but it now takes 200s to build the env and the docs seem the same.