### PR TITLE
Move types to eolearn.core.types

### DIFF
--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -26,8 +26,8 @@ from sentinelhub import SHConfig
 from .constants import FeatureType
 from .eodata import EOPatch
 from .eotask import EOTask
+from .types import FeatureSpec, FeaturesSpecification
 from .utils.fs import get_filesystem, pickle_fs, unpickle_fs
-from .utils.parsing import FeatureSpec, FeaturesSpecification
 
 
 class CopyTask(EOTask):

--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -30,10 +30,10 @@ from sentinelhub import CRS, BBox
 from .constants import FeatureType, OverwritePermission
 from .eodata_io import FeatureIO, load_eopatch, save_eopatch
 from .eodata_merge import merge_eopatches
+from .types import EllipsisType, Literal
 from .utils.common import deep_eq, is_discrete_type
 from .utils.fs import get_filesystem
 from .utils.parsing import FeatureSpec, FeaturesSpecification, parse_features
-from .utils.types import EllipsisType, Literal
 
 _T = TypeVar("_T")
 _Self = TypeVar("_Self")

--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -30,10 +30,10 @@ from sentinelhub import CRS, BBox
 from .constants import FeatureType, OverwritePermission
 from .eodata_io import FeatureIO, load_eopatch, save_eopatch
 from .eodata_merge import merge_eopatches
-from .types import EllipsisType, Literal
+from .types import EllipsisType, FeatureSpec, FeaturesSpecification, Literal
 from .utils.common import deep_eq, is_discrete_type
 from .utils.fs import get_filesystem
-from .utils.parsing import FeatureSpec, FeaturesSpecification, parse_features
+from .utils.parsing import parse_features
 
 _T = TypeVar("_T")
 _Self = TypeVar("_Self")

--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -53,8 +53,8 @@ from sentinelhub import CRS, BBox, Geometry, MimeType
 from sentinelhub.exceptions import SHUserWarning
 
 from .constants import FeatureType, FeatureTypeSet, OverwritePermission
+from .types import EllipsisType
 from .utils.parsing import FeatureParser, FeaturesSpecification
-from .utils.types import EllipsisType
 from .utils.vector_io import infer_schema
 
 _T = TypeVar("_T")

--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -53,8 +53,8 @@ from sentinelhub import CRS, BBox, Geometry, MimeType
 from sentinelhub.exceptions import SHUserWarning
 
 from .constants import FeatureType, FeatureTypeSet, OverwritePermission
-from .types import EllipsisType
-from .utils.parsing import FeatureParser, FeaturesSpecification
+from .types import EllipsisType, FeaturesSpecification
+from .utils.parsing import FeatureParser
 from .utils.vector_io import infer_schema
 
 _T = TypeVar("_T")

--- a/core/eolearn/core/eodata_merge.py
+++ b/core/eolearn/core/eodata_merge.py
@@ -25,8 +25,8 @@ from sentinelhub import BBox
 
 from .constants import FeatureType
 from .exceptions import EORuntimeWarning
-from .types import Literal
-from .utils.parsing import FeatureParser, FeatureSpec, FeaturesSpecification
+from .types import FeatureSpec, FeaturesSpecification, Literal
+from .utils.parsing import FeatureParser
 
 if TYPE_CHECKING:
     from .eodata import EOPatch

--- a/core/eolearn/core/eodata_merge.py
+++ b/core/eolearn/core/eodata_merge.py
@@ -25,8 +25,8 @@ from sentinelhub import BBox
 
 from .constants import FeatureType
 from .exceptions import EORuntimeWarning
+from .types import Literal
 from .utils.parsing import FeatureParser, FeatureSpec, FeaturesSpecification
-from .utils.types import Literal
 
 if TYPE_CHECKING:
     from .eodata import EOPatch

--- a/core/eolearn/core/eotask.py
+++ b/core/eolearn/core/eotask.py
@@ -23,15 +23,8 @@ from dataclasses import dataclass
 from typing import Any, Dict, Iterable, Type, TypeVar, Union
 
 from .constants import FeatureType
