### PR TITLE
Feat/use sh testing utils

### DIFF
--- a/features/eolearn/tests/conftest.py
+++ b/features/eolearn/tests/conftest.py
@@ -8,6 +8,8 @@ import pytest
 
 from eolearn.core import EOPatch
 
+pytest.register_assert_rewrite("sentinelhub.testing_utils")  # makes asserts in helper functions work with pytest
+
 EXAMPLE_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "..", "example_data")
 EXAMPLE_EOPATCH_PATH = os.path.join(EXAMPLE_DATA_PATH, "TestEOPatch")
 

--- a/features/eolearn/tests/test_blob.py
+++ b/features/eolearn/tests/test_blob.py
@@ -12,7 +12,6 @@ import copy
 import sys
 
 import pytest
-from numpy.testing import assert_array_equal
 from pytest import approx
 from skimage.feature import blob_dog
 
@@ -55,11 +54,7 @@ def test_blob_task(small_ndvi_eopatch, task, expected_statistics):
     eopatch = copy.deepcopy(small_ndvi_eopatch)
     task.execute(eopatch)
 
-    # Test that no other features were modified
-    for feature_name in small_ndvi_eopatch.data:
-        feature = FeatureType.DATA, feature_name
-        assert_array_equal(
-            small_ndvi_eopatch[feature], eopatch[feature], err_msg=f"EOPatch data feature '{feature}' has changed"
-        )
-
     test_numpy_data(eopatch[BLOB_FEATURE], exp_shape=(10, 20, 20, 1), **expected_statistics, delta=1e-4)
+
+    del eopatch[BLOB_FEATURE]
+    assert small_ndvi_eopatch == eopatch, "Other features of the EOPatch were affected."

--- a/features/eolearn/tests/test_blob.py
+++ b/features/eolearn/tests/test_blob.py
@@ -11,51 +11,55 @@ file in the root directory of this source tree.
 import copy
 import sys
 
-import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
 from pytest import approx
 from skimage.feature import blob_dog
 
+from sentinelhub.testing_utils import test_numpy_data
+
 from eolearn.core import FeatureType
-from eolearn.core.eodata_io import FeatureIO
 from eolearn.features import BlobTask, DoGBlobTask, DoHBlobTask, LoGBlobTask
 
 FEATURE = (FeatureType.DATA, "NDVI", "blob")
+BLOB_FEATURE = (FeatureType.DATA, "blob")
 
 
-def test_blob_feature(small_ndvi_eopatch):
+def test_dog_blob_task(small_ndvi_eopatch):
     eopatch = small_ndvi_eopatch
     BlobTask(FEATURE, blob_dog, sigma_ratio=1.6, min_sigma=1, max_sigma=30, overlap=0.5, threshold=0)(eopatch)
     DoGBlobTask((FeatureType.DATA, "NDVI", "blob_dog"), threshold=0)(eopatch)
-    assert eopatch.data["blob"] == approx(
-        eopatch.data["blob_dog"]
-    ), "DoG derived class result not equal to base class result"
+    assert eopatch[BLOB_FEATURE] == approx(eopatch.data["blob_dog"])
 
 
 BLOB_TESTS = [
-    [DoGBlobTask(FEATURE, threshold=0), 0.0, 37.9625, 0.0854, 0.0],
+    (DoGBlobTask(FEATURE, threshold=0), {"exp_min": 0.0, "exp_max": 37.9625, "exp_mean": 0.08545, "exp_median": 0.0}),
 ]
 if sys.version_info >= (3, 8):  # For Python 3.7 scikit-image returns less accurate result for this test
-    BLOB_TESTS.append([DoHBlobTask(FEATURE, num_sigma=5, threshold=0), 0.0, 21.9203, 0.05807, 0.0])
-    BLOB_TESTS.append([LoGBlobTask(FEATURE, log_scale=True, threshold=0), 0, 42.4264, 0.0977, 0.0])
+    BLOB_TESTS.extend(
+        [
+            (
+                DoHBlobTask(FEATURE, num_sigma=5, threshold=0),
+                {"exp_min": 0.0, "exp_max": 21.9203, "exp_mean": 0.05807, "exp_median": 0.0},
+            ),
+            (
+                LoGBlobTask(FEATURE, log_scale=True, threshold=0),
+                {"exp_min": 0, "exp_max": 42.4264, "exp_mean": 0.09767, "exp_median": 0.0},
+            ),
+        ]
+    )
 
 
-@pytest.mark.parametrize("task, expected_min, expected_max, expected_mean, expected_median", BLOB_TESTS)
-def test_blob(small_ndvi_eopatch, task, expected_min, expected_max, expected_mean, expected_median):
+@pytest.mark.parametrize("task, expected_statistics", BLOB_TESTS)
+def test_blob_task(small_ndvi_eopatch, task, expected_statistics):
     eopatch = copy.deepcopy(small_ndvi_eopatch)
     task.execute(eopatch)
 
     # Test that no other features were modified
