### PR TITLE
Add types to EOPatch

### DIFF
--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -313,6 +313,22 @@ class EOPatch:
 
         return value
 
+    @overload
+    def __getitem__(
+        self, feature_type: Union[Literal[FeatureType.BBOX], Tuple[Literal[FeatureType.BBOX], Any]]
+    ) -> BBox:
+        ...
+
+    @overload
+    def __getitem__(
+        self, feature_type: Union[Literal[FeatureType.TIMESTAMP], Tuple[Literal[FeatureType.TIMESTAMP], Any]]
+    ) -> List[dt.datetime]:
+        ...
+
+    @overload
+    def __getitem__(self, feature_type: Union[FeatureType, Tuple[FeatureType, Union[str, None, EllipsisType]]]) -> Any:
+        ...
+
     def __getitem__(self, feature_type: Union[FeatureType, Tuple[FeatureType, Union[str, None, EllipsisType]]]) -> Any:
         """Provides features of requested feature type. It can also accept a tuple of (feature_type, feature_name).
 


### PR DESCRIPTION
Adds annotations to all EOPatch methods. Accessing via keys is still not as strong as one would've hoped, but even so it can do certain checks such as:
```python
test_eopatch = EOPatch()

_ = test_eopatch["something"]  # marked as wrong access
_ = test_eopatch[(FeatureType.DATA, 3)]  # marked as wrong access
_ = test_eopatch[(FeatureType.BBOX, ...)]  # works

test_eopatch["something"] = 1  # marked as wrong access
test_eopatch[(FeatureType.DATA, 3)] = None  # marked as wrong access
test_eopatch[(FeatureType.DATA, "something")] = None  # marked as correct, doesn't know the appropriate types

bbox = test_eopatch[FeatureType.BBOX]  # type is BBox
timestamp = test_eopatch[(FeatureType.TIMESTAMP, None)]  # type is List[dt.datetime]
data1 = test_eopatch[FeatureType.DATA]  # type is Any :(
data2 = test_eopatch[(FeatureType.DATA, "bands")]  # type is Any :(
```

Due to overloads the error messages are sometimes not as helpful as one would've liked it, but it's absolutely a step in the right direction.

@AleksMat I told you I'll do it :P