### PR TITLE
Feat/no data value

### DIFF
--- a/io/eolearn/io/raster_io.py
+++ b/io/eolearn/io/raster_io.py
@@ -50,7 +50,7 @@ class BaseRasterIoTask(IOTask, metaclass=ABCMeta):
         *,
         filesystem: Optional[FS] = None,
         image_dtype: Optional[Union[np.dtype, type]] = None,
-        no_data_value: Optional[float] = 0,
+        no_data_value: Optional[float] = None,
         create: bool = False,
         config: Optional[SHConfig] = None,
     ):
@@ -62,8 +62,8 @@ class BaseRasterIoTask(IOTask, metaclass=ABCMeta):
         :param filesystem: An existing filesystem object. If not given it will be initialized according to `folder`
             parameter.
         :param image_dtype: A data type of data in exported images or data imported from images.
-        :param no_data_value: When exporting this is the value of pixels to be masked as undefined in exported images.
-            When importing this is values is assigned to the parts of arrays that don't exist in images.
+        :param no_data_value: When exporting this is the NoData value of pixels in exported images.
+            When importing this value is assigned to the pixels with NoData.
         :param create: If the filesystem path doesn't exist this flag indicates to either create it or raise an error.
         :param config: A configuration object with AWS credentials. By default, is set to None and in this case the
             default configuration will be taken.

--- a/io/eolearn/tests/test_raster_io.py
+++ b/io/eolearn/tests/test_raster_io.py
@@ -386,10 +386,10 @@ def test_export_import_sequence(no_data_value, data_type):
             # when reading, move axis to have the tif_array in the EOPatch.data_timeless dimension structure
             tif_array = np.moveaxis(src.read(masked=True), 0, -1)
 
-            if no_data_value is not np.nan:
-                no_data_arr = np_arr == no_data_value
-            else:
+            if no_data_value is np.nan:
                 no_data_arr = np.isnan(np_arr)
+            else:
+                no_data_arr = np_arr == no_data_value
 
             assert_array_equal(tif_array.mask, no_data_arr)
 


### PR DESCRIPTION
Default value of the parameter `no_data_value`  was set to `None`. In `ExportToTiffTask` this is the NoData value of pixels in exported images. In `ImportFromTiffTask` this value is assigned to the pixels with NoData.

Added test for different `no_data_values`  input to both `ExportToTiffTask` and `ImportFromTiffTask` .
