### PR TITLE
Feat/types

### DIFF
--- a/core/eolearn/core/eotask.py
+++ b/core/eolearn/core/eotask.py
@@ -18,10 +18,11 @@ import inspect
 import logging
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
-from typing import Dict, Iterable, Optional
+from typing import Dict, Iterable, Union
 
 from .constants import FeatureType
 from .utils.parsing import FeatureParser, parse_feature, parse_features, parse_renamed_feature, parse_renamed_features
+from .utils.types import EllipsisType
 
 LOGGER = logging.getLogger(__name__)
 
@@ -67,7 +68,9 @@ class EOTask(metaclass=ABCMeta):
         """Override to specify action performed by task."""
 
     @staticmethod
-    def get_feature_parser(features, allowed_feature_types: Optional[Iterable[FeatureType]] = None) -> FeatureParser:
+    def get_feature_parser(
+        features, allowed_feature_types: Union[Iterable[FeatureType], EllipsisType] = ...
+    ) -> FeatureParser:
         """See :class:`FeatureParser<eolearn.core.utilities.FeatureParser>`."""
         return FeatureParser(features, allowed_feature_types=allowed_feature_types)
 

--- a/core/eolearn/core/utils/parsing.py
+++ b/core/eolearn/core/utils/parsing.py
@@ -172,9 +172,7 @@ class FeatureParser:
 
     def _parse_sequence(
         self,
-        features: Union[
-            Tuple[FeatureType, str], Tuple[FeatureType, str, str], Tuple[FeatureType, EllipsisType], SequenceFeatureSpec
-        ],
+        features: Union[SingleFeatureSpec, SequenceFeatureSpec],
     ) -> List[_ParserFeaturesSpec]:
         """Implements parsing and validation in case the input is a tuple describing a single feature or a sequence."""
 

--- a/core/eolearn/core/utils/parsing.py
+++ b/core/eolearn/core/utils/parsing.py
@@ -94,7 +94,7 @@ class FeatureParser:
     def __init__(
         self,
         features: Union[SingleFeatureSpec, MultiFeatureSpec],
-        allowed_feature_types: Optional[Iterable[FeatureType]] = None,
+        allowed_feature_types: Union[Iterable[FeatureType], EllipsisType] = ...,
     ):
         """
         :param features: A collection of features in one of the supported formats
@@ -102,7 +102,9 @@ class FeatureParser:
             an error is raised
         :raises: ValueError
         """
