### PR TITLE
Fixes SpatialResizeTask that switched width/height when using resolution

### DIFF
--- a/features/eolearn/features/feature_manipulation.py
+++ b/features/eolearn/features/feature_manipulation.py
@@ -264,10 +264,10 @@ class SpatialResizeTask(EOTask):
         :param resize_type: Determines type of resizing process and how `width_param` and `height_param` are used.
             Options:
                 * `new_size`: Resizes data to size (width_param, height_param)
-                * `resolution`: Resizes the data to have width_param, height_param resolution over width/height axis.
-                   Uses EOPatch bbox to compute.
-                * `scale_factor` Resizes the data by scaling the width and height by a factor set by
-                   width_param and height_param respectively.
+                * | `resolution`: Resizes the data to have width_param, height_param resolution over width/height axis.
+                  | Uses EOPatch bbox to compute.
+                * | `scale_factor` Resizes the data by scaling the width and height by a factor set by
+                  | width_param and height_param respectively.
         :param height_param: Parameter to be applied to the height in combination with the resize_type
         :param width_param: Parameter to be applied to the width in combination with the resize_type
         :param resize_method: Interpolation method used for resizing.

--- a/features/eolearn/features/feature_manipulation.py
+++ b/features/eolearn/features/feature_manipulation.py
@@ -261,12 +261,13 @@ class SpatialResizeTask(EOTask):
     ):
         """
         :param features: Which features to resize. Supports new names for features.
-        :param resize_type: Type of resizing process to be performed. Options:
-            * `new_size` (combined with width_param, height_param). Resizes data to size (width_param, height_param)
-            * `resolution` (combined with width_param, height_param). Resizes the data to have
-               width_param, height_param resolution over width/height axis. Uses EOPatch bbox to compute.
-            * `scale_factor` (combined with width_param, height_param). Resizes the data by scaling the width
-               and height by a factor set by width_param and height_param.
+        :param resize_type: Determines type of resizing process and how `width_param` and `height_param` are used.
+        Options:
+            * `new_size`: Resizes data to size (width_param, height_param)
+            * `resolution`: Resizes the data to have width_param, height_param resolution over width/height axis.
+               Uses EOPatch bbox to compute.
+            * `scale_factor` Resizes the data by scaling the width and height by a factor set by
+               width_param and height_param respectively.
         :param height_param: Parameter to be applied to the height in combination with the resize_type
         :param width_param: Parameter to be applied to the width in combination with the resize_type
         :param resize_method: Interpolation method used for resizing.

--- a/features/eolearn/features/feature_manipulation.py
+++ b/features/eolearn/features/feature_manipulation.py
@@ -262,12 +262,12 @@ class SpatialResizeTask(EOTask):
         """
         :param features: Which features to resize. Supports new names for features.
         :param resize_type: Determines type of resizing process and how `width_param` and `height_param` are used.
-        Options:
-            * `new_size`: Resizes data to size (width_param, height_param)
-            * `resolution`: Resizes the data to have width_param, height_param resolution over width/height axis.
-               Uses EOPatch bbox to compute.
-            * `scale_factor` Resizes the data by scaling the width and height by a factor set by
-               width_param and height_param respectively.
+            Options:
+                * `new_size`: Resizes data to size (width_param, height_param)
+                * `resolution`: Resizes the data to have width_param, height_param resolution over width/height axis.
+                   Uses EOPatch bbox to compute.
+                * `scale_factor` Resizes the data by scaling the width and height by a factor set by
+                   width_param and height_param respectively.
         :param height_param: Parameter to be applied to the height in combination with the resize_type
         :param width_param: Parameter to be applied to the width in combination with the resize_type
         :param resize_method: Interpolation method used for resizing.

