### PR TITLE
Feat/docs update

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,8 +6,8 @@ dependencies:
 - pip
 - python=3.10
 - pip:
-  - Sphinx~=4.0
-  - sphinx_rtd_theme>=1.0.0
+  - Sphinx
+  - sphinx_rtd_theme
   - nbsphinx
   - jupyter
   - sphinx_mdinclude

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - sphinx_rtd_theme>=1.0.0
   - nbsphinx
   - jupyter
-  - m2r2
+  - sphinx_mdinclude
 
   - ./../core
   - ./../coregistration

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,7 +34,7 @@ from eolearn.core import EOTask
 
 # General information about the project.
 project = "eo-learn"
-copyright = "2018, eo-learn"
+copyright = "2017-, Sinergise"
 author = "Sinergise EO research team"
 doc_title = "eo-learn Documentation"
 
@@ -64,10 +64,10 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.autosummary",
     "sphinx.ext.viewcode",
+    "sphinx_mdinclude",
     "nbsphinx",
     "sphinx_rtd_theme",
     "IPython.sphinxext.ipython_console_highlighting",
-    "m2r2",
 ]
 
 # Include typehints in descriptions
@@ -228,7 +228,7 @@ intersphinx_mapping = {"https://docs.python.org/3.8/": None}
 # -- Custom settings ----------------------------------------------
 
 # When Sphinx documents class signature it prioritizes __new__ method over __init__ method. The following hack puts
-# EOTask.__new__ method the the blacklist so that __init__ method signature will be taken instead. This seems the
+# EOTask.__new__ method to the blacklist so that __init__ method signature will be taken instead. This seems the
 # cleanest way even though a private object is accessed.
 sphinx.ext.autodoc._CLASS_NEW_BLACKLIST.append("{0.__module__}.{0.__qualname__}".format(EOTask.__new__))
 
@@ -467,4 +467,4 @@ def create_github_url(
 def setup(app):
     app.connect("builder-inited", run_apidoc)
     app.connect("html-page-context", configure_github_link)
-    app.connect("autodoc-process-docstring", sphinx.ext.autodoc.between("Credits:", what=["module"], exclude=True))
+    app.connect("autodoc-process-docstring", sphinx.ext.autodoc.between("Copyright", what=["module"], exclude=True))

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -7,9 +7,9 @@
 -e ./mask
 -e ./ml_tools
 -e ./visualization
-jinja2==3.0.3
+jinja2
 jupyter
-m2r2
 nbsphinx
 sphinx
-sphinx_rtd_theme>=1.0.0
+sphinx_rtd_theme
+sphinx_mdinclude

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -10,5 +10,5 @@
 jupyter
 nbsphinx
 sphinx
-sphinx_rtd_theme
 sphinx_mdinclude
+sphinx_rtd_theme

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -7,7 +7,7 @@
 -e ./mask
 -e ./ml_tools
 -e ./visualization
-jinja2
+jinja2==3.0.3
 jupyter
 nbsphinx
 sphinx

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -7,7 +7,6 @@
 -e ./mask
 -e ./ml_tools
 -e ./visualization
-jinja2==3.0.3
 jupyter
 nbsphinx
 sphinx


### PR DESCRIPTION
This PR does the following:

 * replaces `m2r2` with `sphinx_mbinclude`
 * removes `m2r2` from requirements and environment
 * removes `jinja2` from requirements, as it gets pulled in with sphinx
 * unfixes sphinx version
 * cleans header docs after changes 