-        self.allowed_feature_types = set(FeatureType) if allowed_feature_types is None else set(allowed_feature_types)
+        self.allowed_feature_types = (
+            set(allowed_feature_types) if isinstance(allowed_feature_types, Iterable) else set(FeatureType)
+        )
         self._feature_specs = self._parse_features(features)
 
     def _parse_features(
@@ -325,7 +327,9 @@ class FeatureParser:
 
 
 def parse_feature(
-    feature, eopatch: Optional[EOPatch] = None, allowed_feature_types: Optional[Iterable[FeatureType]] = None
+    feature: SingleFeatureSpec,
+    eopatch: Optional[EOPatch] = None,
+    allowed_feature_types: Union[Iterable[FeatureType], EllipsisType] = ...,
 ) -> Tuple[FeatureType, Optional[str]]:
     """Parses input describing a single feature into a `(feature_type, feature_name)` pair.
 
@@ -339,7 +343,9 @@ def parse_feature(
 
 
 def parse_renamed_feature(
-    feature, eopatch: Optional[EOPatch] = None, allowed_feature_types: Optional[Iterable[FeatureType]] = None
+    feature: SingleFeatureSpec,
+    eopatch: Optional[EOPatch] = None,
+    allowed_feature_types: Union[Iterable[FeatureType], EllipsisType] = ...,
 ) -> Union[Tuple[FeatureType, str, str], Tuple[FeatureType, None, None]]:
     """Parses input describing a single feature into a `(feature_type, old_name, new_name)` triple.
 
@@ -353,7 +359,9 @@ def parse_renamed_feature(
 
 
 def parse_features(
-    features, eopatch: Optional[EOPatch] = None, allowed_feature_types: Optional[Iterable[FeatureType]] = None
+    features: Union[SingleFeatureSpec, MultiFeatureSpec],
+    eopatch: Optional[EOPatch] = None,
+    allowed_feature_types: Union[Iterable[FeatureType], EllipsisType] = ...,
 ) -> List[Tuple[FeatureType, Optional[str]]]:
     """Parses input describing features into a list of `(feature_type, feature_name)` pairs.
 
@@ -363,7 +371,9 @@ def parse_features(
 
 
 def parse_renamed_features(
-    features, eopatch: Optional[EOPatch] = None, allowed_feature_types: Optional[Iterable[FeatureType]] = None
+    features: Union[SingleFeatureSpec, MultiFeatureSpec],
+    eopatch: Optional[EOPatch] = None,
+    allowed_feature_types: Union[Iterable[FeatureType], EllipsisType] = ...,
 ) -> List[Union[Tuple[FeatureType, str, str], Tuple[FeatureType, None, None]]]:
     """Parses input describing features into a list of `(feature_type, old_name, new_name)` triples.
 

--- a/core/eolearn/core/utils/parsing.py
+++ b/core/eolearn/core/utils/parsing.py
@@ -288,13 +288,14 @@ class FeatureParser:
 
         If `eopatch` is not provided the method fails if an all-feature request is in the specification.
         """
-        feature_names = []
-        for feature_type, name, _ in self._feature_specs:
-            self._validate_parsing_request(feature_type, name, eopatch)
-            if name is None and feature_type.has_dict():
-                feature_names.extend(list(zip(repeat(feature_type), eopatch[feature_type])))  # type: ignore
+        feature_names: List[Tuple[FeatureType, Optional[str]]] = []
+        for ftype, name, _ in self._feature_specs:
+            self._validate_parsing_request(ftype, name, eopatch)
+            if name is None and ftype.has_dict():
+                # _validate_parsing_request should ensure that eopatch is not None
+                feature_names.extend((ftype, name) for name in eopatch[ftype])  # type: ignore[index]
             else:
-                feature_names.append((feature_type, name))
+                feature_names.append((ftype, name))
         return feature_names
 
     def get_renamed_features(
@@ -311,15 +312,15 @@ class FeatureParser:
 
         If `eopatch` is not provided the method fails if an all-feature request is in the specification.
         """
-        feature_names = []
-        for feature_type, old_name, new_name in self._feature_specs:
-            self._validate_parsing_request(feature_type, old_name, eopatch)
-            if old_name is None and feature_type.has_dict():
-                feature_names.extend(
-                    list(zip(repeat(feature_type), eopatch[feature_type], eopatch[feature_type]))  # type: ignore
-                )
+        feature_names: List[Union[Tuple[FeatureType, str, str], Tuple[FeatureType, None, None]]] = []
+        for feature_spec in self._feature_specs:
+            ftype, old_name, _ = feature_spec
+            self._validate_parsing_request(ftype, old_name, eopatch)
+            if old_name is None and ftype.has_dict():
+                # _validate_parsing_request should ensure that eopatch is not None
+                feature_names.extend((ftype, name, name) for name in eopatch[ftype])  # type: ignore[index]
             else:
-                feature_names.append((feature_type, old_name, new_name))
+                feature_names.append(feature_spec)
         return feature_names
 
 

--- a/core/eolearn/core/utils/parsing.py
+++ b/core/eolearn/core/utils/parsing.py
@@ -13,14 +13,21 @@ file in the root directory of this source tree.
 """
 from __future__ import annotations
 
+import sys
 from itertools import repeat
-from typing import TYPE_CHECKING, Dict, Iterable, List, Literal, Optional, Sequence, Tuple, Union, cast
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Sequence, Tuple, Union, cast
 
 from ..constants import FeatureType
 from .types import EllipsisType
 
+if sys.version_info < (3, 8):
+    from typing_extensions import Literal
+else:
+    from typing import Literal  # pylint: disable=ungrouped-imports
+
 if TYPE_CHECKING:
     from ..eodata import EOPatch
+
 
 SingleFeatureSpec = Union[
     Literal[FeatureType.TIMESTAMP, FeatureType.BBOX], Tuple[FeatureType, str], Tuple[FeatureType, str, str]

--- a/core/eolearn/core/utils/types.py
+++ b/core/eolearn/core/utils/types.py
@@ -1,0 +1,20 @@
+"""
+Types and type aliases used throughout the code.
+
+Credits:
+Copyright (c) 2022 Žiga Lukšič (Sinergise)
+
+This source code is licensed under the MIT license found in the LICENSE
+file in the root directory of this source tree.
+"""
+# pylint: disable=unused-import
+import sys
+
+if sys.version_info >= (3, 10):
+    from types import EllipsisType  # pylint: disable=ungrouped-imports
+else:
+    import builtins  # noqa: F401
+
+    from typing_extensions import TypeAlias
+
+    EllipsisType: TypeAlias = "builtins.ellipsis"


### PR DESCRIPTION
This adds types to the feature parsers (without changing their functionality)

1. Adds a `eolearn.core.utils.types` module which has the `EllipsisType` handled for pre-3.10 versions
2. Adds type annotations to parsers (any suggestions on how to organize the huge types would be welcome)
3. Change defaults in `allowed_feature_types` to be more in-line with the philosophy of using `...`. The change was made in a way that it should be non-codebreaking (so passing in a None would count as `...`).

I am also not entirely satisfied by names.