### PR TITLE
Add interface to the old walk_filesystem function for backward compatibility

### DIFF
--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -83,7 +83,7 @@ def save_eopatch(
     patch_exists = filesystem.exists(patch_location)
 
     eopatch_features = FeatureParser(features).get_features(eopatch)
-    file_information = walk_filesystem(filesystem, patch_location) if patch_exists else FilesystemDataInfo()
+    file_information = get_filesystem_data_info(filesystem, patch_location) if patch_exists else FilesystemDataInfo()
 
     _check_collisions(overwrite_permission, eopatch_features, file_information)
 
@@ -178,7 +178,7 @@ def load_eopatch(
     lazy_loading: bool = False,
 ) -> EOPatch:
     """A utility function used by `EOPatch.load` method."""
-    file_information = walk_filesystem(filesystem, patch_location, features)
+    file_information = get_filesystem_data_info(filesystem, patch_location, features)
 
     _load_meta_features(filesystem, file_information, eopatch, features)
 
@@ -242,7 +242,9 @@ def _trigger_loading_for_eopatch_features(eopatch: EOPatch) -> None:
         list(executor.map(lambda feature: eopatch[feature], eopatch.get_features()))
 
 
-def walk_filesystem(filesystem: FS, patch_location: str, features: FeaturesSpecification = ...) -> FilesystemDataInfo:
+def get_filesystem_data_info(
+    filesystem: FS, patch_location: str, features: FeaturesSpecification = ...
+) -> FilesystemDataInfo:
     """Returns information on all eopatch files in the storage. Filters with `features` to reduce IO calls."""
     relevant_features = FeatureParser(features).get_feature_specifications()
     relevant_feature_types = {ftype for ftype, _ in relevant_features}

--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -287,6 +287,25 @@ def get_filesystem_data_info(
     return result
 
 
+def walk_filesystem(
+    filesystem: FS, patch_location: str, features: FeaturesSpecification = ...
+) -> Iterator[Tuple[FeatureType, Union[str, EllipsisType], str]]:
+    """Interface to the old walk_filesystem function which yields tuples of (feature_type, feature_name, file_path)."""
+    file_information = get_filesystem_data_info(filesystem, patch_location, features)
+
+    if file_information.bbox is not None:  # remove after BBox is never None
+        yield (FeatureType.BBOX, ..., file_information.bbox)
+
+    if file_information.timestamps is not None:
+        yield (FeatureType.TIMESTAMPS, ..., file_information.timestamps)
+
+    if file_information.meta_info is not None:
+        yield (FeatureType.META_INFO, ..., file_information.meta_info)
+
+    for feature, path in file_information.iterate_features():
+        yield (*feature, path)
+
+
 def walk_feature_type_folder(filesystem: FS, folder_path: str) -> Iterator[Tuple[str, str]]:
     """Walks a feature type subfolder of EOPatch and yields tuples (feature name, path in filesystem).
     Skips folders and files in subfolders.

--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -291,6 +291,14 @@ def walk_filesystem(
     filesystem: FS, patch_location: str, features: FeaturesSpecification = ...
 ) -> Iterator[Tuple[FeatureType, Union[str, EllipsisType], str]]:
     """Interface to the old walk_filesystem function which yields tuples of (feature_type, feature_name, file_path)."""
+    warnings.warn(
+        (
+            "The `walk_filesystem` function is marked for deprecation, check the EOPatch load/save methods to find a"
+            " suitable alternative."
+        ),
+        category=EODeprecationWarning,
+        stacklevel=2,
+    )
     file_information = get_filesystem_data_info(filesystem, patch_location, features)
 
     if file_information.bbox is not None:  # remove after BBox is never None

--- a/core/eolearn/tests/test_eodata_io.py
+++ b/core/eolearn/tests/test_eodata_io.py
@@ -370,9 +370,6 @@ def test_walk_filesystem_interface(fs_loader, features, eopatch):
         eopatch.save(**io_kwargs)
         loaded_eopatch = EOPatch.load(**io_kwargs)
 
-        collected_feature_info = list(walk_filesystem(temp_fs, io_kwargs["path"], features))
-        for ftype, fname, _ in collected_feature_info:
-            if ftype.is_meta():
-                assert ftype in loaded_eopatch
-            else:
-                assert (ftype, fname) in loaded_eopatch
+        for ftype, fname, _ in walk_filesystem(temp_fs, io_kwargs["path"], features):
+            feature_key = ftype if ftype.is_meta() else (ftype, fname) 
+            assert feature_key in loaded_eopatch

--- a/core/eolearn/tests/test_eodata_io.py
+++ b/core/eolearn/tests/test_eodata_io.py
@@ -371,5 +371,5 @@ def test_walk_filesystem_interface(fs_loader, features, eopatch):
         loaded_eopatch = EOPatch.load(**io_kwargs)
 
         for ftype, fname, _ in walk_filesystem(temp_fs, io_kwargs["path"], features):
-            feature_key = ftype if ftype.is_meta() else (ftype, fname) 
+            feature_key = ftype if ftype.is_meta() else (ftype, fname)
             assert feature_key in loaded_eopatch

--- a/core/eolearn/tests/test_eodata_io.py
+++ b/core/eolearn/tests/test_eodata_io.py
@@ -32,6 +32,7 @@ from eolearn.core.eodata_io import (
     FeatureIOJson,
     FeatureIONumpy,
     FeatureIOTimestamps,
+    walk_filesystem,
 )
 from eolearn.core.types import FeaturesSpecification
 from eolearn.core.utils.parsing import FeatureParser
@@ -351,3 +352,27 @@ def test_feature_io(constructor: Type[FeatureIO], data: Any, compress_level: int
         temp_fs.remove(file_name + file_extension)
         cache_data = feat_io.load()
         assert_feature_data_equal(loaded_data, cache_data)
+
+
+@mock_s3
+@pytest.mark.parametrize("fs_loader", FS_LOADERS)
+@pytest.mark.parametrize(
+    "features",
+    [
+        ...,
+        [(FeatureType.DATA, "data"), FeatureType.TIMESTAMPS],
+        [(FeatureType.META_INFO, "something"), (FeatureType.SCALAR_TIMELESS, ...)],
+    ],
+)
+def test_walk_filesystem_interface(fs_loader, features, eopatch):
+    with fs_loader() as temp_fs:
+        io_kwargs = dict(path="./", filesystem=temp_fs, features=features)
+        eopatch.save(**io_kwargs)
+        loaded_eopatch = EOPatch.load(**io_kwargs)
+
+        collected_feature_info = list(walk_filesystem(temp_fs, io_kwargs["path"], features))
+        for ftype, fname, _ in collected_feature_info:
+            if ftype.is_meta():
+                assert ftype in loaded_eopatch
+            else:
+                assert (ftype, fname) in loaded_eopatch


### PR DESCRIPTION
in one of the refactoring PRs we made breaking changes to the `walk_filesystem` functionality. This is now updated so that `eo-grow` tests that use this functionality don't fail with `develop` version of `eo-learn`.

Changes:
- renamed refactored function
- added interface for old function
- added tests