### PR TITLE
Copying always copies the BBox

### DIFF
--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -502,7 +502,7 @@ class EOPatch:
         :param features: Features to be copied into a new `EOPatch`. By default, all features will be copied. Note that
             `BBOX` is always copied.
         :param deep: If `True` it will make a deep copy of all data inside the `EOPatch`. Otherwise, only a shallow copy
-            of `EOPatch` will be made. Note that `BBOX` and `TIMESTAMP` will be deepcopied even with a shallow copy.
+            of `EOPatch` will be made. Note that `BBOX` and `TIMESTAMP` will be copied even with a shallow copy.
         :return: An EOPatch copy.
         """
         if deep:

--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -461,7 +461,7 @@ class EOPatch:
         if not features:  # For some reason deepcopy and copy pass {} by default
             features = ...
 
-        new_eopatch = EOPatch()
+        new_eopatch = EOPatch(bbox=copy.copy(self.bbox))
         for feature_type, feature_name in parse_features(features, eopatch=self):
             if feature_type.has_dict():
                 new_eopatch[feature_type][feature_name] = self[feature_type].__getitem__(feature_name, load=False)
@@ -478,7 +478,7 @@ class EOPatch:
         if not features:  # For some reason deepcopy and copy pass {} by default
             features = ...
 
-        new_eopatch = EOPatch()
+        new_eopatch = EOPatch(bbox=copy.deepcopy(self.bbox))
         for feature_type, feature_name in parse_features(features, eopatch=self):
             if feature_type.has_dict():
                 value = self[feature_type].__getitem__(feature_name, load=False)
@@ -499,9 +499,10 @@ class EOPatch:
     def copy(self, features: FeaturesSpecification = ..., deep: bool = False) -> EOPatch:
         """Get a copy of the current `EOPatch`.
 
-        :param features: Features to be copied into a new `EOPatch`. By default, all features will be copied.
+        :param features: Features to be copied into a new `EOPatch`. By default, all features will be copied. Note that
+            `BBOX` is always copied.
         :param deep: If `True` it will make a deep copy of all data inside the `EOPatch`. Otherwise, only a shallow copy
-            of `EOPatch` will be made. Note that `BBOX` and `TIMESTAMP` will be copied even with a shallow copy.
+            of `EOPatch` will be made. Note that `BBOX` and `TIMESTAMP` will be deepcopied even with a shallow copy.
         :return: An EOPatch copy.
         """
         if deep:

--- a/core/eolearn/tests/test_core_tasks.py
+++ b/core/eolearn/tests/test_core_tasks.py
@@ -98,11 +98,11 @@ def test_deepcopy(patch):
 def test_partial_copy(patch):
     partial_copy = DeepCopyTask(features=[(FeatureType.MASK_TIMELESS, "mask"), FeatureType.BBOX]).execute(patch)
     expected_patch = EOPatch(mask_timeless=patch.mask_timeless, bbox=patch.bbox)
-    assert partial_copy == expected_patch, "Partial copying was not successful"
+    assert partial_copy == expected_patch
 
     partial_deepcopy = DeepCopyTask(features=[FeatureType.TIMESTAMP, (FeatureType.SCALAR, "values")]).execute(patch)
-    expected_patch = EOPatch(scalar=patch.scalar, timestamp=patch.timestamp)
-    assert partial_deepcopy == expected_patch, "Partial deep copying was not successful"
+    expected_patch = EOPatch(scalar=patch.scalar, timestamp=patch.timestamp, bbox=patch.bbox)
+    assert partial_deepcopy == expected_patch
 
 
 def test_load_task(test_eopatch_path):


### PR DESCRIPTION
Since the BBox is the spatial definition of the EOPatch it should always be copied.