### PR TITLE
[VectorToRasterTask] cast to specified dtype upon load

### DIFF
--- a/geometry/eolearn/geometry/transformations.py
+++ b/geometry/eolearn/geometry/transformations.py
@@ -187,6 +187,7 @@ class VectorToRasterTask(EOTask):
         if self.values_column is not None and self.values is not None:
             values = [self.values] if isinstance(self.values, (int, float)) else self.values
             vector_data = vector_data[vector_data[self.values_column].isin(values)]
+            vector_data[self.values_column] = vector_data[self.values_column].astype(self.raster_dtype)
 
         gpd_crs = vector_data.crs
         # This special case has to be handled because of WGS84 and lat-lon order:


### PR DESCRIPTION
As mentioned internally, there are some issues which can happen due to:
- either the VectorToRasterTask not recognizing the dtype of the column correctly, or 
- perhaps the vector file itself not containing the proper dtype

The first is an issue, while the second is the user error. Both can be bypassed by simply casting the column series into the dtype which is specified by the user (or the default). Since the data will be rasterized anyway, I believe it makes sense to convert it already at the beginning in case the `values_column` parameter is provided.

If this is not fixed, the used is forced to manually correct data possibly obtained elsewhere, or creating their own task to handle the issue, so I think it's a convenient addition, but I might be wrong.