### PR TITLE
Make default ploting in EOPatch be without interpolation

### DIFF
--- a/visualization/eolearn/visualization/eopatch.py
+++ b/visualization/eolearn/visualization/eopatch.py
@@ -69,7 +69,7 @@ class PlotConfig(BasePlotConfig):
 
     subplot_width: Union[float, int] = 8
     subplot_height: Union[float, int] = 8
-    interpolation: str = 'none'
+    interpolation: str = "none"
     subplot_kwargs: Dict[str, object] = field(default_factory=dict)
     show_title: bool = True
     title_kwargs: Dict[str, object] = field(default_factory=dict)

--- a/visualization/eolearn/visualization/eopatch.py
+++ b/visualization/eolearn/visualization/eopatch.py
@@ -69,6 +69,7 @@ class PlotConfig(BasePlotConfig):
 
     subplot_width: Union[float, int] = 8
     subplot_height: Union[float, int] = 8
+    interpolation: str = 'none'
     subplot_kwargs: Dict[str, object] = field(default_factory=dict)
     show_title: bool = True
     title_kwargs: Dict[str, object] = field(default_factory=dict)
@@ -149,7 +150,7 @@ class MatplotlibVisualization(BaseEOPatchVisualization):
         label_kwargs = self._get_label_kwargs()
         for (row_idx, column_idx), axis in zip(it.product(range(rows), range(columns)), axes.flatten()):
             raster_slice = raster[row_idx, ...] if self.rgb else raster[row_idx, ..., column_idx]
-            axis.imshow(raster_slice)
+            axis.imshow(raster_slice, interpolation=self.config.interpolation)
 
             if timestamps and column_idx == 0:
                 axis.set_ylabel(timestamps[row_idx].isoformat(), **label_kwargs)


### PR DESCRIPTION
No test (it is hard to make test for this) we make manual test using notebook:
![Screenshot from 2022-09-07 14-27-28](https://user-images.githubusercontent.com/112631680/188886004-bbbc3bbe-4aea-4b78-974f-956d7ce0f830.png)
