### PR TITLE
Enable `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,11 @@ repos:
             --ignore-init-module-imports,
           ]
 
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: "v0.0.269"
+    hooks:
+      - id: ruff
+
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:

--- a/core/eolearn/core/constants.py
+++ b/core/eolearn/core/constants.py
@@ -20,12 +20,12 @@ TIMESTAMP_COLUMN = "TIMESTAMP"
 
 def _warn_and_adjust(name: str) -> str:
     # since we stick with `UPPER` for attributes and `lower` for values, we include both to reuse function
-    deprecation_msg = None
+    deprecation_msg = None  # placeholder
     if name in ("TIMESTAMP", "timestamp"):
         name = "TIMESTAMPS" if name == "TIMESTAMP" else "timestamps"
 
     if deprecation_msg:
-        warnings.warn(deprecation_msg, category=EODeprecationWarning, stacklevel=3)  # type: ignore
+        warnings.warn(deprecation_msg, category=EODeprecationWarning, stacklevel=3)  # type: ignore[unreachable]
     return name
 
 

--- a/core/eolearn/core/constants.py
+++ b/core/eolearn/core/constants.py
@@ -32,13 +32,13 @@ def _warn_and_adjust(name: str) -> str:
 class EnumWithDeprecations(EnumMeta):
     """A custom EnumMeta class for catching the deprecated Enum members of the FeatureType Enum class."""
 
-    def __getattribute__(cls, name: str) -> Any:
+    def __getattribute__(cls, name: str) -> Any:  # noqa[N805]
         return super().__getattribute__(_warn_and_adjust(name))
 
-    def __getitem__(cls, name: str) -> Any:
+    def __getitem__(cls, name: str) -> Any:  # noqa[N805]
         return super().__getitem__(_warn_and_adjust(name))
 
-    def __call__(cls, value: str, *args: Any, **kwargs: Any) -> Any:
+    def __call__(cls, value: str, *args: Any, **kwargs: Any) -> Any:  # noqa[N805]
         return super().__call__(_warn_and_adjust(value), *args, **kwargs)
 
 

--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -49,7 +49,7 @@ class DeepCopyTask(CopyTask):
         return eopatch.copy(features=self.features, deep=True)
 
 
-class IOTask(EOTask, metaclass=ABCMeta):  # noqa B024
+class IOTask(EOTask, metaclass=ABCMeta):  # noqa: B024
     """An abstract Input/Output task that can handle a path and a filesystem object."""
 
     def __init__(

--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -49,7 +49,7 @@ class DeepCopyTask(CopyTask):
         return eopatch.copy(features=self.features, deep=True)
 
 
-class IOTask(EOTask, metaclass=ABCMeta):  # noqa: B024
+class IOTask(EOTask, metaclass=ABCMeta):
     """An abstract Input/Output task that can handle a path and a filesystem object."""
 
     def __init__(

--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -447,10 +447,10 @@ class EOPatch:
 
             l_bracket, r_bracket = ("[", "]") if isinstance(value, list) else ("(", ")")
             if isinstance(value, (list, tuple)) and len(value) > 2:
-                repr_str = f"{l_bracket}{repr(value[0])}, ..., {repr(value[-1])}{r_bracket}"
+                repr_str = f"{l_bracket}{value[0]!r}, ..., {value[-1]!r}{r_bracket}"
 
             if len(repr_str) > MAX_DATA_REPR_LEN and isinstance(value, (list, tuple)) and len(value) > 1:
-                repr_str = f"{l_bracket}{repr(value[0])}, ...{r_bracket}"
+                repr_str = f"{l_bracket}{value[0]!r}, ...{r_bracket}"
 
             if len(repr_str) > MAX_DATA_REPR_LEN:
                 repr_str = str(type(value))

--- a/core/eolearn/core/eoexecution.py
+++ b/core/eolearn/core/eoexecution.py
@@ -237,7 +237,7 @@ class EOExecutor:
                 logger.addHandler(handler)
                 return logger, handler
             except BaseException as exception:
-                warnings.warn(f"Failed to start logging with exception: {repr(exception)}", category=EORuntimeWarning)
+                warnings.warn(f"Failed to start logging with exception: {exception!r}", category=EORuntimeWarning)
 
         return None, None
 
@@ -249,7 +249,7 @@ class EOExecutor:
                 handler.close()
                 logger.removeHandler(handler)
             except BaseException as exception:
-                warnings.warn(f"Failed to end logging with exception: {repr(exception)}", category=EORuntimeWarning)
+                warnings.warn(f"Failed to end logging with exception: {exception!r}", category=EORuntimeWarning)
 
     @classmethod
     def _execute_workflow(cls, data: _ProcessingData) -> WorkflowResults:
@@ -390,5 +390,5 @@ class EOExecutor:
             with self.filesystem.open(log_path, "r") as file_handle:
                 return file_handle.read()
         except BaseException as exception:
-            warnings.warn(f"Failed to load logs with exception: {repr(exception)}", category=EORuntimeWarning)
+            warnings.warn(f"Failed to load logs with exception: {exception!r}", category=EORuntimeWarning)
             return "Failed to load logs"

--- a/core/eolearn/core/extra/ray.py
+++ b/core/eolearn/core/extra/ray.py
@@ -27,7 +27,7 @@ _OutputType = TypeVar("_OutputType")
 class RayExecutor(EOExecutor):
     """A special type of `EOExecutor` that works with Ray framework"""
 
-    def run(self, **tqdm_kwargs: Any) -> List[WorkflowResults]:  # type: ignore
+    def run(self, **tqdm_kwargs: Any) -> List[WorkflowResults]:  # type: ignore[override]
         """Runs the executor using a Ray cluster
 
         Before calling this method make sure to initialize a Ray cluster using `ray.init`.

--- a/core/eolearn/core/types.py
+++ b/core/eolearn/core/types.py
@@ -17,7 +17,7 @@ if sys.version_info >= (3, 10):
     from types import EllipsisType  # pylint: disable=ungrouped-imports
     from typing import TypeAlias
 else:
-    import builtins  # noqa: F401
+    import builtins  # noqa: F401, RUF100
 
     from typing_extensions import TypeAlias
 

--- a/core/eolearn/core/utils/fs.py
+++ b/core/eolearn/core/utils/fs.py
@@ -22,6 +22,9 @@ from fs_s3fs import S3FS
 
 from sentinelhub import SHConfig
 
+# because we access internals when pickling FS
+# ruff: noqa: SLF001
+
 
 def get_filesystem(
     path: Union[str, Path], create: bool = False, config: Optional[SHConfig] = None, **kwargs: Any

--- a/core/eolearn/core/utils/types.py
+++ b/core/eolearn/core/utils/types.py
@@ -2,7 +2,7 @@
 from warnings import warn
 
 from ..exceptions import EODeprecationWarning
-from ..types import *  # noqa # pylint: disable=wildcard-import,unused-wildcard-import
+from ..types import *  # noqa: 403 # pylint: disable=wildcard-import,unused-wildcard-import
 
 warn(
     "The module `eolearn.core.utils.types` is deprecated, use `eolearn.core.types` instead.",

--- a/core/eolearn/tests/test_core_tasks.py
+++ b/core/eolearn/tests/test_core_tasks.py
@@ -386,7 +386,7 @@ def test_map_features_fails(patch: EOPatch) -> None:
     ],
 )
 def test_map_kwargs_passing(input_feature: FeatureSpec, kwargs: Dict[str, Any], patch: EOPatch) -> None:
-    def kwargs_map(data, *, some=3, **kwargs) -> tuple:
+    def kwargs_map(_, *, some=3, **kwargs) -> tuple:
         return some, kwargs
 
     mapped_patch = MapFeatureTask(input_feature, (FeatureType.META_INFO, "kwargs"), kwargs_map, **kwargs)(patch)

--- a/core/eolearn/tests/test_core_tasks.py
+++ b/core/eolearn/tests/test_core_tasks.py
@@ -210,7 +210,7 @@ def test_initialize_feature(
     expected_data = init_val * np.ones(shape)
     patch = InitializeFeatureTask(feature_spec, shape=shape, init_value=init_val)(patch)
 
-    assert all([np.array_equal(patch[features], expected_data) for features in parse_features(feature_spec)])
+    assert all(np.array_equal(patch[features], expected_data) for features in parse_features(feature_spec))
 
 
 @pytest.mark.parametrize(
@@ -225,7 +225,7 @@ def test_initialize_feature_with_spec(
     expected_data = init_val * np.ones(patch[shape].shape)
 
     patch = InitializeFeatureTask(feature_spec, shape=shape, init_value=init_val)(patch)
-    assert all([np.array_equal(patch[features], expected_data) for features in parse_features(feature_spec)])
+    assert all(np.array_equal(patch[features], expected_data) for features in parse_features(feature_spec))
 
 
 def test_initialize_feature_fails(patch: EOPatch) -> None:

--- a/core/eolearn/tests/test_core_tasks.py
+++ b/core/eolearn/tests/test_core_tasks.py
@@ -47,6 +47,7 @@ from eolearn.core.utils.parsing import parse_features
 from eolearn.core.utils.testing import PatchGeneratorConfig, assert_feature_data_equal, generate_eopatch
 
 DUMMY_BBOX = BBox((0, 0, 1, 1), CRS(3857))
+# ruff: noqa: NPY002
 
 
 @pytest.fixture(name="patch")

--- a/core/eolearn/tests/test_eodata.py
+++ b/core/eolearn/tests/test_eodata.py
@@ -21,6 +21,7 @@ from eolearn.core.types import FeatureSpec, FeaturesSpecification
 from eolearn.core.utils.testing import assert_feature_data_equal, generate_eopatch
 
 DUMMY_BBOX = BBox((0, 0, 1, 1), CRS(3857))
+# ruff: noqa: NPY002
 
 
 @pytest.fixture(name="mini_eopatch")

--- a/core/eolearn/tests/test_eodata_merge.py
+++ b/core/eolearn/tests/test_eodata_merge.py
@@ -132,7 +132,7 @@ def test_timeless_merge():
 
 def test_vector_merge():
     bbox = BBox((1, 2, 3, 4), CRS.WGS84)
-    df = GeoDataFrame(
+    dummy_gdf = GeoDataFrame(
         {
             "values": [1, 2],
             TIMESTAMP_COLUMN: [dt.datetime(2017, 1, 1, 10, 4, 7), dt.datetime(2017, 1, 4, 10, 14, 5)],
@@ -141,7 +141,7 @@ def test_vector_merge():
         crs=bbox.crs.pyproj_crs(),
     )
 
-    eop1 = EOPatch(bbox=bbox, vector_timeless={"vectors": df})
+    eop1 = EOPatch(bbox=bbox, vector_timeless={"vectors": dummy_gdf})
 
     assert eop1 == merge_eopatches(eop1, eop1)
 

--- a/core/eolearn/tests/test_eoexecutor.py
+++ b/core/eolearn/tests/test_eoexecutor.py
@@ -69,27 +69,19 @@ def test_nodes_fixture():
     example = EONode(ExampleTask())
     foo = EONode(FooTask(), inputs=[example, example])
     output = EONode(OutputTask("output"), inputs=[foo])
-    nodes = {"example": example, "foo": foo, "output": output}
-    return nodes
+    return {"example": example, "foo": foo, "output": output}
 
 
 @pytest.fixture(name="workflow")
 def workflow_fixture(test_nodes):
-    workflow = EOWorkflow(list(test_nodes.values()))
-    return workflow
+    return EOWorkflow(list(test_nodes.values()))
 
 
 @pytest.fixture(name="execution_kwargs")
 def execution_kwargs_fixture(test_nodes):
     example_node = test_nodes["example"]
 
-    execution_kwargs = [
-        {example_node: {"arg1": 1}},
-        {},
-        {example_node: {"arg1": 3, "arg3": 10}},
-        {example_node: {"arg1": None}},
-    ]
-    return execution_kwargs
+    return [{example_node: {"arg1": 1}}, {}, {example_node: {"arg1": 3, "arg3": 10}}, {example_node: {"arg1": None}}]
 
 
 class DummyFilesystemFileHandler(FileHandler):

--- a/core/eolearn/tests/test_eoworkflow.py
+++ b/core/eolearn/tests/test_eoworkflow.py
@@ -27,7 +27,7 @@ from eolearn.core import (
 from eolearn.core.eoworkflow import NodeStats
 
 
-class CustomException(ValueError):
+class CustomExceptionError(ValueError):
     pass
 
 
@@ -48,7 +48,7 @@ class IncTask(EOTask):
 
 class ExceptionTask(EOTask):
     def execute(self, *_, **__):
-        raise CustomException
+        raise CustomExceptionError
 
 
 def test_workflow_arguments():
@@ -272,7 +272,7 @@ def test_exception_handling():
     increase_node = EONode(IncTask(), inputs=[exception_node])
     workflow = EOWorkflow([input_node, exception_node, increase_node])
 
-    with pytest.raises(CustomException):
+    with pytest.raises(CustomExceptionError):
         workflow.execute()
 
     results = workflow.execute(raise_errors=False)
@@ -288,7 +288,7 @@ def test_exception_handling():
         assert node_stats.node_name == node.name
 
         if node is exception_node:
-            assert isinstance(node_stats.exception, CustomException)
+            assert isinstance(node_stats.exception, CustomExceptionError)
             assert node_stats.exception_traceback.startswith("Traceback")
         else:
             assert node_stats.exception is None

--- a/core/eolearn/tests/test_extra/test_ray.py
+++ b/core/eolearn/tests/test_extra/test_ray.py
@@ -63,27 +63,19 @@ def test_nodes_fixture():
     example = EONode(ExampleTask())
     foo = EONode(FooTask(), inputs=[example, example])
     output = EONode(OutputTask("output"), inputs=[foo])
-    nodes = {"example": example, "foo": foo, "output": output}
-    return nodes
+    return {"example": example, "foo": foo, "output": output}
 
 
 @pytest.fixture(name="workflow")
 def workflow_fixture(test_nodes):
-    workflow = EOWorkflow(list(test_nodes.values()))
-    return workflow
+    return EOWorkflow(list(test_nodes.values()))
 
 
 @pytest.fixture(name="execution_kwargs")
 def execution_kwargs_fixture(test_nodes):
     example_node = test_nodes["example"]
 
-    execution_kwargs = [
-        {example_node: {"arg1": 1}},
-        {},
-        {example_node: {"arg1": 3, "arg3": 10}},
-        {example_node: {"arg1": None}},
-    ]
-    return execution_kwargs
+    return [{example_node: {"arg1": 1}}, {}, {example_node: {"arg1": 3, "arg3": 10}}, {example_node: {"arg1": None}}]
 
 
 def test_fail_without_ray(workflow, execution_kwargs):

--- a/core/eolearn/tests/test_extra/test_ray.py
+++ b/core/eolearn/tests/test_extra/test_ray.py
@@ -19,6 +19,8 @@ from eolearn.core import EOExecutor, EONode, EOTask, EOWorkflow, WorkflowResults
 from eolearn.core.eoworkflow_tasks import OutputTask
 from eolearn.core.extra.ray import RayExecutor, join_ray_futures, join_ray_futures_iter, parallelize_with_ray
 
+# ruff: noqa: ARG001
+
 
 class ExampleTask(EOTask):
     def execute(self, *_, **kwargs):

--- a/core/eolearn/tests/test_graph.py
+++ b/core/eolearn/tests/test_graph.py
@@ -129,4 +129,4 @@ def test_resolve_dependencies(edges):
             graph.topologically_ordered_vertices()
     else:
         vertex_position = {vertex: i for i, vertex in enumerate(graph.topologically_ordered_vertices())}
-        assert functools.reduce(lambda P, Q: P and Q, [vertex_position[u] < vertex_position[v] for u, v in edges])
+        assert functools.reduce(lambda p, q: p and q, [vertex_position[u] < vertex_position[v] for u, v in edges])

--- a/core/eolearn/tests/test_graph.py
+++ b/core/eolearn/tests/test_graph.py
@@ -124,7 +124,7 @@ def test_del_vertex():
 def test_resolve_dependencies(edges):
     graph = DirectedGraph.from_edges(edges)
 
-    if DirectedGraph._is_cyclic(graph):
+    if DirectedGraph._is_cyclic(graph):  # noqa[SLF001]
         with pytest.raises(CyclicDependencyError):
             graph.topologically_ordered_vertices()
     else:

--- a/core/eolearn/tests/test_utils/test_fs.py
+++ b/core/eolearn/tests/test_utils/test_fs.py
@@ -119,7 +119,7 @@ def test_filesystem_serialization(filesystem: FS, compare_params: List[str]):
 
     unpickled_filesystem = unpickle_fs(pickled_filesystem)
     assert filesystem is not unpickled_filesystem
-    assert isinstance(unpickled_filesystem._lock, RLock)
+    assert isinstance(unpickled_filesystem._lock, RLock)  # noqa[SLF001]
     for param in compare_params:
         assert getattr(filesystem, param) == getattr(unpickled_filesystem, param)
 

--- a/core/eolearn/tests/test_utils/test_parsing.py
+++ b/core/eolearn/tests/test_utils/test_parsing.py
@@ -10,7 +10,7 @@ from eolearn.core.utils.testing import generate_eopatch
 
 @dataclass
 class ParserTestCase:
-    input: FeaturesSpecification
+    parser_input: FeaturesSpecification
     features: List[FeatureSpec]
     renaming: List[FeatureRenameSpec]
     specifications: Optional[List[Tuple[FeatureType, Union[str, EllipsisType]]]] = None
@@ -24,30 +24,30 @@ def get_test_case_description(test_case: ParserTestCase) -> str:
 @pytest.mark.parametrize(
     "test_case",
     [
-        ParserTestCase(input=[], features=[], renaming=[], specifications=[], description="Empty input"),
+        ParserTestCase(parser_input=[], features=[], renaming=[], specifications=[], description="Empty input"),
         ParserTestCase(
-            input=(FeatureType.DATA, "bands"),
+            parser_input=(FeatureType.DATA, "bands"),
             features=[(FeatureType.DATA, "bands")],
             renaming=[(FeatureType.DATA, "bands", "bands")],
             specifications=[(FeatureType.DATA, "bands")],
             description="Singleton feature",
         ),
         ParserTestCase(
-            input=FeatureType.BBOX,
+            parser_input=FeatureType.BBOX,
             features=[(FeatureType.BBOX, None)],
             renaming=[(FeatureType.BBOX, None, None)],
             specifications=[(FeatureType.BBOX, ...)],
             description="BBox feature",
         ),
         ParserTestCase(
-            input=(FeatureType.MASK, "CLM", "new_CLM"),
+            parser_input=(FeatureType.MASK, "CLM", "new_CLM"),
             features=[(FeatureType.MASK, "CLM")],
             renaming=[(FeatureType.MASK, "CLM", "new_CLM")],
             specifications=[(FeatureType.MASK, "CLM")],
             description="Renamed feature",
         ),
         ParserTestCase(
-            input=[FeatureType.BBOX, (FeatureType.DATA, "bands"), (FeatureType.VECTOR_TIMELESS, "geoms")],
+            parser_input=[FeatureType.BBOX, (FeatureType.DATA, "bands"), (FeatureType.VECTOR_TIMELESS, "geoms")],
             features=[(FeatureType.BBOX, None), (FeatureType.DATA, "bands"), (FeatureType.VECTOR_TIMELESS, "geoms")],
             renaming=[
                 (FeatureType.BBOX, None, None),
@@ -62,7 +62,7 @@ def get_test_case_description(test_case: ParserTestCase) -> str:
             description="List of inputs",
         ),
         ParserTestCase(
-            input=((FeatureType.TIMESTAMPS, ...), (FeatureType.MASK, "CLM"), (FeatureType.SCALAR, "a", "b")),
+            parser_input=((FeatureType.TIMESTAMPS, ...), (FeatureType.MASK, "CLM"), (FeatureType.SCALAR, "a", "b")),
             features=[(FeatureType.TIMESTAMPS, None), (FeatureType.MASK, "CLM"), (FeatureType.SCALAR, "a")],
             renaming=[
                 (FeatureType.TIMESTAMPS, None, None),
@@ -73,7 +73,7 @@ def get_test_case_description(test_case: ParserTestCase) -> str:
             description="Tuple of inputs with rename",
         ),
         ParserTestCase(
-            input={
+            parser_input={
                 FeatureType.DATA: ["bands_S2", ("bands_l8", "BANDS_L8")],
                 FeatureType.MASK_TIMELESS: [],
                 FeatureType.BBOX: ...,
@@ -104,7 +104,7 @@ def get_test_case_description(test_case: ParserTestCase) -> str:
 )
 def test_feature_parser_no_eopatch(test_case: ParserTestCase):
     """Test that input is parsed according to our expectations. No EOPatch provided."""
-    parser = FeatureParser(test_case.input)
+    parser = FeatureParser(test_case.parser_input)
     assert parser.get_features() == test_case.features
     assert parser.get_renamed_features() == test_case.renaming
     assert parser.get_feature_specifications() == test_case.specifications
@@ -227,7 +227,7 @@ def test_all_features_allowed_feature_types(
     "test_case",
     [
         ParserTestCase(
-            input=...,
+            parser_input=...,
             features=[
                 (FeatureType.BBOX, None),
                 (FeatureType.DATA, "data"),
@@ -251,13 +251,13 @@ def test_all_features_allowed_feature_types(
             description="Get-all",
         ),
         ParserTestCase(
-            input=(FeatureType.DATA, ...),
+            parser_input=(FeatureType.DATA, ...),
             features=[(FeatureType.DATA, "data"), (FeatureType.DATA, "CLP")],
             renaming=[(FeatureType.DATA, "data", "data"), (FeatureType.DATA, "CLP", "CLP")],
             description="Get-all for a feature type",
         ),
         ParserTestCase(
-            input=[
+            parser_input=[
                 FeatureType.BBOX,
                 FeatureType.MASK,
                 (FeatureType.META_INFO, ...),
@@ -280,7 +280,7 @@ def test_all_features_allowed_feature_types(
             description="Sequence with ellipsis",
         ),
         ParserTestCase(
-            input={
+            parser_input={
                 FeatureType.DATA: ["data", ("CLP", "new_CLP")],
                 FeatureType.MASK_TIMELESS: ...,
             },
@@ -293,14 +293,17 @@ def test_all_features_allowed_feature_types(
             description="Dictionary with ellipsis",
         ),
         ParserTestCase(
-            input={FeatureType.VECTOR: ...}, features=[], renaming=[], description="Request all of an empty feature"
+            parser_input={FeatureType.VECTOR: ...},
+            features=[],
+            renaming=[],
+            description="Request all of an empty feature",
         ),
     ],
     ids=get_test_case_description,
 )
 def test_feature_parser_with_eopatch(test_case: ParserTestCase, eopatch: EOPatch):
     """Test that input is parsed according to our expectations. EOPatch provided."""
-    parser = FeatureParser(test_case.input)
+    parser = FeatureParser(test_case.parser_input)
     assert parser.get_features(eopatch) == test_case.features, f"{parser.get_features(eopatch)}"
     assert parser.get_renamed_features(eopatch) == test_case.renaming
 

--- a/core/eolearn/tests/test_utils/test_raster.py
+++ b/core/eolearn/tests/test_utils/test_raster.py
@@ -13,6 +13,8 @@ from numpy.testing import assert_array_equal
 
 from eolearn.core.utils.raster import constant_pad, fast_nanpercentile
 
+# ruff: noqa: NPY002
+
 
 @pytest.mark.parametrize("size", [0, 5])
 @pytest.mark.parametrize("percentile", [0, 1.5, 50, 80.99, 100])

--- a/core/setup.py
+++ b/core/setup.py
@@ -7,9 +7,7 @@ def get_long_description():
     this_directory = os.path.abspath(os.path.dirname(__file__))
 
     with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
-        long_description = f.read()
-
-    return long_description
+        return f.read()
 
 
 def parse_requirements(file):

--- a/coregistration/eolearn/coregistration/coregistration.py
+++ b/coregistration/eolearn/coregistration/coregistration.py
@@ -216,6 +216,5 @@ def get_gradient(src: np.ndarray) -> np.ndarray:
     grad_x = cv2.Sobel(src, cv2.CV_32F, 1, 0, ksize=3)
     grad_y = cv2.Sobel(src, cv2.CV_32F, 0, 1, ksize=3)
 
-    # Combine the two gradients
-    grad = cv2.addWeighted(np.absolute(grad_x), 0.5, np.absolute(grad_y), 0.5, 0)
-    return grad
+    # Combine and return the two gradients
+    return cv2.addWeighted(np.absolute(grad_x), 0.5, np.absolute(grad_y), 0.5, 0)

--- a/coregistration/setup.py
+++ b/coregistration/setup.py
@@ -7,9 +7,7 @@ def get_long_description():
     this_directory = os.path.abspath(os.path.dirname(__file__))
 
     with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
-        long_description = f.read()
-
-    return long_description
+        return f.read()
 
 
 def parse_requirements(file):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ import eolearn.geometry
 import eolearn.io
 import eolearn.mask
 import eolearn.ml_tools
-import eolearn.visualization  # noqa
+import eolearn.visualization  # noqa: F401
 from eolearn.core import EOTask
 
 # -- Project information -----------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,7 +34,7 @@ from eolearn.core import EOTask
 
 # General information about the project.
 project = "eo-learn"
-copyright = "2017-, Sinergise"
+copyright = "2017-, Sinergise"  # noqa[A001]
 author = "Sinergise EO research team"
 doc_title = "eo-learn Documentation"
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -289,13 +289,7 @@ def process_readme():
 
     chapters = ["\n".join(chapter) for chapter in chapters]
 
-    intro = "\n".join(
-        [
-            chapter
-            for chapter in chapters
-            if not (chapter.startswith("## Install") or chapter.startswith("## Documentation"))
-        ]
-    )
+    intro = "\n".join([chapter for chapter in chapters if not (chapter.startswith(("## Install", "## Documentation")))])
     install = "\n".join([chapter for chapter in chapters if chapter.startswith("## Install")])
 
     intro = intro.replace("./CONTRIBUTING.md", "contribute.html")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,7 +34,7 @@ from eolearn.core import EOTask
 
 # General information about the project.
 project = "eo-learn"
-copyright = "2017-, Sinergise"  # noqa[A001]
+copyright = "2017-, Sinergise"  # noqa: A001
 author = "Sinergise EO research team"
 doc_title = "eo-learn Documentation"
 
@@ -77,7 +77,7 @@ autodoc_type_aliases = {
     "SingleFeatureSpec": "eolearn.core.types.SingleFeatureSpec",
 }
 
-# Both the class’ and the __init__ method’s docstring are concatenated and inserted.
+# Both the class' and the __init__ method's docstring are concatenated and inserted.
 autoclass_content = "both"
 
 # Content is in the same order as in module

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -230,7 +230,7 @@ intersphinx_mapping = {"https://docs.python.org/3.8/": None}
 # When Sphinx documents class signature it prioritizes __new__ method over __init__ method. The following hack puts
 # EOTask.__new__ method to the blacklist so that __init__ method signature will be taken instead. This seems the
 # cleanest way even though a private object is accessed.
-sphinx.ext.autodoc._CLASS_NEW_BLACKLIST.append("{0.__module__}.{0.__qualname__}".format(EOTask.__new__))
+sphinx.ext.autodoc._CLASS_NEW_BLACKLIST.append("{0.__module__}.{0.__qualname__}".format(EOTask.__new__))  # noqa[SLF001]
 
 
 EXAMPLES_FOLDER = "./examples"

--- a/features/eolearn/features/radiometric_normalization.py
+++ b/features/eolearn/features/radiometric_normalization.py
@@ -133,8 +133,7 @@ class BaseCompositingTask(EOTask, metaclass=ABCMeta):
         ind = f_arr.astype("int16")
         y_val, x_val = ind_tmp.shape[1], ind_tmp.shape[2]
         y_val, x_val = np.ogrid[0:y_val, 0:x_val]  # type: ignore[assignment]
-        idx = np.where(valid_obs == 0, self.max_index, ind_tmp[ind, y_val, x_val])
-        return idx
+        return np.where(valid_obs == 0, self.max_index, ind_tmp[ind, y_val, x_val])
 
     @abstractmethod
     def _get_reference_band(self, data: np.ndarray) -> np.ndarray:
@@ -150,8 +149,7 @@ class BaseCompositingTask(EOTask, metaclass=ABCMeta):
         :param data: Input 3D array holding the reference band
         :return: 2D array holding the temporal index corresponding to percentile
         """
-        indices = self._index_by_percentile(data, self.percentile)
-        return indices
+        return self._index_by_percentile(data, self.percentile)
 
     def execute(self, eopatch: EOPatch) -> EOPatch:
         """Compute composite array merging temporal frames according to the compositing method
@@ -283,8 +281,7 @@ class MaxNDVICompositingTask(BaseCompositingTask):
         median = np.nanmedian(data, axis=0)
         indices_min = self._index_by_percentile(data, self.percentiles[0])
         indices_max = self._index_by_percentile(data, self.percentiles[1])
-        indices = np.where(median < -0.05, indices_min, indices_max)
-        return indices
+        return np.where(median < -0.05, indices_min, indices_max)
 
 
 class MaxNDWICompositingTask(BaseCompositingTask):

--- a/features/eolearn/features/temporal_features.py
+++ b/features/eolearn/features/temporal_features.py
@@ -154,10 +154,10 @@ class AddMaxMinTemporalIndicesTask(EOTask):
         argmin_data = np.ma.MaskedArray.argmin(madata, axis=0)
 
         if argmax_data.ndim == 2:
-            argmax_data = argmax_data.reshape(argmax_data.shape + (1,))
+            argmax_data = argmax_data.reshape((*argmax_data.shape, 1))
 
         if argmin_data.ndim == 2:
-            argmin_data = argmin_data.reshape(argmin_data.shape + (1,))
+            argmin_data = argmin_data.reshape((*argmin_data.shape, 1))
 
         eopatch.data_timeless[self.amax_feature] = argmax_data
         eopatch.data_timeless[self.amin_feature] = argmin_data

--- a/features/eolearn/tests/test_feature_manipulation.py
+++ b/features/eolearn/tests/test_feature_manipulation.py
@@ -20,6 +20,7 @@ from eolearn.features.feature_manipulation import SpatialResizeTask
 from eolearn.features.utils import ResizeParam
 
 DUMMY_BBOX = BBox((0, 0, 1, 1), CRS(3857))
+# ruff: noqa: NPY002
 
 
 @pytest.mark.parametrize(

--- a/features/eolearn/tests/test_radiometric_normalization.py
+++ b/features/eolearn/tests/test_radiometric_normalization.py
@@ -24,6 +24,8 @@ from eolearn.features import (
 )
 from eolearn.mask import MaskFeatureTask
 
+# ruff: noqa: NPY002
+
 
 @pytest.fixture(name="eopatch")
 def eopatch_fixture(example_eopatch):

--- a/features/setup.py
+++ b/features/setup.py
@@ -7,9 +7,7 @@ def get_long_description():
     this_directory = os.path.abspath(os.path.dirname(__file__))
 
     with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
-        long_description = f.read()
-
-    return long_description
+        return f.read()
 
 
 def parse_requirements(file):

--- a/geometry/eolearn/geometry/transformations.py
+++ b/geometry/eolearn/geometry/transformations.py
@@ -37,6 +37,9 @@ LOGGER = logging.getLogger(__name__)
 
 ShapeIterator = Iterator[Tuple[BaseGeometry, float]]
 
+# ruff 0.269 wrongly recognizes `self.values` as a pandas method `.values`
+# ruff: noqa: PD011
+
 
 class VectorToRasterTask(EOTask):
     """A task for transforming a vector feature into a raster feature

--- a/geometry/eolearn/geometry/transformations.py
+++ b/geometry/eolearn/geometry/transformations.py
@@ -243,7 +243,7 @@ class VectorToRasterTask(EOTask):
         if self.write_to_existing and self.raster_feature in eopatch:
             raster = eopatch[self.raster_feature]
 
-            expected_full_shape = raster_shape + (1,)
+            expected_full_shape = (*raster_shape, 1)
             if raster.shape != expected_full_shape:
                 msg = (
                     f"The existing raster feature {self.raster_feature} has a shape {raster.shape} but the expected"

--- a/geometry/eolearn/tests/test_morphology.py
+++ b/geometry/eolearn/tests/test_morphology.py
@@ -16,6 +16,7 @@ from eolearn.geometry import ErosionTask, MorphologicalFilterTask, Morphological
 CLASSES = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 MASK_FEATURE = FeatureType.MASK, "mask"
 MASK_TIMELESS_FEATURE = FeatureType.MASK_TIMELESS, "timeless_mask"
+# ruff: noqa: NPY002
 
 
 @pytest.mark.parametrize("invalid_input", [None, 0, "a"])

--- a/geometry/eolearn/tests/test_transformations.py
+++ b/geometry/eolearn/tests/test_transformations.py
@@ -35,6 +35,9 @@ CUSTOM_DATAFRAME_3D = CUSTOM_DATAFRAME.copy()
 CUSTOM_DATAFRAME_3D.geometry = CUSTOM_DATAFRAME_3D.geometry.map(partial(shapely.ops.transform, lambda x, y: (x, y, 0)))
 
 
+# ruff: noqa: PD008
+
+
 @dataclasses.dataclass(frozen=True)
 class VectorToRasterTestCase:
     name: str

--- a/geometry/setup.py
+++ b/geometry/setup.py
@@ -7,9 +7,7 @@ def get_long_description():
     this_directory = os.path.abspath(os.path.dirname(__file__))
 
     with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
-        long_description = f.read()
-
-    return long_description
+        return f.read()
 
 
 def parse_requirements(file):

--- a/install_all.py
+++ b/install_all.py
@@ -24,7 +24,7 @@ SUBPACKAGE_LIST = [
 
 def pip_command(name, args):
     args = [arg for arg in args if not arg.startswith(".")]
-    subprocess.check_call([sys.executable, "-m", "pip", "install"] + args + [f"./{name}"])
+    subprocess.check_call([sys.executable, "-m", "pip", "install", *args, f"./{name}"])
 
 
 if __name__ == "__main__":

--- a/io/eolearn/io/extra/meteoblue.py
+++ b/io/eolearn/io/extra/meteoblue.py
@@ -45,7 +45,7 @@ class BaseMeteoblueTask(EOTask, metaclass=ABCMeta):
         apikey: str,
         query: Optional[dict] = None,
         units: Optional[dict] = None,
-        time_difference: dt.timedelta = dt.timedelta(minutes=30),  # noqa: B008
+        time_difference: dt.timedelta = dt.timedelta(minutes=30),  # noqa: B008, RUF100
         cache_folder: Optional[str] = None,
         cache_max_age: int = 604800,
     ):
@@ -208,7 +208,7 @@ def meteoblue_to_dataframe(result: Any) -> pd.DataFrame:
     code_names = [f"{code.code}_{code.level}_{code.aggregation}" for code in geometry.codes]
 
     if not geometry.timeIntervals:
-        return pd.DataFrame(columns=[TIMESTAMP_COLUMN, "Longitude", "Latitude"] + code_names)
+        return pd.DataFrame(columns=[TIMESTAMP_COLUMN, "Longitude", "Latitude", *code_names])
 
     dataframes = []
     for index, time_interval in enumerate(geometry.timeIntervals):

--- a/io/eolearn/io/geometry_io.py
+++ b/io/eolearn/io/geometry_io.py
@@ -173,7 +173,7 @@ class VectorImportTask(_BaseVectorImportTask):
 
                 return gpd.GeoDataFrame.from_features(
                     feature_iter,
-                    columns=list(features.schema["properties"]) + ["geometry"],
+                    columns=list(features.schema["properties"]) + ["geometry"],  # noqa: RUF005
                     crs=self.dataset_crs.pyproj_crs(),
                 )
 

--- a/io/eolearn/io/raster_io.py
+++ b/io/eolearn/io/raster_io.py
@@ -37,7 +37,7 @@ from eolearn.core.utils.fs import get_base_filesystem_and_path, get_full_path
 LOGGER = logging.getLogger(__name__)
 
 
-class BaseRasterIoTask(IOTask, metaclass=ABCMeta):  # noqa: B024
+class BaseRasterIoTask(IOTask, metaclass=ABCMeta):
     """Base abstract class for raster IO tasks"""
 
     def __init__(

--- a/io/eolearn/tests/conftest.py
+++ b/io/eolearn/tests/conftest.py
@@ -35,8 +35,7 @@ def example_data_path_fixture():
 @pytest.fixture(name="gpkg_file")
 def local_gpkg_example_file_fixture():
     """A pytest fixture to retrieve a gpkg example file"""
-    path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../../example_data/import-gpkg-test.gpkg")
-    return path
+    return os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../../example_data/import-gpkg-test.gpkg")
 
 
 @pytest.fixture(name="s3_gpkg_file")

--- a/io/eolearn/tests/test_sentinelhub_process.py
+++ b/io/eolearn/tests/test_sentinelhub_process.py
@@ -56,7 +56,7 @@ def calculate_stats(array):
         array[: max(int(time / 2), 1), -1, -1, :],
         array[:, int(height / 2), int(width / 2), :],
     ]
-    values = [(np.nanmean(slice) if not np.isnan(slice).all() else np.nan) for slice in slices]
+    values = [(np.nanmean(_slice) if not np.isnan(_slice).all() else np.nan) for _slice in slices]
     return np.round(np.array(values), 4)
 
 

--- a/io/setup.py
+++ b/io/setup.py
@@ -7,9 +7,7 @@ def get_long_description():
     this_directory = os.path.abspath(os.path.dirname(__file__))
 
     with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
-        long_description = f.read()
-
-    return long_description
+        return f.read()
 
 
 def parse_requirements(file):

--- a/mask/eolearn/mask/cloud_mask.py
+++ b/mask/eolearn/mask/cloud_mask.py
@@ -29,10 +29,12 @@ LOGGER = logging.getLogger(__name__)
 class ClassifierType(Protocol):
     """Defines the necessary classifier interface."""
 
-    def predict(self, X: np.ndarray) -> np.ndarray:  # pylint: disable=missing-function-docstring,invalid-name
+    # pylint: disable-next=missing-function-docstring,invalid-name
+    def predict(self, X: np.ndarray) -> np.ndarray:  # noqa[N803]
         ...
 
-    def predict_proba(self, X: np.ndarray) -> np.ndarray:  # pylint: disable=missing-function-docstring,invalid-name
+    # pylint: disable-next=missing-function-docstring,invalid-name
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:  # noqa[N803]
         ...
 
 

--- a/mask/eolearn/mask/utils.py
+++ b/mask/eolearn/mask/utils.py
@@ -97,8 +97,10 @@ def resize_images(  # type: ignore[no-untyped-def]
         height, width = new_size
         return cv2.resize(image, (width, height), interpolation=interpolation_method)
 
-    _resize3d = lambda x: map_over_axis(x, _resize2d, axis=2)  # pylint: disable=unnecessary-lambda-assignment # noqa
-    _resize4d = lambda x: map_over_axis(x, _resize3d, axis=0)  # pylint: disable=unnecessary-lambda-assignment # noqa
+    # pylint: disable-next=unnecessary-lambda-assignment
+    _resize3d = lambda x: map_over_axis(x, _resize2d, axis=2)  # noqa: E731
+    # pylint: disable-next=unnecessary-lambda-assignment
+    _resize4d = lambda x: map_over_axis(x, _resize3d, axis=0)  # noqa: E731
 
     # Choose a resize method based on number of dimensions
     resize_methods = {2: _resize2d, 3: _resize3d, 4: _resize4d}

--- a/mask/eolearn/mask/utils.py
+++ b/mask/eolearn/mask/utils.py
@@ -95,9 +95,7 @@ def resize_images(  # type: ignore[no-untyped-def]
             image = cv2.GaussianBlur(image, (0, 0), sigmaX=sigma_x, sigmaY=sigma_y, borderType=cv2.BORDER_REFLECT)
 
         height, width = new_size
-        resized = cv2.resize(image, (width, height), interpolation=interpolation_method)
-
-        return resized
+        return cv2.resize(image, (width, height), interpolation=interpolation_method)
 
     _resize3d = lambda x: map_over_axis(x, _resize2d, axis=2)  # pylint: disable=unnecessary-lambda-assignment # noqa
     _resize4d = lambda x: map_over_axis(x, _resize3d, axis=0)  # pylint: disable=unnecessary-lambda-assignment # noqa

--- a/mask/eolearn/tests/test_mask_counting.py
+++ b/mask/eolearn/tests/test_mask_counting.py
@@ -15,6 +15,7 @@ from eolearn.mask import ClassFrequencyTask
 
 IN_FEATURE = (FeatureType.MASK, "TEST")
 OUT_FEATURE = (FeatureType.DATA_TIMELESS, "FREQ")
+# ruff: noqa: NPY002
 
 
 @pytest.mark.parametrize("classes, no_data_value", ((["a", "b"], 0), (4, 0), (None, 0), ([1, 2, 3], 2)))

--- a/mask/eolearn/tests/test_mask_utils.py
+++ b/mask/eolearn/tests/test_mask_utils.py
@@ -5,9 +5,9 @@ from eolearn.mask.utils import map_over_axis
 
 def test_map_over_axis():
     data = np.ones((5, 10, 10))
-    result = map_over_axis(data, lambda x: np.zeros((7, 20)), axis=0)
+    result = map_over_axis(data, lambda _: np.zeros((7, 20)), axis=0)
     assert result.shape == (5, 7, 20)
-    result = map_over_axis(data, lambda x: np.zeros((7, 20)), axis=1)
+    result = map_over_axis(data, lambda _: np.zeros((7, 20)), axis=1)
     assert result.shape == (7, 10, 20)
-    result = map_over_axis(data, lambda x: np.zeros((5, 10)), axis=1)
+    result = map_over_axis(data, lambda _: np.zeros((5, 10)), axis=1)
     assert result.shape == (5, 10, 10)

--- a/mask/setup.py
+++ b/mask/setup.py
@@ -7,9 +7,7 @@ def get_long_description():
     this_directory = os.path.abspath(os.path.dirname(__file__))
 
     with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
-        long_description = f.read()
-
-    return long_description
+        return f.read()
 
 
 def parse_requirements(file):

--- a/ml_tools/eolearn/ml_tools/sampling.py
+++ b/ml_tools/eolearn/ml_tools/sampling.py
@@ -126,7 +126,7 @@ def get_mask_of_samples(image_shape: Tuple[int, int], row_grid: np.ndarray, colu
     return mask
 
 
-class BaseSamplingTask(EOTask, metaclass=ABCMeta):  # noqa: B024
+class BaseSamplingTask(EOTask, metaclass=ABCMeta):
     """A base class for sampling tasks"""
 
     def __init__(

--- a/ml_tools/eolearn/ml_tools/train_test_split.py
+++ b/ml_tools/eolearn/ml_tools/train_test_split.py
@@ -16,6 +16,9 @@ import numpy as np
 from eolearn.core import EOPatch, EOTask, FeatureType
 from eolearn.core.types import SingleFeatureSpec
 
+# switching to np.random.Generator would change results
+# ruff: noqa: NPY002
+
 
 class TrainTestSplitType(Enum):
     """An enum defining TrainTestSplitTask's methods of splitting the data into subsets"""

--- a/ml_tools/eolearn/tests/test_sampling.py
+++ b/ml_tools/eolearn/tests/test_sampling.py
@@ -135,7 +135,7 @@ def test_get_mask_of_samples(small_image: np.ndarray, n_samples: Dict[int, int])
 def eopatch_fixture(small_image: np.ndarray) -> EOPatch:
     config = PatchGeneratorConfig(raster_shape=small_image.shape, depth_range=(5, 6), num_timestamps=10)
     patch = generate_eopatch([(FeatureType.DATA, "bands")], config=config)
-    patch.mask_timeless["raster"] = small_image.reshape(small_image.shape + (1,))
+    patch.mask_timeless["raster"] = small_image.reshape((*small_image.shape, 1))
     return patch
 
 

--- a/ml_tools/setup.py
+++ b/ml_tools/setup.py
@@ -7,9 +7,7 @@ def get_long_description():
     this_directory = os.path.abspath(os.path.dirname(__file__))
 
     with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
-        long_description = f.read()
-
-    return long_description
+        return f.read()
 
 
 def parse_requirements(file):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ line_length = 120
 exclude = [".git", "__pycache__", "build", "dist"]
 ignore = ["C408", "SIM117", "SIM108", "B904", "B028", "A003", "COM812"]
 line-length = 120
-select = ["C4", "C90", "E", "F", "SIM", "W", "N", "YTT", "B", "A", "COM", "T10", "ISC", "ICN", "G", "PIE", "T20", "RET"]
+select = ["C4", "C90", "E", "F", "SIM", "W", "N", "YTT", "B", "A", "COM", "T10", "ISC", "ICN", "G", "PIE", "T20", "RET", "SLF"]
 target-version = "py38"
 
 [tool.ruff.mccabe]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,27 @@ preview = true
 profile = "black"
 known_first_party = "sentinelhub"
 known_absolute = "eolearn"
-sections = ["FUTURE","STDLIB","THIRDPARTY","FIRSTPARTY","ABSOLUTE","LOCALFOLDER"]
+sections = [
+    "FUTURE",
+    "STDLIB",
+    "THIRDPARTY",
+    "FIRSTPARTY",
+    "ABSOLUTE",
+    "LOCALFOLDER",
+]
 line_length = 120
+
+[tool.ruff]
+exclude = [".git", "__pycache__", "build", "dist"]
+ignore = ["C408", "SIM117", "SIM108"]
+line-length = 120
+select = ["C4", "C9", "E", "F", "SIM", "W"]
+
+[tool.ruff.mccabe]
+max-complexity = 15
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401"]
 
 [tool.pylint.format]
 max-line-length = 120
@@ -21,7 +40,7 @@ disable = [
     "invalid-unary-operand-type",
     "unspecified-encoding",
     "unnecessary-ellipsis",
-    "use-dict-literal"
+    "use-dict-literal",
 ]
 
 [tool.pylint.design]
@@ -44,9 +63,7 @@ overgeneral-exceptions = "builtins.Exception"
 max-nested-blocks = 7
 
 [tool.pytest.ini_options]
-markers = [
-    "sh_integration: marks integration tests with Sentinel Hub service"
-]
+markers = ["sh_integration: marks integration tests with Sentinel Hub service"]
 
 [tool.coverage.run]
 source = [
@@ -57,20 +74,14 @@ source = [
     "io",
     "mask",
     "ml_tools",
-    "visualization"
+    "visualization",
 ]
 
 [tool.coverage.report]
-omit = [
-    "*/setup.py",
-    "*/tests/*",
-    "*/__init__.py"
-]
+omit = ["*/setup.py", "*/tests/*", "*/__init__.py"]
 
 [tool.nbqa.addopts]
-flake8 = [
-    "--extend-ignore=E402"
-]
+flake8 = ["--extend-ignore=E402"]
 
 [tool.nbqa.exclude]
 flake8 = "examples/core/CoreOverview.ipynb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ line_length = 120
 exclude = [".git", "__pycache__", "build", "dist"]
 ignore = ["C408", "SIM117", "SIM108", "B904", "B028", "A003", "COM812"]
 line-length = 120
-select = ["C4", "C90", "E", "F", "SIM", "W", "N", "YTT", "B", "A", "COM", "T10", "ISC", "ICN", "G", "PIE", "T20", "RET", "SLF"]
+select = ["C4", "C90", "E", "F", "SIM", "W", "N", "YTT", "B", "A", "COM", "T10", "ISC", "ICN", "G", "PIE", "T20", "RET", "SLF", "ARG"]
 target-version = "py38"
 
 [tool.ruff.mccabe]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ line_length = 120
 exclude = [".git", "__pycache__", "build", "dist"]
 ignore = ["C408", "SIM117", "SIM108"]
 line-length = 120
-select = ["C4", "C9", "E", "F", "SIM", "W"]
+select = ["C4", "C90", "E", "F", "SIM", "W", "N"]
 
 [tool.ruff.mccabe]
 max-complexity = 15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,9 @@ line_length = 120
 
 [tool.ruff]
 exclude = [".git", "__pycache__", "build", "dist"]
-ignore = ["C408", "SIM117", "SIM108", "B904", "B028", "A003"]
+ignore = ["C408", "SIM117", "SIM108", "B904", "B028", "A003", "COM812"]
 line-length = 120
-select = ["C4", "C90", "E", "F", "SIM", "W", "N", "YTT", "B", "A"]
+select = ["C4", "C90", "E", "F", "SIM", "W", "N", "YTT", "B", "A", "COM", "T10", "ISC", "ICN", "G", "PIE"]
 target-version = "py38"
 
 [tool.ruff.mccabe]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ line_length = 120
 exclude = [".git", "__pycache__", "build", "dist"]
 ignore = ["C408", "SIM117", "SIM108", "B904", "B028", "A003", "COM812"]
 line-length = 120
-select = ["C4", "C90", "E", "F", "SIM", "W", "N", "YTT", "B", "A", "COM", "T10", "ISC", "ICN", "G", "PIE"]
+select = ["C4", "C90", "E", "F", "SIM", "W", "N", "YTT", "B", "A", "COM", "T10", "ISC", "ICN", "G", "PIE", "T20", "RET"]
 target-version = "py38"
 
 [tool.ruff.mccabe]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ line_length = 120
 exclude = [".git", "__pycache__", "build", "dist"]
 ignore = ["C408", "SIM117", "SIM108", "B904", "B028", "A003", "COM812"]
 line-length = 120
-select = ["C4", "C90", "E", "F", "SIM", "W", "N", "YTT", "B", "A", "COM", "T10", "ISC", "ICN", "G", "PIE", "T20", "RET", "SLF", "ARG"]
+select = ["C4", "C90", "E", "F", "SIM", "W", "N", "YTT", "B", "A", "COM", "T10", "ISC", "ICN", "G", "PIE", "T20", "RET", "SLF", "ARG", "PD"]
 target-version = "py38"
 
 [tool.ruff.mccabe]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ select = [
     "ARG",
     "PD",
     "PGH",
+    "FLY",
+    "NPY",
 ]
 target-version = "py38"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,30 @@ line_length = 120
 exclude = [".git", "__pycache__", "build", "dist"]
 ignore = ["C408", "SIM117", "SIM108", "B904", "B028", "A003", "COM812"]
 line-length = 120
-select = ["C4", "C90", "E", "F", "SIM", "W", "N", "YTT", "B", "A", "COM", "T10", "ISC", "ICN", "G", "PIE", "T20", "RET", "SLF", "ARG", "PD"]
+select = [
+    "C4",
+    "C90",
+    "E",
+    "F",
+    "SIM",
+    "W",
+    "N",
+    "YTT",
+    "B",
+    "A",
+    "COM",
+    "T10",
+    "ISC",
+    "ICN",
+    "G",
+    "PIE",
+    "T20",
+    "RET",
+    "SLF",
+    "ARG",
+    "PD",
+    "PGH",
+]
 target-version = "py38"
 
 [tool.ruff.mccabe]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,10 @@ line_length = 120
 
 [tool.ruff]
 exclude = [".git", "__pycache__", "build", "dist"]
-ignore = ["C408", "SIM117", "SIM108"]
+ignore = ["C408", "SIM117", "SIM108", "B904", "B028", "A003"]
 line-length = 120
-select = ["C4", "C90", "E", "F", "SIM", "W", "N"]
+select = ["C4", "C90", "E", "F", "SIM", "W", "N", "YTT", "B", "A"]
+target-version = "py38"
 
 [tool.ruff.mccabe]
 max-complexity = 15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ select = [
     "PGH",
     "FLY",
     "NPY",
+    "RUF",
 ]
 target-version = "py38"
 

--- a/visualization/eolearn/visualization/eoexecutor.py
+++ b/visualization/eolearn/visualization/eoexecutor.py
@@ -148,7 +148,7 @@ class EOExecutorVisualization:
                     "name": f"{node_name} ({node.uid})",
                     "uid": node.uid,
                     "args": {
-                        key: value.replace("<", "&lt;").replace(">", "&gt;")  # type: ignore
+                        key: value.replace("<", "&lt;").replace(">", "&gt;")  # type: ignore[attr-defined]
                         for key, value in node.task.private_task_config.init_args.items()
                     },
                 }

--- a/visualization/eolearn/visualization/eoexecutor.py
+++ b/visualization/eolearn/visualization/eoexecutor.py
@@ -211,9 +211,8 @@ class EOExecutorVisualization:
         env = Environment(loader=FileSystemLoader(templates_dir))
         env.filters["datetime"] = self._format_datetime
         env.globals.update(timedelta=self._format_timedelta)
-        template = env.get_template(self.eoexecutor.REPORT_FILENAME)
 
-        return template
+        return env.get_template(self.eoexecutor.REPORT_FILENAME)
 
     @staticmethod
     def _format_datetime(value: dt.datetime) -> str:

--- a/visualization/setup.py
+++ b/visualization/setup.py
@@ -7,9 +7,7 @@ def get_long_description():
     this_directory = os.path.abspath(os.path.dirname(__file__))
 
     with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
-        long_description = f.read()
-
-    return long_description
+        return f.read()
 
 
 def parse_requirements(file):


### PR DESCRIPTION
In a future PR we can also get rid of flake8 now.
Also we might want to migrate `isort` over to `ruff`, even the isort creators [advise so](https://news.ycombinator.com/item?id=34062974)

I suggest you proceed commit by commit.
Some flags are more radical, so i opened new issues for those.

P.S. VSCode has a ruff extension written by the author of ruff