### PR TITLE
Add delete instructions for bbox and timestamps

### DIFF
--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -352,7 +352,7 @@ class EOPatch:
 
         return self.__setattr__(FeatureType(feature_type).value, value, feature_name=feature_name)
 
-    def __delitem__(self, feature: Tuple[FeatureType, str]) -> None:
+    def __delitem__(self, feature: FeatureSpec) -> None:
         """Deletes the selected feature.
 
         :param feature: EOPatch feature
@@ -361,12 +361,13 @@ class EOPatch:
         feature_type, feature_name = feature
         if feature_type in [FeatureType.BBOX, FeatureType.TIMESTAMP]:
             self.reset_feature_type(feature_type)
-        del self[feature_type][feature_name]
+        else:
+            del self[feature_type][feature_name]
 
     @staticmethod
     def _check_tuple_key(key: tuple) -> None:
         """A helper function that checks a tuple, which should hold (feature_type, feature_name)."""
-        if len(key) != 2:
+        if not isinstance(key, (tuple, list)) or len(key) != 2:
             raise ValueError(f"Given element should be a tuple of (feature_type, feature_name), but {key} found.")
 
     def __eq__(self, other: object) -> bool:

--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -359,6 +359,8 @@ class EOPatch:
         """
         self._check_tuple_key(feature)
         feature_type, feature_name = feature
+        if feature_type in [FeatureType.BBOX, FeatureType.TIMESTAMP]:
+            self.reset_feature_type(feature_type)
         del self[feature_type][feature_name]
 
     @staticmethod

--- a/core/eolearn/tests/test_eodata.py
+++ b/core/eolearn/tests/test_eodata.py
@@ -163,10 +163,10 @@ def test_simplified_feature_operations() -> None:
         (FeatureType.MASK, "ones"),
         (FeatureType.MASK_TIMELESS, "threes"),
         (FeatureType.META_INFO, "beep"),
-        (FeatureType.BBOX),
+        (FeatureType.BBOX, None),
     ],
 )
-def test_delete_existing_feature(feature: Tuple[FeatureType, str], mini_eopatch: EOPatch) -> None:
+def test_delete_existing_feature(feature: FeatureSpec, mini_eopatch: EOPatch) -> None:
     old = mini_eopatch.copy(deep=True)
 
     del mini_eopatch[feature]
@@ -174,6 +174,7 @@ def test_delete_existing_feature(feature: Tuple[FeatureType, str], mini_eopatch:
 
     for old_feature in old.get_features():
         if old_feature != feature:
+            # this also works for BBox :D
             assert_array_equal(old[old_feature], mini_eopatch[old_feature])
 
 

--- a/core/eolearn/tests/test_eodata.py
+++ b/core/eolearn/tests/test_eodata.py
@@ -163,6 +163,7 @@ def test_simplified_feature_operations() -> None:
         (FeatureType.MASK, "ones"),
         (FeatureType.MASK_TIMELESS, "threes"),
         (FeatureType.META_INFO, "beep"),
+        (FeatureType.BBOX),
     ],
 )
 def test_delete_existing_feature(feature: Tuple[FeatureType, str], mini_eopatch: EOPatch) -> None:


### PR DESCRIPTION
While we will move away from BBOX and TIMESTAMP feature types, for the time being it seems right to support deletion of those as well. I did make it so that one must use their full spec (so `(FeatureType.BBOX, None)`) in order to not lose too much time with it