### PR TITLE
Allow loading numpy arrays containing objects

### DIFF
--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -332,7 +332,7 @@ class FeatureIONumpy(FeatureIO[np.ndarray]):
         return MimeType.NPY
 
     def _read_from_file(self, file: Union[BinaryIO, gzip.GzipFile]) -> np.ndarray:
-        return np.load(file)
+        return np.load(file, allow_pickle=True)
 
     @classmethod
     def _write_to_file(cls, data: np.ndarray, file: Union[BinaryIO, gzip.GzipFile], _: str) -> None:

--- a/core/eolearn/tests/test_eodata_io.py
+++ b/core/eolearn/tests/test_eodata_io.py
@@ -298,8 +298,9 @@ def assert_data_equal(data1: Any, data2: Any) -> None:
     [
         (FeatureIONumpy, np.zeros(20)),
         (FeatureIONumpy, np.zeros((2, 3, 3, 2), dtype=np.int16)),
+        (FeatureIONumpy, np.full((4, 5), fill_value=CRS.POP_WEB)),
         (FeatureIOBBox, BBox((1, 2, 3, 4), CRS.WGS84)),
-        (FeatureIOGeoDf, gpd.GeoDataFrame({"col1": ["name1"], "geometry": [Point(1, 2)]}, crs="EPSG:4326")),
+        (FeatureIOGeoDf, gpd.GeoDataFrame({"col1": ["name1"], "geometry": [Point(1, 2)]}, crs="EPSG:3857")),
         (FeatureIOGeoDf, gpd.GeoDataFrame({"col1": ["name1"], "geometry": [Point(1, 2)]}, crs="EPSG:32733")),
         (
             FeatureIOGeoDf,
@@ -309,7 +310,7 @@ def assert_data_equal(data1: Any, data2: Any) -> None:
                     "TIMESTAMP": [datetime.datetime(2017, 1, 1, 10, 4, 7), datetime.datetime(2017, 1, 4, 10, 14, 5)],
                     "geometry": [Point(1, 2), Point(2, 1)],
                 },
-                crs="EPSG:4326",
+                crs="EPSG:3857",
             ),
         ),
         (FeatureIOJson, {"test": "test1", "test3": {"test": "test1"}}),


### PR DESCRIPTION
In some rare cases users want to save and load arrays populated with objects, which are serialized with pickle. Numpy does not allow loading of such data by default since pickled objects are a security issue. This MR removes this restriction.