--- a/features/eolearn/tests/test_feature_manipulation.py
+++ b/features/eolearn/tests/test_feature_manipulation.py
@@ -231,29 +231,37 @@ def test_linear_function_task():
 
 
 @pytest.mark.parametrize(
-    ["resize_parameters", "features_call", "features_check", "outputs"],
+    ["resize_type", "height_param", "width_param", "features_call", "features_check", "outputs"],
     [
-        ((ResizeParam.NEW_SIZE, (50, 70)), ("data", "CLP"), ("data", "CLP"), (68, 50, 70, 1)),
-        ((ResizeParam.NEW_SIZE, (50, 70)), ("data", "CLP"), ("mask", "CLM"), (68, 101, 100, 1)),
-        ((ResizeParam.NEW_SIZE, (50, 70)), ..., ("data", "CLP"), (68, 50, 70, 1)),
-        ((ResizeParam.NEW_SIZE, (50, 70)), ..., ("mask", "CLM"), (68, 50, 70, 1)),
-        ((ResizeParam.NEW_SIZE, (50, 70)), ("data", "CLP", "CLP_small"), ("data", "CLP_small"), (68, 50, 70, 1)),
-        ((ResizeParam.NEW_SIZE, (50, 70)), ("data", "CLP", "CLP_small"), ("data", "CLP"), (68, 101, 100, 1)),
-        ((ResizeParam.SCALE_FACTORS, (2, 2)), ("data", "CLP"), ("data", "CLP"), (68, 202, 200, 1)),
-        ((ResizeParam.SCALE_FACTORS, (0.1, 0.1)), ("data", "CLP"), ("data", "CLP"), (68, 10, 10, 1)),
-        ((ResizeParam.RESOLUTION, (5, 5)), ("data", "CLP"), ("data", "CLP"), (68, 200, 202, 1)),
-        ((ResizeParam.RESOLUTION, (20, 20)), ("data", "CLP"), ("data", "CLP"), (68, 50, 50, 1)),
+        (ResizeParam.NEW_SIZE, 50, 70, ("data", "CLP"), ("data", "CLP"), (68, 50, 70, 1)),
+        (ResizeParam.NEW_SIZE, 50, 70, ("data", "CLP"), ("mask", "CLM"), (68, 101, 100, 1)),
+        (ResizeParam.NEW_SIZE, 50, 70, ..., ("data", "CLP"), (68, 50, 70, 1)),
+        (ResizeParam.NEW_SIZE, 50, 70, ..., ("mask", "CLM"), (68, 50, 70, 1)),
+        (ResizeParam.NEW_SIZE, 50, 70, ("data", "CLP", "CLP_small"), ("data", "CLP_small"), (68, 50, 70, 1)),
+        (ResizeParam.NEW_SIZE, 50, 70, ("data", "CLP", "CLP_small"), ("data", "CLP"), (68, 101, 100, 1)),
+        (ResizeParam.SCALE_FACTORS, 2, 2, ("data", "CLP"), ("data", "CLP"), (68, 202, 200, 1)),
+        (ResizeParam.SCALE_FACTORS, 0.5, 2, ("data", "CLP"), ("data", "CLP"), (68, 50, 200, 1)),
+        (ResizeParam.SCALE_FACTORS, 0.1, 0.1, ("data", "CLP"), ("data", "CLP"), (68, 10, 10, 1)),
+        (ResizeParam.RESOLUTION, 5, 5, ("data", "CLP"), ("data", "CLP"), (68, 202, 200, 1)),
+        (ResizeParam.RESOLUTION, 20, 20, ("data", "CLP"), ("data", "CLP"), (68, 50, 50, 1)),
+        (ResizeParam.RESOLUTION, 5, 20, ("data", "CLP"), ("data", "CLP"), (68, 202, 50, 1)),
     ],
 )
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-def test_spatial_resize_task(example_eopatch, resize_parameters, features_call, features_check, outputs):
+def test_spatial_resize_task(
+    example_eopatch, resize_type, height_param, width_param, features_call, features_check, outputs
+):
     # Warnings occur due to lossy casting in the downsampling procedure
 
-    resize = SpatialResizeTask(resize_parameters=resize_parameters, features=features_call)
+    resize = SpatialResizeTask(
+        resize_type=resize_type, height_param=height_param, width_param=width_param, features=features_call
+    )
     assert resize(example_eopatch)[features_check].shape == outputs
 
 
 def test_spatial_resize_task_exception(example_eopatch):
     with pytest.raises(ValueError):
-        resize_wrong_param = SpatialResizeTask(features=("mask", "CLM"), resize_parameters=("blabla", (20, 20)))
+        resize_wrong_param = SpatialResizeTask(
+            features=("mask", "CLM"), resize_type="blabla", height_param=20, width_param=20
+        )
         resize_wrong_param(example_eopatch)


### PR DESCRIPTION
Changes that were made: 

* The signature of the SpatialResizeTask was changed to explicitly take width / height parameters. 
* The bug that switched the width/height when using resolution was fixed 
* Tests were updated to reflect the new signature, tests were added to test for non-symettbic width/height parameters for `ResizeType.SCALE_FACTORS` and `ResizeType.RESOLUTION`

