### PR TITLE
Reduce `EOPatch` method count

### DIFF
--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -313,7 +313,7 @@ class InitializeFeatureTask(EOTask):
         """
         shape = eopatch[self.shape_feature].shape if self.shape_feature else self.shape
 
-        add_features = set(self.features) - set(self.parse_features(eopatch.get_feature_list()))
+        add_features = set(self.features) - set(self.parse_features(eopatch.get_features()))
 
         for feature in add_features:
             eopatch[feature] = np.ones(shape, dtype=self.dtype) * self.init_value

--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -544,8 +544,9 @@ class EOPatch:
         """
         feature_list: List[FeatureSpec] = []
         for feature_type in FeatureType:
-            if (feature_type is FeatureType.BBOX or feature_type is FeatureType.TIMESTAMP) and feature_type in self:
-                feature_list.append((feature_type, None))
+            if feature_type is FeatureType.BBOX or feature_type is FeatureType.TIMESTAMP:
+                if feature_type in self:
+                    feature_list.append((feature_type, None))
             else:
                 for feature_name in self[feature_type]:
                     feature_list.append((feature_type, feature_name))

--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -644,27 +644,6 @@ class EOPatch:
 
         return merged_eopatch
 
-    def get_time_series(self, ref_date: Optional[dt.datetime] = None, scale_time: int = 1) -> np.ndarray:
-        """Returns a numpy array with seconds passed between the reference date and the timestamp of each image.
-
-        An array is constructed as time_series[i] = (timestamp[i] - ref_date).total_seconds().
-        If reference date is None the first date in the EOPatch's timestamp is taken.
-        If EOPatch timestamp attribute is empty the method returns None.
-
-        :param ref_date: reference date relative to which the time is measured
-        :param scale_time: scale seconds by factor. If `60`, time will be in minutes, if `3600` hours
-        """
-
-        if not self.timestamp:
-            return np.zeros(0, dtype=np.int64)
-
-        if ref_date is None:
-            ref_date = self.timestamp[0]
-
-        return np.asarray(
-            [round((timestamp - ref_date).total_seconds() / scale_time) for timestamp in self.timestamp], dtype=np.int64
-        )
-
     def consolidate_timestamps(self, timestamps: List[dt.datetime]) -> Set[dt.datetime]:
         """Removes all frames from the EOPatch with a date not found in the provided timestamps list.
 

--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -520,21 +520,6 @@ class EOPatch:
         else:
             self[feature_type] = []
 
-    def get_features(self) -> Dict[FeatureType, Union[Set[str], Literal[True]]]:
-        """Returns a dictionary of all non-empty features of EOPatch.
-
-        The elements are either sets of feature names or a boolean `True` in case feature type has no dictionary of
-        feature names.
-
-        :return: A dictionary of features
-        """
-        feature_dict: Dict[FeatureType, Union[Set[str], Literal[True]]] = {}
-        for feature_type in FeatureType:
-            if self[feature_type]:
-                feature_dict[feature_type] = set(self[feature_type]) if feature_type.has_dict() else True
-
-        return feature_dict
-
     def get_spatial_dimension(self, feature_type: FeatureType, feature_name: str) -> Tuple[int, int]:
         """
         Returns a tuple of spatial dimension (height, width) of a feature.
@@ -552,20 +537,18 @@ class EOPatch:
             "FeatureType used to determine the width and height of raster must be time dependent or spatial."
         )
 
-    def get_feature_list(self) -> List[Union[FeatureType, Tuple[FeatureType, str]]]:
+    def get_features(self) -> List[FeatureSpec]:
         """Returns a list of all non-empty features of EOPatch.
 
-        The elements are either only FeatureType or a pair of FeatureType and feature name.
-
-        :return: list of features
+        :return: List of non-empty features
         """
-        feature_list: List[Union[FeatureType, Tuple[FeatureType, str]]] = []
+        feature_list: List[FeatureSpec] = []
         for feature_type in FeatureType:
-            if feature_type.has_dict():
+            if (feature_type is FeatureType.BBOX or feature_type is FeatureType.TIMESTAMP) and feature_type in self:
+                feature_list.append((feature_type, None))
+            else:
                 for feature_name in self[feature_type]:
                     feature_list.append((feature_type, feature_name))
