### PR TITLE
Refactor eodata_io

### DIFF
--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -212,11 +212,11 @@ def _load_meta_feature(
     filesystem: FS, fsinfo: FilesystemDataInfo, eopatch: EOPatch, patch_location: str, ftype: FeatureType
 ) -> None:
     if ftype == FeatureType.BBOX and fsinfo.bbox is not None:
-        eopatch.bbox = FeatureIOBBox(fsinfo.bbox, filesystem)
+        eopatch.bbox = FeatureIOBBox(fsinfo.bbox, filesystem)  # type: ignore[assignment]
     elif ftype == FeatureType.TIMESTAMPS and fsinfo.timestamps is not None:
-        eopatch.timestamps = FeatureIOTimestamps(fsinfo.timestamps, filesystem)
+        eopatch.timestamps = FeatureIOTimestamps(fsinfo.timestamps, filesystem)  # type: ignore[assignment]
     elif ftype == FeatureType.META_INFO and fsinfo.meta_info is not None:
-        eopatch.meta_info = FeatureIOJson(fsinfo.meta_info, filesystem)
+        eopatch.meta_info = FeatureIOJson(fsinfo.meta_info, filesystem)  # type: ignore[assignment]
     else:
         raise IOError(f"Feature {ftype} does not exist in eopatch at {patch_location}.")
 

--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -67,6 +67,7 @@ Self = TypeVar("Self", bound="FeatureIO")
 FeatureInfo = Tuple[FeatureType, Union[str, EllipsisType], str]
 
 BBOX_FILENAME = "bbox"
+TIMESTAMPS_FILENAME = "timestamps"
 
 
 @dataclass
@@ -77,6 +78,7 @@ class FilesystemDataInfo:
     bbox: Optional[str] = None
     meta_info: Optional[str] = None
     features: Dict[FeatureType, Dict[str, str]] = field(default_factory=lambda: defaultdict(dict))
+    # Note: add a flat iterator for features
 
 
 def save_eopatch(
@@ -253,7 +255,7 @@ def walk_filesystem(filesystem: FS, patch_location: str, features: FeaturesSpeci
                 category=EODeprecationWarning,
                 stacklevel=2,
             )
-            object_name = FeatureType.TIMESTAMPS.value
+            object_name = TIMESTAMPS_FILENAME
 
         if "/" in object_name:  # For cases where S3 does not have a regular folder structure
             ftype_str, fname = fs.path.split(object_name)
@@ -262,7 +264,7 @@ def walk_filesystem(filesystem: FS, patch_location: str, features: FeaturesSpeci
         elif object_name == BBOX_FILENAME:
             result.bbox = object_path
 
-        elif object_name == FeatureType.TIMESTAMPS.value:
+        elif object_name == TIMESTAMPS_FILENAME:
             result.timestamps = object_path
 
         elif object_name == FeatureType.META_INFO.value:

--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -195,9 +195,7 @@ def load_eopatch(
             _load_whole_feature_type(filesystem, file_information, eopatch, ftype)
         else:
             if ftype not in file_information.features or fname not in file_information.features[ftype]:
-                raise IOError(
-                    f"Feature {(ftype, fname)} does not exist in eopatch at {filesystem.getsyspath(patch_location)}."
-                )
+                raise IOError(f"Feature {(ftype, fname)} does not exist in eopatch at {patch_location}.")
             path = file_information.features[ftype][fname]
             eopatch[(ftype, fname)] = _get_feature_io_constructor(ftype)(path, filesystem)
 
@@ -217,7 +215,7 @@ def _load_meta_feature(
     elif ftype == FeatureType.META_INFO and file_information.meta_info is not None:
         eopatch.meta_info = FeatureIOJson(file_information.meta_info, filesystem)  # type: ignore[assignment]
     else:
-        raise IOError(f"Feature {ftype} does not exist in eopatch at {filesystem.getsyspath(patch_location)}.")
+        raise IOError(f"Feature {ftype} does not exist in eopatch at {patch_location}.")
 
 
 def _load_whole_feature_type(
@@ -248,9 +246,9 @@ def walk_filesystem(filesystem: FS, patch_location: str, features: FeaturesSpeci
         if object_name == "timestamp":
             warnings.warn(
                 (
-                    f"EOPatch at {filesystem.getsyspath(patch_location)} contains the deprecated naming `timestamp` for"
-                    " the `timestamps` feature. The old name will no longer be valid in the future. You can re-save"
-                    " the `EOPatch` to update it."
+                    f"EOPatch at {patch_location} contains the deprecated naming `timestamp` for the `timestamps`"
+                    " feature. The old name will no longer be valid in the future. You can re-save the `EOPatch` to"
+                    " update it."
                 ),
                 category=EODeprecationWarning,
                 stacklevel=2,


### PR DESCRIPTION
Switches return type of `walk_filesystem` to simplify a lot of the logic. Many changes were made to make it harder to screw up in the future.