### PR TITLE
Feat/s3fs strict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ features/.pytest_cache
 
 # execution reports
 **execution-report**
+
+# MacOS cache
+.DS_Store

--- a/core/eolearn/tests/test_utils/test_fs.py
+++ b/core/eolearn/tests/test_utils/test_fs.py
@@ -57,7 +57,7 @@ def test_s3_filesystem(aws_session_token):
     filesystem = get_filesystem(s3_url)
     assert isinstance(filesystem, S3FS)
     assert filesystem.dir_path == folder_name
-    assert not filesystem.strict, "By default, resulting S3FS is not strict."
+    assert not filesystem.strict, "Other use-cases assume that the returned S3FS is non-strict by default."
 
     custom_config = SHConfig()
     custom_config.aws_access_key_id = "fake-key"

--- a/core/eolearn/tests/test_utils/test_fs.py
+++ b/core/eolearn/tests/test_utils/test_fs.py
@@ -57,6 +57,7 @@ def test_s3_filesystem(aws_session_token):
     filesystem = get_filesystem(s3_url)
     assert isinstance(filesystem, S3FS)
     assert filesystem.dir_path == folder_name
+    assert not filesystem.strict, "By default, resulting S3FS is not strict."
 
     custom_config = SHConfig()
     custom_config.aws_access_key_id = "fake-key"


### PR DESCRIPTION
As we are having some issues in eo-grow when dealing with S3FS, this PR ensures that the S3FS created in eo-learn is not `strict`.

Additionally, updated .gitignore with ".DS_Store". 