### PR TITLE
Fix docs by settings python to 3.10

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,6 +4,8 @@ channels:
 dependencies:
 - rasterio
 - pip:
+  - python=3.8
+  - pip
   - Sphinx~=4.0
   - sphinx_rtd_theme>=1.0.0
   - nbsphinx

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
 - rasterio
 - pip:
-  - python=3.8
+  - python==3.10
   - pip
   - Sphinx~=4.0
   - sphinx_rtd_theme>=1.0.0

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,9 +3,9 @@ channels:
 - conda-forge
 dependencies:
 - rasterio
+- pip
+- python=3.10
 - pip:
-  - python==3.10
-  - pip
   - Sphinx~=4.0
   - sphinx_rtd_theme>=1.0.0
   - nbsphinx


### PR DESCRIPTION
Somewhere along the way either the default python version changed, or numba started complaining about 3.11
This sets our docsbuilding python to 3.10 to avoid issues