-    for feature, value in small_ndvi_eopatch.data.items():
-        if isinstance(value, FeatureIO):
-            value = value.load()
-        assert_array_equal(value, eopatch.data[feature], err_msg=f"EOPatch data feature '{feature}' has changed")
+    for feature_name in small_ndvi_eopatch.data:
+        feature = FeatureType.DATA, feature_name
+        assert_array_equal(
+            small_ndvi_eopatch[feature], eopatch[feature], err_msg=f"EOPatch data feature '{feature}' has changed"
+        )
 
-    delta = 1e-4
-
-    blob = eopatch.data[FEATURE[-1]]
-    assert np.min(blob) == approx(expected_min, abs=delta)
-    assert np.max(blob) == approx(expected_max, abs=delta)
-    assert np.mean(blob) == approx(expected_mean, abs=delta)
-    assert np.median(blob) == approx(expected_median, abs=delta)
+    test_numpy_data(eopatch[BLOB_FEATURE], exp_shape=(10, 20, 20, 1), **expected_statistics, delta=1e-4)

--- a/features/eolearn/tests/test_interpolation.py
+++ b/features/eolearn/tests/test_interpolation.py
@@ -11,11 +11,12 @@ file in the root directory of this source tree.
 """
 import dataclasses
 from datetime import datetime
-from typing import Optional
+from typing import Dict, Optional
 
 import numpy as np
 import pytest
-from pytest import approx
+
+from sentinelhub.testing_utils import test_numpy_data
 
 from eolearn.core import EOPatch, EOTask, FeatureType
 from eolearn.features import (
@@ -53,10 +54,7 @@ class InterpolationTestCase:
     name: str
     task: EOTask
     result_len: int
-    img_min: float
-    img_max: float
-    img_mean: float
-    img_median: float
+    expected_statistics: Dict[str, float]
     nan_replace: Optional[float] = None
 
     def execute(self, eopatch):
@@ -82,10 +80,7 @@ INTERPOLATION_TEST_CASES = [
             unknown_value=10,
         ),
         result_len=68,
-        img_min=0.0,
-        img_max=0.82836,
-        img_mean=0.51187,
-        img_median=0.57889,
+        expected_statistics=dict(exp_min=0.0, exp_max=0.82836, exp_mean=0.51187, exp_median=0.57889),
     ),
     InterpolationTestCase(
         "linear-p",
@@ -97,10 +92,7 @@ INTERPOLATION_TEST_CASES = [
             interpolate_pixel_wise=True,
         ),
         result_len=68,
-        img_min=0.0,
-        img_max=0.82836,
-        img_mean=0.51187,
-        img_median=0.57889,
+        expected_statistics=dict(exp_min=0.0, exp_max=0.82836, exp_mean=0.51187, exp_median=0.57889),
     ),
     InterpolationTestCase(
         "linear_change_timescale",
@@ -112,10 +104,7 @@ INTERPOLATION_TEST_CASES = [
             scale_time=1,
         ),
         result_len=68,
-        img_min=0.0,
-        img_max=0.82836,
-        img_mean=0.51187,
-        img_median=0.57889,
+        expected_statistics=dict(exp_min=0.0, exp_max=0.82836, exp_mean=0.51187, exp_median=0.57889),
     ),
     InterpolationTestCase(
         "cubic",
@@ -128,10 +117,7 @@ INTERPOLATION_TEST_CASES = [
             bounds_error=False,
         ),
         result_len=69,
-        img_min=0.0,
-        img_max=5.0,
-        img_mean=1.3532,
-        img_median=0.638732,
+        expected_statistics=dict(exp_min=0.0, exp_max=5.0, exp_mean=1.3532, exp_median=0.638732),
     ),
     InterpolationTestCase(
         "spline",
@@ -145,10 +131,7 @@ INTERPOLATION_TEST_CASES = [
             unknown_value=0,
         ),
         result_len=147,
-        img_min=-0.17814,
-        img_max=1.0,
-        img_mean=0.49738,
-        img_median=0.556853,
+        expected_statistics=dict(exp_min=-0.1781458, exp_max=1.0, exp_mean=0.49738, exp_median=0.556853),
     ),
     InterpolationTestCase(
         "bspline",
@@ -160,10 +143,7 @@ INTERPOLATION_TEST_CASES = [
             spline_degree=5,
         ),
         result_len=1,
-        img_min=-0.0163,
-        img_max=0.62323,
-        img_mean=0.319117,
-        img_median=0.32588,
+        expected_statistics=dict(exp_min=-0.0162962, exp_max=0.62323, exp_mean=0.319117, exp_median=0.3258836),
     ),
     InterpolationTestCase(
         "bspline-p",
@@ -176,10 +156,7 @@ INTERPOLATION_TEST_CASES = [
             interpolate_pixel_wise=True,
         ),
         result_len=1,
-        img_min=-0.0163,
-        img_max=0.62323,
-        img_mean=0.319117,
-        img_median=0.32588,
+        expected_statistics=dict(exp_min=-0.0162962, exp_max=0.62323, exp_mean=0.319117, exp_median=0.3258836),
     ),
     InterpolationTestCase(
         "akima",
@@ -187,10 +164,7 @@ INTERPOLATION_TEST_CASES = [
             (FeatureType.DATA, "NDVI"), unknown_value=0, mask_feature=(FeatureType.MASK, "IS_VALID")
         ),
         result_len=68,
-        img_min=-0.091035,
-        img_max=0.8283603,
-        img_mean=0.51427454,
-        img_median=0.59095883,
+        expected_statistics=dict(exp_min=-0.091035, exp_max=0.8283603, exp_mean=0.51427454, exp_median=0.59095883),
     ),
     InterpolationTestCase(
         "kriging interpolation",
@@ -198,10 +172,7 @@ INTERPOLATION_TEST_CASES = [
             (FeatureType.DATA, "NDVI"), result_interval=(-10, 10), resample_range=("2017-01-01", "2018-01-01", 10)
         ),
         result_len=37,
-        img_min=-0.18389,
-        img_max=0.5995388,
-        img_mean=0.35485545,
-        img_median=0.37279952,
+        expected_statistics=dict(exp_min=-0.183885, exp_max=0.5995388, exp_mean=0.35485545, exp_median=0.37279952),
     ),
     InterpolationTestCase(
         "nearest resample",
@@ -209,10 +180,7 @@ INTERPOLATION_TEST_CASES = [
             (FeatureType.DATA, "NDVI"), result_interval=(0.0, 1.0), resample_range=("2016-01-01", "2018-01-01", 5)
         ),
         result_len=147,
-        img_min=-0.2,
-        img_max=0.8283603,
-        img_mean=0.32318678,
-        img_median=0.2794411,
+        expected_statistics=dict(exp_min=-0.2, exp_max=0.8283603, exp_mean=0.32318678, exp_median=0.2794411),
         nan_replace=-0.2,
     ),
     InterpolationTestCase(
@@ -221,10 +189,7 @@ INTERPOLATION_TEST_CASES = [
             (FeatureType.DATA, "NDVI"), result_interval=(0.0, 1.0), resample_range=("2016-01-01", "2018-01-01", 5)
         ),
         result_len=147,
-        img_min=-0.2,
-        img_max=0.82643485,
-        img_mean=0.32218185,
-        img_median=0.29093677,
+        expected_statistics=dict(exp_min=-0.2, exp_max=0.82643485, exp_mean=0.32218185, exp_median=0.29093677),
         nan_replace=-0.2,
     ),
     InterpolationTestCase(
@@ -236,10 +201,7 @@ INTERPOLATION_TEST_CASES = [
             unknown_value=5,
         ),
         result_len=69,
-        img_min=-0.2,
-        img_max=5.0,
-        img_mean=1.209852,
-        img_median=0.40995836,
+        expected_statistics=dict(exp_min=-0.2, exp_max=5.0, exp_mean=1.209852, exp_median=0.40995836),
         nan_replace=-0.2,
     ),
     InterpolationTestCase(
@@ -252,10 +214,7 @@ INTERPOLATION_TEST_CASES = [
             resample_range=("2015-09-01", "2016-01-01", "2016-07-01", "2017-01-01", "2017-07-01"),
         ),
         result_len=5,
-        img_min=-0.0252167,
-        img_max=0.816656,
-        img_mean=0.49966,
-        img_median=0.533415,
+        expected_statistics=dict(exp_min=-0.0252167, exp_max=0.816656, exp_mean=0.49966, exp_median=0.533415),
     ),
     InterpolationTestCase(
         "linear with bands and multiple masks",
@@ -270,10 +229,7 @@ INTERPOLATION_TEST_CASES = [
             ],
         ),
         result_len=68,
-        img_min=0.0003,
-        img_max=10.0,
-        img_mean=0.132176,
-        img_median=0.086,
+        expected_statistics=dict(exp_min=0.0003, exp_max=10.0, exp_mean=0.132176, exp_median=0.086),
     ),
 ]
 
@@ -295,10 +251,7 @@ COPY_FEATURE_CASES = [
             ],
         ),
         result_len=69,
-        img_min=0.0,
-        img_max=5.0,
-        img_mean=1.3592644,
-        img_median=0.6174331,
+        expected_statistics=dict(exp_min=0.0, exp_max=5.0, exp_mean=1.3592644, exp_median=0.6174331),
     ),
     InterpolationTestCase(
         "cubic_copy_fail",
@@ -316,10 +269,7 @@ COPY_FEATURE_CASES = [
             ],
         ),
         result_len=69,
-        img_min=0.0,
-        img_max=5.0,
-        img_mean=1.3592644,
-        img_median=0.6174331,
+        expected_statistics=dict(exp_min=0.0, exp_max=5.0, exp_mean=1.3592644, exp_median=0.6174331),
     ),
 ]
 
@@ -335,14 +285,9 @@ def test_interpolation(test_case, test_patch):
     assert eopatch.data["NDVI"].shape == (test_case.result_len, 20, 20, 1)
 
     # Check results
-    delta = 1e-5  # Can't be higher accuracy because of Kriging interpolation
     feature_type, feature_name, _ = test_case.task.renamed_feature
     data = eopatch[feature_type, feature_name]
-
-    assert np.min(data) == approx(test_case.img_min, abs=delta)
-    assert np.max(data) == approx(test_case.img_max, abs=delta)
-    assert np.mean(data) == approx(test_case.img_mean, abs=delta)
-    assert np.median(data) == approx(test_case.img_median, abs=delta)
+    test_numpy_data(data, **test_case.expected_statistics, delta=1e-5)
 
 
 @pytest.mark.parametrize("test_case", COPY_FEATURE_CASES)
@@ -359,4 +304,4 @@ def test_copied_fields(test_case, test_patch):
             (FeatureType.MASK_TIMELESS, "LULC"),
         ]
         for feature in copied_features:
-            assert feature in eopatch.get_feature_list(), f"Expected feature `{feature}` is not present in EOPatch"
+            assert feature in eopatch, f"Expected feature `{feature}` is not present in EOPatch"

--- a/features/eolearn/tests/test_interpolation.py
+++ b/features/eolearn/tests/test_interpolation.py
@@ -275,8 +275,9 @@ COPY_FEATURE_CASES = [
 
 
 @pytest.mark.parametrize("test_case", INTERPOLATION_TEST_CASES)
-def test_interpolation(test_case, test_patch):
+def test_interpolation(test_case: InterpolationTestCase, test_patch):
     eopatch = test_case.execute(test_patch)
+    delta = 1e-4 if isinstance(test_case.task, KrigingInterpolationTask) else 1e-5
 
     # Check types and shapes
     assert isinstance(eopatch.timestamp, list), "Expected a list of timestamps"
@@ -287,7 +288,7 @@ def test_interpolation(test_case, test_patch):
     # Check results
     feature_type, feature_name, _ = test_case.task.renamed_feature
     data = eopatch[feature_type, feature_name]
-    test_numpy_data(data, **test_case.expected_statistics, delta=1e-5)
+    test_numpy_data(data, **test_case.expected_statistics, delta=delta)
 
 
 @pytest.mark.parametrize("test_case", COPY_FEATURE_CASES)


### PR DESCRIPTION
In many tests we used statistical comparisons, but we have a utility function for that in `sh-py`! And it works pretty well  if one enables pytest assert propagation to reach it (done in `conftest.py`).

I updated all the tests in `eolearn.features` to this format, and the tests become a fair bit shorter and much more readable (when you look at the test case you know which number is which statistic without having to memorize order etc.)

Some values had to be adjusted because the delta went from absolute to relative (current util implementation does not support absolute delta, will need to update)