### PR TITLE
Avoid inconsistency in paths of FeatureIO

### DIFF
--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -210,7 +210,7 @@ class _FeatureDictJson(_FeatureDict[Any]):
 
 
 def _create_feature_dict(feature_type: FeatureType, value: Dict[str, Any]) -> _FeatureDict:
-    """Creates the correct FeatureIO, corresponding to the FeatureType."""
+    """Creates the correct FeatureDict, corresponding to the FeatureType."""
     if feature_type.is_vector():
         return _FeatureDictGeoDf(value, feature_type)
     if feature_type is FeatureType.META_INFO:


### PR DESCRIPTION
When designing the tests it came up that `FeatureIO` cannot load it's own saved file, due to the inconsistencies with paths.

On saving the object assumed paths returned by `walk_eopatch` which are just a file-system-structured paths of features (e.g. `"eopatch/data/NDVI"`) and lack any extensions.

On loading the object assumed filesystem paths (e.g. `"eopatch/data/NDVI.npy.gz"`).

Turns out it is not that simple to unify the two. What I did is:
- paths are always assumed to be filesystem paths with full extensions
- they are checked for compliance with feature type extension and compression level
- if the compression level is not specified, it is inferred from path (so 0 if no `.gz` ending and 1 otherwise), which is needed for loading, since we have no clue how the feature was saved other than inspecting the path
- for working with 'eopatch paths' a new constructor was added that automatically adds extensions to produce a proper filesystem path