### PR TITLE
Add affiliation Moldenhauer

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -141,6 +141,7 @@
         },
         {
             "name": "Colin Moldenhauer",
+            "affiliation": "Technical University of Munich",
             "type": "Other"
         },
         {

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -42,7 +42,7 @@ page or mine the [commit history](https://github.com/sentinel-hub/eo-learn/commi
 * Hugo Fournier (Magellium)
 * Ben Huff
 * Filip Koprivec (Jožef Stefan Institute)
-* Colin Moldenhauer
+* Colin Moldenhauer (Technical University of Munich)
 * William Ouellette (TomTom)
 * Radoslav Pitoňák
 * Johannes Schmid (GeoVille)


### PR DESCRIPTION
My contributions to eo-learn were developed as part of a TUM project, hence I would appreciate if the affiliation could be added.