-from .types import EllipsisType
-from .utils.parsing import (
-    FeatureParser,
-    FeaturesSpecification,
-    parse_feature,
-    parse_features,
-    parse_renamed_feature,
-    parse_renamed_features,
-)
+from .types import EllipsisType, FeaturesSpecification
+from .utils.parsing import FeatureParser, parse_feature, parse_features, parse_renamed_feature, parse_renamed_features
 
 LOGGER = logging.getLogger(__name__)
 

--- a/core/eolearn/core/eotask.py
+++ b/core/eolearn/core/eotask.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Iterable, Type, TypeVar, Union
 
 from .constants import FeatureType
+from .types import EllipsisType
 from .utils.parsing import (
     FeatureParser,
     FeaturesSpecification,
@@ -31,7 +32,6 @@ from .utils.parsing import (
     parse_renamed_feature,
     parse_renamed_features,
 )
-from .utils.types import EllipsisType
 
 LOGGER = logging.getLogger(__name__)
 

--- a/core/eolearn/core/eoworkflow_tasks.py
+++ b/core/eolearn/core/eoworkflow_tasks.py
@@ -13,8 +13,8 @@ from typing import Optional
 
 from .eodata import EOPatch
 from .eotask import EOTask
+from .types import FeaturesSpecification
 from .utils.common import generate_uid
-from .utils.parsing import FeaturesSpecification
 
 
 class InputTask(EOTask):

--- a/core/eolearn/core/types.py
+++ b/core/eolearn/core/types.py
@@ -1,0 +1,25 @@
+"""
+Types and type aliases used throughout the code.
+
+Credits:
+Copyright (c) 2022 Žiga Lukšič (Sinergise)
+
+This source code is licensed under the MIT license found in the LICENSE
+file in the root directory of this source tree.
+"""
+# pylint: disable=unused-import
+import sys
+
+if sys.version_info >= (3, 10):
+    from types import EllipsisType  # pylint: disable=ungrouped-imports
+else:
+    import builtins  # noqa: F401
+
+    from typing_extensions import TypeAlias
+
+    EllipsisType: TypeAlias = "builtins.ellipsis"
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Literal
+else:
+    from typing import Literal  # pylint: disable=ungrouped-imports # noqa: F401

--- a/core/eolearn/core/types.py
+++ b/core/eolearn/core/types.py
@@ -15,7 +15,8 @@ from typing import Dict, Iterable, Optional, Sequence, Tuple, Union
 from .constants import FeatureType
 
 if sys.version_info >= (3, 10):
-    from types import EllipsisType, TypeAlias  # pylint: disable=ungrouped-imports
+    from types import EllipsisType  # pylint: disable=ungrouped-imports
+    from typing import TypeAlias
 else:
     import builtins  # noqa: F401
 

--- a/core/eolearn/core/types.py
+++ b/core/eolearn/core/types.py
@@ -7,11 +7,15 @@ Copyright (c) 2022 Žiga Lukšič (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
-# pylint: disable=unused-import
 import sys
 
+# pylint: disable=unused-import
+from typing import Dict, Iterable, Optional, Sequence, Tuple, Union
+
+from .constants import FeatureType
+
 if sys.version_info >= (3, 10):
-    from types import EllipsisType  # pylint: disable=ungrouped-imports
+    from types import EllipsisType, TypeAlias  # pylint: disable=ungrouped-imports
 else:
     import builtins  # noqa: F401
 
@@ -23,3 +27,25 @@ if sys.version_info < (3, 8):
     from typing_extensions import Literal
 else:
     from typing import Literal  # pylint: disable=ungrouped-imports # noqa: F401
+
+
+# DEVELOPER NOTE: the #: comments are applied as docstrings
+
+#: Specification describing a single feature
+FeatureSpec: TypeAlias = Union[Tuple[Literal[FeatureType.BBOX, FeatureType.TIMESTAMP], None], Tuple[FeatureType, str]]
+#: Specification describing a feature with its current and desired new name
+FeatureRenameSpec: TypeAlias = Union[
+    Tuple[Literal[FeatureType.BBOX, FeatureType.TIMESTAMP], None, None], Tuple[FeatureType, str, str]
+]
+SingleFeatureSpec: TypeAlias = Union[FeatureSpec, FeatureRenameSpec]
+
+SequenceFeatureSpec: TypeAlias = Sequence[
+    Union[SingleFeatureSpec, FeatureType, Tuple[FeatureType, Optional[EllipsisType]]]
+]
+DictFeatureSpec: TypeAlias = Dict[FeatureType, Union[None, EllipsisType, Iterable[Union[str, Tuple[str, str]]]]]
+MultiFeatureSpec: TypeAlias = Union[
+    EllipsisType, FeatureType, Tuple[FeatureType, EllipsisType], SequenceFeatureSpec, DictFeatureSpec
+]
+
+#: Specification of a single or multiple features. See :class:`FeatureParser<eolearn.core.utilities.FeatureParser>`.
+FeaturesSpecification: TypeAlias = Union[SingleFeatureSpec, MultiFeatureSpec]

--- a/core/eolearn/core/utils/parsing.py
+++ b/core/eolearn/core/utils/parsing.py
@@ -14,40 +14,21 @@ file in the root directory of this source tree.
 from __future__ import annotations
 
 import contextlib
-import sys
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Sequence, Tuple, Union, cast
+from typing import TYPE_CHECKING, Iterable, List, Optional, Sequence, Tuple, Union, cast
 
 from ..constants import FeatureType
-from .types import EllipsisType, Literal
-
-if sys.version_info < (3, 10):
-    from typing_extensions import TypeAlias
-else:
-    from typing import TypeAlias  # pylint: disable=ungrouped-imports
+from .types import (
+    DictFeatureSpec,
+    EllipsisType,
+    FeatureRenameSpec,
+    FeatureSpec,
+    FeaturesSpecification,
+    SequenceFeatureSpec,
+    SingleFeatureSpec,
+)
 
 if TYPE_CHECKING:
     from ..eodata import EOPatch
-
-# DEVELOPER NOTE: the #: comments are applied as docstrings
-
-#: Specification describing a single feature
-FeatureSpec: TypeAlias = Union[Tuple[Literal[FeatureType.BBOX, FeatureType.TIMESTAMP], None], Tuple[FeatureType, str]]
-#: Specification describing a feature with its current and desired new name
-FeatureRenameSpec: TypeAlias = Union[
-    Tuple[Literal[FeatureType.BBOX, FeatureType.TIMESTAMP], None, None], Tuple[FeatureType, str, str]
-]
-SingleFeatureSpec: TypeAlias = Union[FeatureSpec, FeatureRenameSpec]
-
-SequenceFeatureSpec: TypeAlias = Sequence[
-    Union[SingleFeatureSpec, FeatureType, Tuple[FeatureType, Optional[EllipsisType]]]
-]
-DictFeatureSpec: TypeAlias = Dict[FeatureType, Union[None, EllipsisType, Iterable[Union[str, Tuple[str, str]]]]]
-MultiFeatureSpec: TypeAlias = Union[
-    EllipsisType, FeatureType, Tuple[FeatureType, EllipsisType], SequenceFeatureSpec, DictFeatureSpec
-]
-
-#: Specification of a single or multiple features. See :class:`FeatureParser<eolearn.core.utilities.FeatureParser>`.
-FeaturesSpecification: TypeAlias = Union[SingleFeatureSpec, MultiFeatureSpec]
 
 _ParserFeaturesSpec = Union[Tuple[FeatureType, None, None], Tuple[FeatureType, str, str]]
 

--- a/core/eolearn/core/utils/types.py
+++ b/core/eolearn/core/utils/types.py
@@ -1,25 +1,11 @@
-"""
-Types and type aliases used throughout the code.
+"""Deprecated module for types, moved to `eolearn.core.types`."""
+from warnings import warn
 
-Credits:
-Copyright (c) 2022 Žiga Lukšič (Sinergise)
+from ..exceptions import EODeprecationWarning
+from ..types import *  # noqa # pylint: disable=wildcard-import,unused-wildcard-import
 
-This source code is licensed under the MIT license found in the LICENSE
-file in the root directory of this source tree.
-"""
-# pylint: disable=unused-import
-import sys
-
-if sys.version_info >= (3, 10):
-    from types import EllipsisType  # pylint: disable=ungrouped-imports
-else:
-    import builtins  # noqa: F401
-
-    from typing_extensions import TypeAlias
-
-    EllipsisType: TypeAlias = "builtins.ellipsis"
-
-if sys.version_info < (3, 8):
-    from typing_extensions import Literal
-else:
-    from typing import Literal  # pylint: disable=ungrouped-imports # noqa: F401
+warn(
+    "The module `eolearn.core.utils.types` is deprecated, use `eolearn.core.types` instead.",
+    category=EODeprecationWarning,
+    stacklevel=2,
+)

--- a/core/eolearn/tests/test_utils/test_parsing.py
+++ b/core/eolearn/tests/test_utils/test_parsing.py
@@ -8,8 +8,8 @@ import pytest
 from sentinelhub import CRS, BBox
 
 from eolearn.core import EOPatch, FeatureParser, FeatureType
+from eolearn.core.types import EllipsisType
 from eolearn.core.utils.parsing import FeatureRenameSpec, FeatureSpec, FeaturesSpecification
-from eolearn.core.utils.types import EllipsisType
 
 
 @dataclass

--- a/core/eolearn/tests/test_utils/test_parsing.py
+++ b/core/eolearn/tests/test_utils/test_parsing.py
@@ -8,8 +8,7 @@ import pytest
 from sentinelhub import CRS, BBox
 
 from eolearn.core import EOPatch, FeatureParser, FeatureType
-from eolearn.core.types import EllipsisType
-from eolearn.core.utils.parsing import FeatureRenameSpec, FeatureSpec, FeaturesSpecification
+from eolearn.core.types import EllipsisType, FeatureRenameSpec, FeatureSpec, FeaturesSpecification
 
 
 @dataclass

--- a/core/eolearn/tests/test_utils/test_raster.py
+++ b/core/eolearn/tests/test_utils/test_raster.py
@@ -13,8 +13,8 @@ import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
 
+from eolearn.core.types import Literal
 from eolearn.core.utils.raster import constant_pad, fast_nanpercentile
-from eolearn.core.utils.types import Literal
 
 
 @pytest.mark.parametrize("size", [0, 5])

--- a/coregistration/eolearn/coregistration/coregistration.py
+++ b/coregistration/eolearn/coregistration/coregistration.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from eolearn.core import EOPatch, EOTask, FeatureType
 from eolearn.core.exceptions import EORuntimeWarning
-from eolearn.core.utils.parsing import FeaturesSpecification
+from eolearn.core.types import FeaturesSpecification
 
 LOGGER = logging.getLogger(__name__)
 

--- a/coregistration/eolearn/coregistration/coregistration.py
+++ b/coregistration/eolearn/coregistration/coregistration.py
@@ -10,6 +10,7 @@ Copyright (c) 2017-2019 Blaž Sovdat, Andrej Burja (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+from __future__ import annotations
 
 import logging
 import warnings

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,8 +73,8 @@ extensions = [
 # Include typehints in descriptions
 autodoc_typehints = "description"
 autodoc_type_aliases = {
-    "FeaturesSpecification": "eolearn.core.parsing.FeaturesSpecification",
-    "SingleFeatureSpec": "eolearn.core.parsing.SingleFeatureSpec",
+    "FeaturesSpecification": "eolearn.core.types.FeaturesSpecification",
+    "SingleFeatureSpec": "eolearn.core.types.SingleFeatureSpec",
 }
 
 # Both the class’ and the __init__ method’s docstring are concatenated and inserted.

--- a/features/eolearn/features/bands_extraction.py
+++ b/features/eolearn/features/bands_extraction.py
@@ -8,6 +8,7 @@ Copyright (c) 2017-2022 Žiga Lukšič, Devis Peressutti, Nejc Vesel, Jovan Viš
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+from __future__ import annotations
 
 from typing import List, Optional, Tuple
 

--- a/features/eolearn/features/bands_extraction.py
+++ b/features/eolearn/features/bands_extraction.py
@@ -14,7 +14,7 @@ from typing import List, Optional, Tuple
 import numpy as np
 
 from eolearn.core import MapFeatureTask
-from eolearn.core.utils.parsing import SingleFeatureSpec
+from eolearn.core.types import SingleFeatureSpec
 
 
 class EuclideanNormTask(MapFeatureTask):

--- a/features/eolearn/features/blob.py
+++ b/features/eolearn/features/blob.py
@@ -16,7 +16,7 @@ import numpy as np
 import skimage.feature
 
 from eolearn.core import EOPatch, EOTask
-from eolearn.core.utils.parsing import SingleFeatureSpec
+from eolearn.core.types import SingleFeatureSpec
 
 
 class BlobTask(EOTask):

--- a/features/eolearn/features/blob.py
+++ b/features/eolearn/features/blob.py
@@ -8,6 +8,7 @@ Copyright (c) 2017-2022 Matej Aleksandrov, Devis Peressutti, Žiga Lukšič (Sin
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+from __future__ import annotations
 
 from math import sqrt
 from typing import Any, Callable
@@ -109,7 +110,7 @@ class DoGBlobTask(BlobTask):
         max_sigma: float = 30,
         threshold: float = 0.1,
         overlap: float = 0.5,
-        **kwargs: Any
+        **kwargs: Any,
     ):
         super().__init__(
             feature,
@@ -119,7 +120,7 @@ class DoGBlobTask(BlobTask):
             max_sigma=max_sigma,
             threshold=threshold,
             overlap=overlap,
-            **kwargs
+            **kwargs,
         )
 
 
@@ -136,7 +137,7 @@ class DoHBlobTask(BlobTask):
         max_sigma: float = 30,
         threshold: float = 0.1,
         overlap: float = 0.5,
-        **kwargs: Any
+        **kwargs: Any,
     ):
         super().__init__(
             feature,
@@ -147,7 +148,7 @@ class DoHBlobTask(BlobTask):
             max_sigma=max_sigma,
             threshold=threshold,
             overlap=overlap,
-            **kwargs
+            **kwargs,
         )
 
 
@@ -164,7 +165,7 @@ class LoGBlobTask(BlobTask):
         max_sigma: float = 30,
         threshold: float = 0.1,
         overlap: float = 0.5,
-        **kwargs: Any
+        **kwargs: Any,
     ):
         super().__init__(
             feature,
@@ -175,5 +176,5 @@ class LoGBlobTask(BlobTask):
             max_sigma=max_sigma,
             threshold=threshold,
             overlap=overlap,
-            **kwargs
+            **kwargs,
         )

--- a/features/eolearn/features/clustering.py
+++ b/features/eolearn/features/clustering.py
@@ -8,6 +8,7 @@ Copyright (c) 2017-2022 Matej Aleksandrov, Žiga Lukšič (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+from __future__ import annotations
 
 from typing import Callable, List, Optional, Union, cast
 

--- a/features/eolearn/features/clustering.py
+++ b/features/eolearn/features/clustering.py
@@ -16,8 +16,7 @@ from sklearn.cluster import AgglomerativeClustering
 from sklearn.feature_extraction.image import grid_to_graph
 
 from eolearn.core import EOPatch, EOTask, FeatureType
-from eolearn.core.types import Literal
-from eolearn.core.utils.parsing import FeatureSpec
+from eolearn.core.types import FeatureSpec, Literal
 
 
 class ClusteringTask(EOTask):

--- a/features/eolearn/features/clustering.py
+++ b/features/eolearn/features/clustering.py
@@ -16,8 +16,8 @@ from sklearn.cluster import AgglomerativeClustering
 from sklearn.feature_extraction.image import grid_to_graph
 
 from eolearn.core import EOPatch, EOTask, FeatureType
+from eolearn.core.types import Literal
 from eolearn.core.utils.parsing import FeatureSpec
-from eolearn.core.utils.types import Literal
 
 
 class ClusteringTask(EOTask):

--- a/features/eolearn/features/doubly_logistic_approximation.py
+++ b/features/eolearn/features/doubly_logistic_approximation.py
@@ -15,7 +15,7 @@ import numpy as np
 from scipy.optimize import curve_fit
 
 from eolearn.core import EOPatch, EOTask, FeatureType
-from eolearn.core.utils.parsing import SingleFeatureSpec
+from eolearn.core.types import SingleFeatureSpec
 
 
 def doubly_logistic(middle, initial_value, scale, a1, a2, a3, a4, a5) -> np.ndarray:

--- a/features/eolearn/features/doubly_logistic_approximation.py
+++ b/features/eolearn/features/doubly_logistic_approximation.py
@@ -8,6 +8,8 @@ Copyright (c) 2017-2022 Matej Aleksandrov, Žiga Lukšič (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+from __future__ import annotations
+
 import itertools as it
 from typing import List, Optional
 

--- a/features/eolearn/features/feature_manipulation.py
+++ b/features/eolearn/features/feature_manipulation.py
@@ -24,8 +24,8 @@ from geopandas import GeoDataFrame
 from sentinelhub import bbox_to_dimensions
 
 from eolearn.core import EOPatch, EOTask, FeatureType, FeatureTypeSet, MapFeatureTask
+from eolearn.core.types import Literal
 from eolearn.core.utils.parsing import FeaturesSpecification, SingleFeatureSpec
-from eolearn.core.utils.types import Literal
 
 from .utils import ResizeLib, ResizeMethod, ResizeParam, spatially_resize_image
 

--- a/features/eolearn/features/feature_manipulation.py
+++ b/features/eolearn/features/feature_manipulation.py
@@ -24,8 +24,7 @@ from geopandas import GeoDataFrame
 from sentinelhub import bbox_to_dimensions
 
 from eolearn.core import EOPatch, EOTask, FeatureType, FeatureTypeSet, MapFeatureTask
-from eolearn.core.types import Literal
-from eolearn.core.utils.parsing import FeaturesSpecification, SingleFeatureSpec
+from eolearn.core.types import FeaturesSpecification, Literal, SingleFeatureSpec
 
 from .utils import ResizeLib, ResizeMethod, ResizeParam, spatially_resize_image
 

--- a/features/eolearn/features/haralick.py
+++ b/features/eolearn/features/haralick.py
@@ -17,7 +17,7 @@ import skimage.feature
 
 from eolearn.core import EOPatch, EOTask
 from eolearn.core.exceptions import EOUserWarning
-from eolearn.core.utils.parsing import SingleFeatureSpec
+from eolearn.core.types import SingleFeatureSpec
 
 
 class HaralickTask(EOTask):

--- a/features/eolearn/features/haralick.py
+++ b/features/eolearn/features/haralick.py
@@ -8,6 +8,7 @@ Copyright (c) 2017-2022 Matej Aleksandrov, Žiga Lukšič (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+from __future__ import annotations
 
 import itertools as it
 import warnings

--- a/features/eolearn/features/hog.py
+++ b/features/eolearn/features/hog.py
@@ -8,6 +8,7 @@ Copyright (c) 2017-2022 Matej Aleksandrov, Devis Peressutti, Žiga Lukšič (Sin
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+from __future__ import annotations
 
 from typing import Optional, Tuple
 

--- a/features/eolearn/features/hog.py
+++ b/features/eolearn/features/hog.py
@@ -15,7 +15,7 @@ import numpy as np
 import skimage.feature
 
 from eolearn.core import EOPatch, EOTask, FeatureType
-from eolearn.core.utils.parsing import SingleFeatureSpec
+from eolearn.core.types import SingleFeatureSpec
 
 
 class HOGTask(EOTask):

--- a/features/eolearn/features/interpolation.py
+++ b/features/eolearn/features/interpolation.py
@@ -11,6 +11,7 @@ Copyright (c) 2018-2019 William Ouellette
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+from __future__ import annotations
 
 import datetime as dt
 import inspect

--- a/features/eolearn/features/interpolation.py
+++ b/features/eolearn/features/interpolation.py
@@ -25,7 +25,7 @@ from sklearn.gaussian_process import GaussianProcessRegressor
 
 from eolearn.core import EOPatch, EOTask, FeatureType, FeatureTypeSet
 from eolearn.core.exceptions import EOUserWarning
-from eolearn.core.utils.parsing import FeaturesSpecification, SingleFeatureSpec
+from eolearn.core.types import FeaturesSpecification, SingleFeatureSpec
 
 try:
     import numba

--- a/features/eolearn/features/local_binary_pattern.py
+++ b/features/eolearn/features/local_binary_pattern.py
@@ -13,7 +13,7 @@ import numpy as np
 import skimage.feature
 
 from eolearn.core import EOPatch, EOTask
-from eolearn.core.utils.parsing import SingleFeatureSpec
+from eolearn.core.types import SingleFeatureSpec
 
 
 class LocalBinaryPatternTask(EOTask):

--- a/features/eolearn/features/local_binary_pattern.py
+++ b/features/eolearn/features/local_binary_pattern.py
@@ -8,6 +8,7 @@ Copyright (c) 2017-2022 Matej Aleksandrov, Devis Peressutti, Žiga Lukšič (Sin
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+from __future__ import annotations
 
 import numpy as np
 import skimage.feature

--- a/features/eolearn/features/radiometric_normalization.py
+++ b/features/eolearn/features/radiometric_normalization.py
@@ -14,7 +14,7 @@ from typing import Optional
 import numpy as np
 
 from eolearn.core import EOPatch, EOTask
-from eolearn.core.utils.parsing import SingleFeatureSpec
+from eolearn.core.types import SingleFeatureSpec
 
 
 class ReferenceScenesTask(EOTask):

--- a/features/eolearn/features/radiometric_normalization.py
+++ b/features/eolearn/features/radiometric_normalization.py
@@ -8,6 +8,8 @@ Copyright (c) 2017-2022 Matej Aleksandrov, Matic Lubej, Devis Peressutti, Žiga 
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+from __future__ import annotations
+
 from abc import ABCMeta, abstractmethod
 from typing import Optional
 

--- a/geometry/eolearn/geometry/morphology.py
+++ b/geometry/eolearn/geometry/morphology.py
@@ -21,7 +21,7 @@ import skimage.filters.rank
 import skimage.morphology
 
 from eolearn.core import EOPatch, EOTask, FeatureType, FeatureTypeSet, MapFeatureTask
-from eolearn.core.utils.parsing import FeaturesSpecification, SingleFeatureSpec
+from eolearn.core.types import FeaturesSpecification, SingleFeatureSpec
 
 
 class ErosionTask(EOTask):

--- a/geometry/eolearn/geometry/superpixel.py
+++ b/geometry/eolearn/geometry/superpixel.py
@@ -19,7 +19,7 @@ import skimage.segmentation
 
 from eolearn.core import EOPatch, EOTask, FeatureType, FeatureTypeSet
 from eolearn.core.exceptions import EORuntimeWarning
-from eolearn.core.utils.parsing import SingleFeatureSpec
+from eolearn.core.types import SingleFeatureSpec
 
 LOGGER = logging.getLogger(__name__)
 

--- a/geometry/eolearn/geometry/transformations.py
+++ b/geometry/eolearn/geometry/transformations.py
@@ -33,7 +33,7 @@ from sentinelhub import CRS, BBox, bbox_to_dimensions, parse_time
 
 from eolearn.core import EOPatch, EOTask, FeatureType, FeatureTypeSet
 from eolearn.core.exceptions import EORuntimeWarning
-from eolearn.core.utils.parsing import FeaturesSpecification, SingleFeatureSpec
+from eolearn.core.types import FeaturesSpecification, SingleFeatureSpec
 
 LOGGER = logging.getLogger(__name__)
 

--- a/io/eolearn/io/sentinelhub_process.py
+++ b/io/eolearn/io/sentinelhub_process.py
@@ -36,8 +36,8 @@ from sentinelhub import (
 from sentinelhub.type_utils import RawTimeIntervalType
 
 from eolearn.core import EOPatch, EOTask, FeatureType, FeatureTypeSet
+from eolearn.core.types import Literal
 from eolearn.core.utils.parsing import FeatureRenameSpec, FeatureSpec, FeaturesSpecification
-from eolearn.core.utils.types import Literal
 
 LOGGER = logging.getLogger(__name__)
 

--- a/io/eolearn/io/sentinelhub_process.py
+++ b/io/eolearn/io/sentinelhub_process.py
@@ -36,8 +36,7 @@ from sentinelhub import (
 from sentinelhub.type_utils import RawTimeIntervalType
 
 from eolearn.core import EOPatch, EOTask, FeatureType, FeatureTypeSet
-from eolearn.core.types import Literal
-from eolearn.core.utils.parsing import FeatureRenameSpec, FeatureSpec, FeaturesSpecification
+from eolearn.core.types import FeatureRenameSpec, FeatureSpec, FeaturesSpecification, Literal
 
 LOGGER = logging.getLogger(__name__)
 

--- a/ml_tools/eolearn/ml_tools/sampling.py
+++ b/ml_tools/eolearn/ml_tools/sampling.py
@@ -19,7 +19,7 @@ import numpy as np
 from shapely.geometry import Point, Polygon
 
 from eolearn.core import EOPatch, EOTask, FeatureType, FeatureTypeSet
-from eolearn.core.utils.parsing import FeaturesSpecification, SingleFeatureSpec
+from eolearn.core.types import FeaturesSpecification, SingleFeatureSpec
 
 _FractionType = Union[float, Dict[int, float]]
 

--- a/ml_tools/eolearn/ml_tools/train_test_split.py
+++ b/ml_tools/eolearn/ml_tools/train_test_split.py
@@ -9,6 +9,7 @@ Copyright (c) 2017-2019 Blaž Sovdat, Andrej Burja (Sinergise)
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+from __future__ import annotations
 
 from enum import Enum
 from typing import Any, List, Optional, Union

--- a/ml_tools/eolearn/ml_tools/train_test_split.py
+++ b/ml_tools/eolearn/ml_tools/train_test_split.py
@@ -16,7 +16,7 @@ from typing import Any, List, Optional, Union
 import numpy as np
 
 from eolearn.core import EOPatch, EOTask, FeatureType
-from eolearn.core.utils.parsing import FeaturesSpecification
+from eolearn.core.types import FeaturesSpecification
 
 
 class TrainTestSplitType(Enum):

--- a/visualization/eolearn/visualization/eopatch.py
+++ b/visualization/eolearn/visualization/eopatch.py
@@ -20,7 +20,7 @@ from geopandas import GeoDataFrame
 from pyproj import CRS
 
 from eolearn.core import EOPatch, FeatureType
-from eolearn.core.utils.parsing import SingleFeatureSpec
+from eolearn.core.types import SingleFeatureSpec
 
 from .eopatch_base import BaseEOPatchVisualization, BasePlotConfig
 

--- a/visualization/eolearn/visualization/eopatch.py
+++ b/visualization/eolearn/visualization/eopatch.py
@@ -8,6 +8,8 @@ Copyright (c) 2017-2022 Žiga Lukšič, Devis Peressutti, Nejc Vesel, Jovan Viš
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+from __future__ import annotations
+
 import datetime as dt
 import itertools as it
 from dataclasses import dataclass, field

--- a/visualization/eolearn/visualization/eopatch_base.py
+++ b/visualization/eolearn/visualization/eopatch_base.py
@@ -8,6 +8,8 @@ Copyright (c) 2017-2022 Žiga Lukšič, Devis Peressutti, Nejc Vesel, Jovan Viš
 This source code is licensed under the MIT license found in the LICENSE
 file in the root directory of this source tree.
 """
+from __future__ import annotations
+
 import abc
 import datetime as dt
 from dataclasses import dataclass

--- a/visualization/eolearn/visualization/eopatch_base.py
+++ b/visualization/eolearn/visualization/eopatch_base.py
@@ -17,8 +17,9 @@ import numpy as np
 from geopandas import GeoDataFrame
 
 from eolearn.core import EOPatch
+from eolearn.core.types import SingleFeatureSpec
 from eolearn.core.utils.common import is_discrete_type
-from eolearn.core.utils.parsing import SingleFeatureSpec, parse_feature
+from eolearn.core.utils.parsing import parse_feature
 
 
 @dataclass


### PR DESCRIPTION
- moves `eolearn.core.utils.types` to `eolearn.core.types`
- moves types from `eolearn.core.utils.parsing` to the new type module as well
- add `from future import __annotations__` to all modules using the parsing types, so that docs are nice