### PR TITLE
Add deprecation warning to EOPatches without a BBox

### DIFF
--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -44,6 +44,11 @@ T = TypeVar("T")
 Self = TypeVar("Self")
 
 LOGGER = logging.getLogger(__name__)
+MISSING_BBOX_WARNING = (
+    "Initializing an EOPatch without providing a BBox will no longer be possible in the future."
+    " EOPatches represent geolocated data and so any EOPatch without a BBox is ill-formed. Consider"
+    " using a different data structure for non-geolocated data."
+)
 
 MAX_DATA_REPR_LEN = 100
 
@@ -256,15 +261,7 @@ class EOPatch:
 
     def __attrs_post_init__(self) -> None:
         if self.bbox is None:
-            warn(
-                (
-                    "Initializing an EOPatch without providing a BBox will no longer be possible in the future."
-                    " EOPatches represent geolocated data and so any EOPatch without a BBox is ill-formed. Consider"
-                    " using a different data structure for non-geolocated data."
-                ),
-                category=EODeprecationWarning,
-                stacklevel=2,
-            )
+            warn(MISSING_BBOX_WARNING, category=EODeprecationWarning, stacklevel=2)
 
     @property
     def timestamp(self) -> List[dt.datetime]:
@@ -316,6 +313,8 @@ class EOPatch:
             return value if isinstance(value, _FeatureDict) else _create_feature_dict(feature_type, value)
 
         if feature_type is FeatureType.BBOX and (value is None or isinstance(value, BBox)):
+            if value is None:
+                warn(MISSING_BBOX_WARNING, category=EODeprecationWarning, stacklevel=2)
             return value
 
         if feature_type is FeatureType.TIMESTAMPS and isinstance(value, (tuple, list)):

--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -254,6 +254,18 @@ class EOPatch:
     bbox: Optional[BBox] = attr.ib(default=None)
     timestamps: List[dt.datetime] = attr.ib(factory=list)
 
