### PR TITLE
skip B028 for flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,6 @@
 [flake8]
-ignore = E203, W503, C408
+# B028 is ignored because !r flags cannot be used in python < 3.8
+ignore = E203, W503, C408, B028
 exclude = .git, __pycache__, build, dist
 max-line-length= 120
 max-complexity = 15


### PR DESCRIPTION
Nothing to be 'fixed' found, cannot do the `!r` flag because we still support python 3.7