-            elif self[feature_type]:
-                feature_list.append(feature_type)
         return feature_list
 
     def save(

--- a/core/eolearn/tests/test_core_tasks.py
+++ b/core/eolearn/tests/test_core_tasks.py
@@ -108,7 +108,7 @@ def test_partial_copy(patch):
 def test_load_task(test_eopatch_path):
     full_load = LoadTask(test_eopatch_path)
     full_patch = full_load.execute(eopatch_folder=".")
-    assert len(full_patch.get_feature_list()) == 30
+    assert len(full_patch.get_features()) == 30
 
     partial_load = LoadTask(test_eopatch_path, features=[FeatureType.BBOX, FeatureType.MASK_TIMELESS])
     partial_patch = partial_load.execute(eopatch_folder=".")
@@ -301,11 +301,10 @@ def test_move_feature():
     patch_dst = EOPatch()
     patch_dst = MoveFeatureTask(features)(patch_src, patch_dst)
 
-    assert FeatureType.MASK_TIMELESS in patch_dst.get_features()
-    assert FeatureType.DATA not in patch_dst.get_features()
+    assert FeatureType.DATA not in patch_dst, "FeatureType.DATA features were moved but shouldn't be."
 
-    assert "MTless1" in patch_dst[FeatureType.MASK_TIMELESS]
-    assert "MTless2" in patch_dst[FeatureType.MASK_TIMELESS]
+    assert (FeatureType.MASK_TIMELESS, "MTless1") in patch_dst
+    assert (FeatureType.MASK_TIMELESS, "MTless2") in patch_dst
 
 
 @pytest.mark.parametrize("axis", (0, -1))

--- a/core/eolearn/tests/test_eoworkflow_tasks.py
+++ b/core/eolearn/tests/test_eoworkflow_tasks.py
@@ -36,7 +36,7 @@ def test_output_task(test_eopatch):
     new_eopatch = task.execute(test_eopatch)
     assert id(new_eopatch) != id(test_eopatch)
 
-    assert len(new_eopatch.get_feature_list()) == 2
+    assert len(new_eopatch.get_features()) == 2
     assert new_eopatch.bbox == test_eopatch.bbox
 
 

--- a/features/eolearn/features/interpolation.py
+++ b/features/eolearn/features/interpolation.py
@@ -404,6 +404,7 @@ class InterpolationTask(EOTask):
         If reference date is None the first date in the EOPatch's timestamp is taken.
         If EOPatch timestamp attribute is empty the method returns None.
 
+        :eopatch: the EOPatch whose timestamps are used to construct the time series
         :param ref_date: reference date relative to which the time is measured
         :param scale_time: scale seconds by factor. If `60`, time will be in minutes, if `3600` hours
         """

--- a/features/eolearn/features/interpolation.py
+++ b/features/eolearn/features/interpolation.py
@@ -404,7 +404,7 @@ class InterpolationTask(EOTask):
         If reference date is None the first date in the EOPatch's timestamp is taken.
         If EOPatch timestamp attribute is empty the method returns None.
 
-        :eopatch: the EOPatch whose timestamps are used to construct the time series
+        :param eopatch: the EOPatch whose timestamps are used to construct the time series
         :param ref_date: reference date relative to which the time is measured
         :param scale_time: scale seconds by factor. If `60`, time will be in minutes, if `3600` hours
         """

--- a/features/eolearn/features/interpolation.py
+++ b/features/eolearn/features/interpolation.py
@@ -394,6 +394,30 @@ class InterpolationTask(EOTask):
 
         return days
 
+    @staticmethod
+    def _get_eopatch_time_series(
+        eopatch: EOPatch, ref_date: Optional[dt.datetime] = None, scale_time: int = 1
+    ) -> np.ndarray:
+        """Returns a numpy array with seconds passed between the reference date and the timestamp of each image.
+
+        An array is constructed as time_series[i] = (timestamp[i] - ref_date).total_seconds().
+        If reference date is None the first date in the EOPatch's timestamp is taken.
+        If EOPatch timestamp attribute is empty the method returns None.
+
+        :param ref_date: reference date relative to which the time is measured
+        :param scale_time: scale seconds by factor. If `60`, time will be in minutes, if `3600` hours
+        """
+        if not eopatch.timestamp:
+            return np.zeros(0, dtype=np.int64)
+
+        if ref_date is None:
+            ref_date = eopatch.timestamp[0]
+
+        return np.asarray(
+            [round((timestamp - ref_date).total_seconds() / scale_time) for timestamp in eopatch.timestamp],
+            dtype=np.int64,
+        )
+
     def execute(self, eopatch: EOPatch) -> EOPatch:
         """Execute method that processes EOPatch and returns EOPatch"""
         # pylint: disable=too-many-locals
@@ -421,10 +445,12 @@ class InterpolationTask(EOTask):
         new_eopatch = EOPatch() if self.resample_range else eopatch
 
         # Resample times
-        times = eopatch.get_time_series(scale_time=self.scale_time)
+        times = self._get_eopatch_time_series(eopatch, scale_time=self.scale_time)
         new_eopatch.timestamp = self.get_resampled_timestamp(eopatch.timestamp)
         total_diff = int((new_eopatch.timestamp[0].date() - eopatch.timestamp[0].date()).total_seconds())
-        resampled_times = new_eopatch.get_time_series(scale_time=self.scale_time) + total_diff // self.scale_time
+        resampled_times = (
+            self._get_eopatch_time_series(new_eopatch, scale_time=self.scale_time) + total_diff // self.scale_time
+        )
 
         # Add BBox to eopatch if it was created anew
         if new_eopatch.bbox is None:


### PR DESCRIPTION
1. `get_features_list` and `get_features` have been joined into a new `get_features` that returns a list as if the parser were run on the EOPatch (no more weird types)
2. the `get_timeseries` had little to do with the EOPatch, so it was moved to the only place where it was used, interpolation tasks