+    def __attrs_post_init__(self) -> None:
+        if self.bbox is None:
+            warn(
+                (
+                    "Initializing an EOPatch without providing a BBox will no longer be possible in the future."
+                    " EOPatches represent geolocated data and so any EOPatch without a BBox is ill-formed. Consider"
+                    " using a different data structure for non-geolocated data."
+                ),
+                category=EODeprecationWarning,
+                stacklevel=2,
+            )
+
     @property
     def timestamp(self) -> List[dt.datetime]:
         """A property for handling the deprecated timestamp attribute.

--- a/core/eolearn/tests/pytest.ini
+++ b/core/eolearn/tests/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-log_cli = FALSE
-log_cli_level = INFO
-filterwarnings = ignore::DeprecationWarning

--- a/core/eolearn/tests/test_core_tasks.py
+++ b/core/eolearn/tests/test_core_tasks.py
@@ -300,7 +300,7 @@ def test_merge_features(axis: int, features_to_merge: List[FeatureSpec], feature
             {},
         ),
         (
-            {FeatureType.DATA: ["CLP", "CLP_S2C"]},
+            {FeatureType.DATA: ["bands", "CLP"]},
             (FeatureType.DATA, "feat_max"),
             np.floor_divide,
             {"dtype": np.float32},

--- a/core/eolearn/tests/test_core_tasks.py
+++ b/core/eolearn/tests/test_core_tasks.py
@@ -449,8 +449,8 @@ def test_extract_bands_fails(patch: EOPatch) -> None:
 @pytest.mark.parametrize(
     "features",
     [
-        {},
-        {"data": {"bands": np.arange(0, 32).reshape(1, 4, 4, 2)}},
+        {"bbox": DUMMY_BBOX},
+        {"data": {"bands": np.arange(0, 32).reshape(1, 4, 4, 2)}, "bbox": DUMMY_BBOX},
         {"data": {"bands": np.arange(0, 32).reshape(1, 4, 4, 2), "CLP": np.ones((1, 4, 4, 2))}, "bbox": DUMMY_BBOX},
     ],
 )

--- a/core/eolearn/tests/test_eodata.py
+++ b/core/eolearn/tests/test_eodata.py
@@ -285,7 +285,9 @@ def test_contains(ftype: FeatureType, fname: str, test_eopatch: EOPatch) -> None
     if ftype.has_dict():
         del test_eopatch[ftype, fname]
     else:
-        test_eopatch[ftype] = None if ftype is FeatureType.BBOX else []
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", EODeprecationWarning)
+            test_eopatch[ftype] = None if ftype is FeatureType.BBOX else []
 
     assert ftype, fname not in test_eopatch
 
@@ -414,3 +416,16 @@ def test_timestamps_deprecation():
         # so the warnings get ignored in pytest summary
         assert eop.timestamp == [datetime.datetime(4321, 5, 6)]
         assert eop.timestamp == eop.timestamps
+
+
+def test_bbox_none_deprecation():
+    with pytest.warns(EODeprecationWarning):
+        EOPatch()
+
+    eop = EOPatch(bbox=DUMMY_BBOX)
+    assert eop.bbox == DUMMY_BBOX
+
+    with pytest.warns(EODeprecationWarning):
+        eop.bbox = None
+
+    assert eop.bbox is None

--- a/core/eolearn/tests/test_eoworkflow.py
+++ b/core/eolearn/tests/test_eoworkflow.py
@@ -13,6 +13,8 @@ import datetime as dt
 import numpy as np
 import pytest
 
+from sentinelhub import CRS, BBox
+
 from eolearn.core import (
     CreateEOPatchTask,
     EONode,
@@ -177,6 +179,7 @@ def test_multiedge_workflow():
 def test_workflow_copying_eopatches():
     feature1 = FeatureType.DATA, "data1"
     feature2 = FeatureType.DATA, "data2"
+    bbox = BBox((0, 0, 1, 1), CRS(3857))
 
     create_node = EONode(CreateEOPatchTask())
     init_node = EONode(
@@ -189,13 +192,13 @@ def test_workflow_copying_eopatches():
     output_node2 = EONode(OutputTask(name="out2"), inputs=[remove_node2])
 
     workflow = EOWorkflow([create_node, init_node, remove_node1, remove_node2, output_node1, output_node2])
-    results = workflow.execute()
+    results = workflow.execute({create_node: {"bbox": bbox}})
 
     eop1 = results.outputs["out1"]
     eop2 = results.outputs["out2"]
 
-    assert eop1 == EOPatch(data={"data2": np.ones((2, 4, 4, 3), dtype=np.uint8)})
-    assert eop2 == EOPatch(data={"data1": np.ones((2, 4, 4, 3), dtype=np.uint8)})
+    assert eop1 == EOPatch(bbox=bbox, data={"data2": np.ones((2, 4, 4, 3), dtype=np.uint8)})
+    assert eop2 == EOPatch(bbox=bbox, data={"data1": np.ones((2, 4, 4, 3), dtype=np.uint8)})
 
 
 def test_workflows_reusing_nodes():

--- a/features/eolearn/tests/test_feature_manipulation.py
+++ b/features/eolearn/tests/test_feature_manipulation.py
@@ -22,6 +22,8 @@ from eolearn.features import FilterTimeSeriesTask, LinearFunctionTask, SimpleFil
 from eolearn.features.feature_manipulation import SpatialResizeTask
 from eolearn.features.utils import ResizeParam
 
+DUMMY_BBOX = BBox((0, 0, 1, 1), CRS(3857))
+
 
 @pytest.mark.parametrize(
     "feature", [(FeatureType.DATA, "BANDS-S2-L1C"), FeatureType.TIMESTAMPS, (FeatureType.LABEL, "IS_CLOUDLESS")]
@@ -68,7 +70,7 @@ def test_content_after_time_filter():
 
     new_start, new_end = 4, -3
 
-    eop = EOPatch(timestamps=timestamps, data={"data": data})
+    eop = EOPatch(bbox=DUMMY_BBOX, timestamps=timestamps, data={"data": data})
 
     filter_task = FilterTimeSeriesTask(start_date=timestamps[new_start], end_date=timestamps[new_end])
     filtered_eop = filter_task.execute(eop)
@@ -137,7 +139,7 @@ def test_value_fillout():
     feature = (FeatureType.DATA, "TEST")
     shape = (8, 10, 10, 5)
     data = np.random.randint(0, 100, size=shape).astype(float)
-    eopatch = EOPatch(data={"TEST": data})
+    eopatch = EOPatch(bbox=DUMMY_BBOX, data={"TEST": data})
 
     # nothing to be filled, return the same eopatch object immediately
     eopatch_new = ValueFilloutTask(feature, operations="fb", axis=0)(eopatch)
@@ -188,7 +190,7 @@ def test_value_fillout():
 
 
 def test_linear_function_task():
-    eopatch = EOPatch(bbox=BBox((0, 0, 1, 1), CRS(3857)))
+    eopatch = EOPatch(bbox=DUMMY_BBOX)
 
     data_feature = (FeatureType.DATA, "DATA_TEST")
     data_result_feature = (FeatureType.DATA, "DATA_TRANSFORMED")

--- a/features/eolearn/tests/test_temporal_features.py
+++ b/features/eolearn/tests/test_temporal_features.py
@@ -19,9 +19,11 @@ from sentinelhub import CRS, BBox
 from eolearn.core import EOPatch, FeatureType
 from eolearn.features import AddMaxMinNDVISlopeIndicesTask, AddMaxMinTemporalIndicesTask, AddSpatioTemporalFeaturesTask
 
+DUMMY_BBOX = BBox((0, 0, 1, 1), CRS(3857))
+
 
 def test_temporal_indices():
-    eopatch = EOPatch(bbox=BBox((0, 0, 1, 1), CRS(3857)))
+    eopatch = EOPatch(bbox=DUMMY_BBOX)
     t, h, w, c = 5, 3, 3, 2
 
     ndvi_shape = (t, h, w, 1)
@@ -60,7 +62,7 @@ def test_temporal_indices():
 
 def test_ndvi_slope_indices():
     timestamps = [date(2018, 3, 1) + timedelta(days=x) for x in range(11)]
-    eopatch = EOPatch(timestamps=list(timestamps))
+    eopatch = EOPatch(bbox=DUMMY_BBOX, timestamps=list(timestamps))
 
     t, h, w = (10, 3, 3)
     ndvi_shape = (t, h, w, 1)
@@ -101,7 +103,7 @@ def test_ndvi_slope_indices():
 
 def test_stf_task():
     timestamps = [date(2018, 3, 1) + timedelta(days=x) for x in range(11)]
-    eopatch = EOPatch(timestamps=list(timestamps))
+    eopatch = EOPatch(bbox=DUMMY_BBOX, timestamps=list(timestamps))
 
     t, h, w, c = 10, 3, 3, 2
 

--- a/io/requirements.txt
+++ b/io/requirements.txt
@@ -4,6 +4,5 @@ eo-learn-core
 fiona>=1.8.18
 geopandas>=0.8.1
 rasterio>=1.2.7
-rtree
 sentinelhub>=3.8.0
 typing-extensions

--- a/io/requirements.txt
+++ b/io/requirements.txt
@@ -4,5 +4,6 @@ eo-learn-core
 fiona>=1.8.18
 geopandas>=0.8.1
 rasterio>=1.2.7
+rtree # might be redundant after 3.7 is dropped due to new geopandas version
 sentinelhub>=3.8.0
 typing-extensions

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,13 +2,11 @@ codecov
 hypothesis
 moto
 mypy>=0.990
-nbval
 pylint>=2.14.0
 pytest>=7.0.0
 pytest-cov
 pytest-lazy-fixture
 pytest-mock
 ray[default]
-responses
 twine
 types-python-dateutil

--- a/visualization/requirements.txt
+++ b/visualization/requirements.txt
@@ -2,5 +2,4 @@ eo-learn-core
 graphviz>=0.10.1
 jinja2
 matplotlib
-pydot
 pygments


### PR DESCRIPTION
Sorry, sorry, i know, i did a lot of changes that are not 100% related:
1. Added deprecation warning to init and to setter, added test for it
2. Removed pytest.ini because it was messing with warnings depending on which folder you called `pytest` from
3. Adjusted tests so that the warnings from point 1. is not triggered
4. Adjusted a test for zip task, because it raised a warning about dividing by zero
5. cleaned up requirements :see_no_evil: 