### PR TITLE
Use new-style type annotations

### DIFF
--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import copy
 from abc import ABCMeta
-from typing import Any, Callable, Dict, Iterable, List, Tuple, Union, cast
+from typing import Any, Callable, Iterable, Tuple, Union, cast
 
 import fs
 import numpy as np
@@ -254,7 +254,7 @@ class InitializeFeatureTask(EOTask):
     def __init__(
         self,
         features: FeaturesSpecification,
-        shape: Tuple[int, ...] | FeatureSpec,
+        shape: tuple[int, ...] | FeatureSpec,
         init_value: int = 0,
         dtype: np.dtype | type = np.uint8,
     ):
@@ -267,8 +267,8 @@ class InitializeFeatureTask(EOTask):
         """
 
         self.features = self.parse_features(features)
-        self.shape_feature: Tuple[FeatureType, str | None] | None
-        self.shape: None | Tuple[int, int, int] | Tuple[int, int, int, int]
+        self.shape_feature: tuple[FeatureType, str | None] | None
+        self.shape: None | tuple[int, int, int] | tuple[int, int, int, int]
 
         try:
             self.shape_feature = self.parse_feature(shape)  # type: ignore[arg-type]
@@ -495,7 +495,7 @@ class MergeFeatureTask(ZipFeatureTask):
 class ExtractBandsTask(MapFeatureTask):
     """Moves a subset of bands from one feature to a new one."""
 
-    def __init__(self, input_feature: FeaturesSpecification, output_feature: FeaturesSpecification, bands: List[int]):
+    def __init__(self, input_feature: FeaturesSpecification, output_feature: FeaturesSpecification, bands: list[int]):
         """
         :param input_feature: A source feature from which to take the subset of bands.
         :param output_feature: An output feature to which to write the bands.
@@ -516,8 +516,8 @@ class ExplodeBandsTask(EOTask):
 
     def __init__(
         self,
-        input_feature: Tuple[FeatureType, str],
-        output_mapping: Dict[Tuple[FeatureType, str], int | Iterable[int]],
+        input_feature: tuple[FeatureType, str],
+        output_mapping: dict[tuple[FeatureType, str], int | Iterable[int]],
     ):
         """
         :param input_feature: A source feature from which to take the subset of bands.

--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import copy
 from abc import ABCMeta
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union, cast
+from typing import Any, Callable, Dict, Iterable, List, Tuple, Union, cast
 
 import fs
 import numpy as np
@@ -52,9 +52,7 @@ class DeepCopyTask(CopyTask):
 class IOTask(EOTask, metaclass=ABCMeta):
     """An abstract Input/Output task that can handle a path and a filesystem object."""
 
-    def __init__(
-        self, path: str, filesystem: Optional[FS] = None, create: bool = False, config: Optional[SHConfig] = None
-    ):
+    def __init__(self, path: str, filesystem: FS | None = None, create: bool = False, config: SHConfig | None = None):
         """
         :param path: root path where all EOPatches are saved
         :param filesystem: An existing filesystem object. If not given it will be initialized according to the EOPatch
@@ -84,7 +82,7 @@ class IOTask(EOTask, metaclass=ABCMeta):
 class SaveTask(IOTask):
     """Saves the given EOPatch to a filesystem."""
 
-    def __init__(self, path: str, filesystem: Optional[FS] = None, config: Optional[SHConfig] = None, **kwargs: Any):
+    def __init__(self, path: str, filesystem: FS | None = None, config: SHConfig | None = None, **kwargs: Any):
         """
         :param path: root path where all EOPatches are saved
         :param filesystem: An existing filesystem object. If not given it will be initialized according to the EOPatch
@@ -115,7 +113,7 @@ class SaveTask(IOTask):
 class LoadTask(IOTask):
     """Loads an EOPatch from a filesystem."""
 
-    def __init__(self, path: str, filesystem: Optional[FS] = None, config: Optional[SHConfig] = None, **kwargs: Any):
+    def __init__(self, path: str, filesystem: FS | None = None, config: SHConfig | None = None, **kwargs: Any):
         """
         :param path: root directory where all EOPatches are saved
         :param filesystem: An existing filesystem object. If not given it will be initialized according to the EOPatch
@@ -128,7 +126,7 @@ class LoadTask(IOTask):
         self.kwargs = kwargs
         super().__init__(path, filesystem=filesystem, create=False, config=config)
 
-    def execute(self, eopatch: Optional[EOPatch] = None, *, eopatch_folder: str = "") -> EOPatch:
+    def execute(self, eopatch: EOPatch | None = None, *, eopatch_folder: str = "") -> EOPatch:
         """Loads the EOPatch from disk: `folder/eopatch_folder`.
 
         :param eopatch: Optional input EOPatch. If given the loaded features are merged onto it, otherwise a new EOPatch
@@ -256,9 +254,9 @@ class InitializeFeatureTask(EOTask):
     def __init__(
         self,
         features: FeaturesSpecification,
-        shape: Union[Tuple[int, ...], FeatureSpec],
+        shape: Tuple[int, ...] | FeatureSpec,
         init_value: int = 0,
-        dtype: Union[np.dtype, type] = np.uint8,
+        dtype: np.dtype | type = np.uint8,
     ):
         """
         :param features: A collection of features to initialize.
@@ -269,8 +267,8 @@ class InitializeFeatureTask(EOTask):
         """
 
         self.features = self.parse_features(features)
-        self.shape_feature: Optional[Tuple[FeatureType, Optional[str]]]
-        self.shape: Union[None, Tuple[int, int, int], Tuple[int, int, int, int]]
+        self.shape_feature: Tuple[FeatureType, str | None] | None
+        self.shape: None | Tuple[int, int, int] | Tuple[int, int, int, int]
 
         try:
             self.shape_feature = self.parse_feature(shape)  # type: ignore[arg-type]
@@ -372,7 +370,7 @@ class MapFeatureTask(EOTask):
         self,
         input_features: FeaturesSpecification,
         output_features: FeaturesSpecification,
-        map_function: Optional[Callable] = None,
+        map_function: Callable | None = None,
         **kwargs: Any,
     ):
         """
@@ -452,7 +450,7 @@ class ZipFeatureTask(EOTask):
         self,
         input_features: FeaturesSpecification,
         output_feature: SingleFeatureSpec,
-        zip_function: Optional[Callable] = None,
+        zip_function: Callable | None = None,
         **kwargs: Any,
     ):
         """
@@ -489,7 +487,7 @@ class ZipFeatureTask(EOTask):
 class MergeFeatureTask(ZipFeatureTask):
     """Merges multiple features together by concatenating their data along the specified axis."""
 
-    def zip_method(self, *f: np.ndarray, dtype: Union[None, np.dtype, type] = None, axis: int = -1) -> np.ndarray:
+    def zip_method(self, *f: np.ndarray, dtype: None | np.dtype | type = None, axis: int = -1) -> np.ndarray:
         """Concatenates the data of features along the specified axis."""
         return np.concatenate(f, axis=axis, dtype=dtype)  # pylint: disable=unexpected-keyword-arg
 
@@ -519,7 +517,7 @@ class ExplodeBandsTask(EOTask):
     def __init__(
         self,
         input_feature: Tuple[FeatureType, str],
-        output_mapping: Dict[Tuple[FeatureType, str], Union[int, Iterable[int]]],
+        output_mapping: Dict[Tuple[FeatureType, str], int | Iterable[int]],
     ):
         """
         :param input_feature: A source feature from which to take the subset of bands.

--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -20,12 +20,9 @@ from typing import (
     Callable,
     Iterable,
     Iterator,
-    List,
     Literal,
     Mapping,
     MutableMapping,
-    Set,
-    Tuple,
     TypeVar,
     cast,
     overload,
@@ -225,7 +222,7 @@ class EOPatch:
     """
 
     # establish types of property value holders
-    _timestamps: List[dt.datetime]
+    _timestamps: list[dt.datetime]
     _bbox: BBox | None
     _meta_info: FeatureIOJson | _FeatureDictJson
 
@@ -244,7 +241,7 @@ class EOPatch:
         vector_timeless: Mapping[str, gpd.GeoDataFrame] | None = None,
         meta_info: Mapping[str, Any] | None = None,
         bbox: BBox | None = None,
-        timestamps: List[dt.datetime] | None = None,
+        timestamps: list[dt.datetime] | None = None,
     ):
         self.data: MutableMapping[str, np.ndarray] = _FeatureDictNumpy(data or {}, FeatureType.DATA)
         self.mask: MutableMapping[str, np.ndarray] = _FeatureDictNumpy(mask or {}, FeatureType.MASK)
@@ -271,18 +268,18 @@ class EOPatch:
         self.timestamps = timestamps or []
 
     @property
-    def timestamp(self) -> List[dt.datetime]:
+    def timestamp(self) -> list[dt.datetime]:
         """A property for handling the deprecated timestamp attribute."""
         warn(TIMESTAMP_RENAME_WARNING, category=EODeprecationWarning, stacklevel=2)
         return self.timestamps
 
     @timestamp.setter
-    def timestamp(self, value: List[dt.datetime]) -> None:
+    def timestamp(self, value: list[dt.datetime]) -> None:
         warn(TIMESTAMP_RENAME_WARNING, category=EODeprecationWarning, stacklevel=2)
         self.timestamps = value
 
     @property
-    def timestamps(self) -> List[dt.datetime]:
+    def timestamps(self) -> list[dt.datetime]:
         """A property for handling the `timestamps` attribute."""
         return self._timestamps
 
@@ -329,20 +326,20 @@ class EOPatch:
         super().__setattr__(key, value)
 
     @overload
-    def __getitem__(self, key: Literal[FeatureType.BBOX] | Tuple[Literal[FeatureType.BBOX], Any]) -> BBox:
+    def __getitem__(self, key: Literal[FeatureType.BBOX] | tuple[Literal[FeatureType.BBOX], Any]) -> BBox:
         ...
 
     @overload
     def __getitem__(
-        self, key: Literal[FeatureType.TIMESTAMPS] | Tuple[Literal[FeatureType.TIMESTAMPS], Any]
-    ) -> List[dt.datetime]:
+        self, key: Literal[FeatureType.TIMESTAMPS] | tuple[Literal[FeatureType.TIMESTAMPS], Any]
+    ) -> list[dt.datetime]:
         ...
 
     @overload
-    def __getitem__(self, key: FeatureType | Tuple[FeatureType, str | None | EllipsisType]) -> Any:
+    def __getitem__(self, key: FeatureType | tuple[FeatureType, str | None | EllipsisType]) -> Any:
         ...
 
-    def __getitem__(self, key: FeatureType | Tuple[FeatureType, str | None | EllipsisType]) -> Any:
+    def __getitem__(self, key: FeatureType | tuple[FeatureType, str | None | EllipsisType]) -> Any:
         """Provides features of requested feature type. It can also accept a tuple of (feature_type, feature_name).
 
         :param key: Feature type or a (feature_type, feature_name) pair.
@@ -354,7 +351,7 @@ class EOPatch:
             return value[feature_name]
         return value
 
-    def __setitem__(self, key: FeatureType | Tuple[FeatureType, str | None | EllipsisType], value: Any) -> None:
+    def __setitem__(self, key: FeatureType | tuple[FeatureType, str | None | EllipsisType], value: Any) -> None:
         """Sets a new value to the given FeatureType or tuple of (feature_type, feature_name)."""
         feature_type, feature_name = key if isinstance(key, tuple) else (key, None)
         ftype_attr = FeatureType(feature_type).value
@@ -540,7 +537,7 @@ class EOPatch:
         else:
             self[feature_type] = {}
 
-    def get_spatial_dimension(self, feature_type: FeatureType, feature_name: str) -> Tuple[int, int]:
+    def get_spatial_dimension(self, feature_type: FeatureType, feature_name: str) -> tuple[int, int]:
         """
         Returns a tuple of spatial dimensions (height, width) of a feature.
 
@@ -553,12 +550,12 @@ class EOPatch:
 
         raise ValueError(f"Features of type {feature_type} do not have a spatial dimension or are not arrays.")
 
-    def get_features(self) -> List[FeatureSpec]:
+    def get_features(self) -> list[FeatureSpec]:
         """Returns a list of all non-empty features of EOPatch.
 
         :return: List of non-empty features
         """
-        feature_list: List[FeatureSpec] = []
+        feature_list: list[FeatureSpec] = []
         for feature_type in FeatureType:
             if feature_type is FeatureType.BBOX or feature_type is FeatureType.TIMESTAMPS:
                 if feature_type in self:
@@ -670,7 +667,7 @@ class EOPatch:
             self, *eopatches, features=features, time_dependent_op=time_dependent_op, timeless_op=timeless_op
         )
 
-    def consolidate_timestamps(self, timestamps: List[dt.datetime]) -> Set[dt.datetime]:
+    def consolidate_timestamps(self, timestamps: list[dt.datetime]) -> set[dt.datetime]:
         """Removes all frames from the EOPatch with a date not found in the provided timestamps list.
 
         :param timestamps: keep frames with date found in this list
@@ -693,10 +690,10 @@ class EOPatch:
         self,
         feature: FeatureSpec,
         *,
-        times: List[int] | slice | None = None,
-        channels: List[int] | slice | None = None,
-        channel_names: List[str] | None = None,
-        rgb: Tuple[int, int, int] | None = None,
+        times: list[int] | slice | None = None,
+        channels: list[int] | slice | None = None,
+        channel_names: list[str] | None = None,
+        rgb: tuple[int, int, int] | None = None,
         backend: str | PlotBackend = "matplotlib",
         config: PlotConfig | None = None,
         **kwargs: Any,

--- a/core/eolearn/core/eodata_merge.py
+++ b/core/eolearn/core/eodata_merge.py
@@ -12,7 +12,7 @@ import datetime as dt
 import functools
 import itertools as it
 import warnings
-from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple, Union, cast
+from typing import Any, Callable, Dict, List, Literal, Sequence, Tuple, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -96,7 +96,7 @@ def _parse_operation(operation_input: OperationInputType, is_timeless: bool) -> 
     """Transforms operation's instruction (i.e. an input string) into a function that can be applied to a list of
     arrays. If the input already is a function it returns it.
     """
-    defaults: Dict[Optional[str], Callable] = {
+    defaults: Dict[str | None, Callable] = {
         None: _return_if_equal_operation,
         "concatenate": functools.partial(np.concatenate, axis=-1 if is_timeless else 0),
         "mean": functools.partial(np.nanmean, axis=0),
@@ -287,7 +287,7 @@ def _select_meta_info_feature(eopatches: Sequence[EOPatch], feature_name: str) -
     return values[0]
 
 
-def _get_common_bbox(eopatches: Sequence[EOPatch]) -> Optional[BBox]:
+def _get_common_bbox(eopatches: Sequence[EOPatch]) -> BBox | None:
     """Makes sure that all EOPatches, which define a bounding box and CRS, define the same ones."""
     bboxes = [eopatch.bbox for eopatch in eopatches if eopatch.bbox is not None]
 
@@ -305,7 +305,7 @@ def _extract_feature_values(eopatches: Sequence[EOPatch], feature: FeatureSpec) 
     return [eopatch[feature] for eopatch in eopatches if feature_name in eopatch[feature_type]]
 
 
-def _all_equal(values: Union[Sequence[Any], np.ndarray]) -> bool:
+def _all_equal(values: Sequence[Any] | np.ndarray) -> bool:
     """A helper function that checks if all values in a given list are equal to each other."""
     first_value = values[0]
 

--- a/core/eolearn/core/eodata_merge.py
+++ b/core/eolearn/core/eodata_merge.py
@@ -12,7 +12,7 @@ import datetime as dt
 import functools
 import itertools as it
 import warnings
-from typing import Any, Callable, Dict, List, Literal, Sequence, Tuple, Union, cast
+from typing import Any, Callable, Literal, Sequence, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -96,7 +96,7 @@ def _parse_operation(operation_input: OperationInputType, is_timeless: bool) -> 
     """Transforms operation's instruction (i.e. an input string) into a function that can be applied to a list of
     arrays. If the input already is a function it returns it.
     """
-    defaults: Dict[str | None, Callable] = {
+    defaults: dict[str | None, Callable] = {
         None: _return_if_equal_operation,
         "concatenate": functools.partial(np.concatenate, axis=-1 if is_timeless else 0),
         "mean": functools.partial(np.nanmean, axis=0),
@@ -121,7 +121,7 @@ def _return_if_equal_operation(arrays: np.ndarray) -> bool:
 
 def _merge_timestamps(
     eopatches: Sequence[EOPatch], reduce_timestamps: bool
-) -> Tuple[List[dt.datetime], List[np.ndarray]]:
+) -> tuple[list[dt.datetime], list[np.ndarray]]:
     """Merges together timestamps from EOPatches. It also prepares a list of masks, one for each EOPatch, how
     timestamps should be ordered and joined together.
     """
@@ -205,7 +205,7 @@ def _extract_and_join_time_dependent_feature_values(
     feature: FeatureSpec,
     order_mask_per_eopatch: Sequence[np.ndarray],
     optimize: bool,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """Collects feature arrays from EOPatches that have them and joins them together. It also joins together
     corresponding order masks.
     """
@@ -299,7 +299,7 @@ def _get_common_bbox(eopatches: Sequence[EOPatch]) -> BBox | None:
     raise ValueError("Cannot merge EOPatches because they are defined for different bounding boxes.")
 
 
-def _extract_feature_values(eopatches: Sequence[EOPatch], feature: FeatureSpec) -> List[Any]:
+def _extract_feature_values(eopatches: Sequence[EOPatch], feature: FeatureSpec) -> list[Any]:
     """A helper function that extracts a feature values from those EOPatches where a feature exists."""
     feature_type, feature_name = feature
     return [eopatch[feature] for eopatch in eopatches if feature_name in eopatch[feature_type]]

--- a/core/eolearn/core/eoexecution.py
+++ b/core/eolearn/core/eoexecution.py
@@ -20,7 +20,7 @@ import threading
 import warnings
 from dataclasses import dataclass
 from logging import FileHandler, Filter, Handler, Logger
-from typing import Any, Callable, Dict, List, Protocol, Sequence, Tuple, Union
+from typing import Any, Callable, Protocol, Sequence, Union
 
 import fs
 from fs.base import FS
@@ -50,7 +50,7 @@ class _ProcessingData:
     serializable with pickle."""
 
     workflow: EOWorkflow
-    workflow_kwargs: Dict[EONode, Dict[str, object]]
+    workflow_kwargs: dict[EONode, dict[str, object]]
     pickled_filesystem: bytes
     log_path: str | None
     filter_logs_by_thread: bool
@@ -64,7 +64,7 @@ class _ExecutionRunParams:
 
     workers: int | None
     multiprocess: bool
-    tqdm_kwargs: Dict[str, Any]
+    tqdm_kwargs: dict[str, Any]
 
 
 class EOExecutor:
@@ -79,9 +79,9 @@ class EOExecutor:
     def __init__(
         self,
         workflow: EOWorkflow,
-        execution_kwargs: Sequence[Dict[EONode, Dict[str, object]]],
+        execution_kwargs: Sequence[dict[EONode, dict[str, object]]],
         *,
-        execution_names: List[str] | None = None,
+        execution_names: list[str] | None = None,
         save_logs: bool = False,
         logs_folder: str = ".",
         filesystem: FS | None = None,
@@ -120,13 +120,13 @@ class EOExecutor:
 
         self.start_time: dt.datetime | None = None
         self.report_folder: str | None = None
-        self.general_stats: Dict[str, object] = {}
-        self.execution_results: List[WorkflowResults] = []
+        self.general_stats: dict[str, object] = {}
+        self.execution_results: list[WorkflowResults] = []
 
     @staticmethod
     def _parse_and_validate_execution_kwargs(
-        execution_kwargs: Sequence[Dict[EONode, Dict[str, object]]]
-    ) -> List[Dict[EONode, Dict[str, object]]]:
+        execution_kwargs: Sequence[dict[EONode, dict[str, object]]]
+    ) -> list[dict[EONode, dict[str, object]]]:
         """Parses and validates execution arguments provided by user and raises an error if something is wrong."""
         if not isinstance(execution_kwargs, (list, tuple)):
             raise ValueError("Parameter 'execution_kwargs' should be a list.")
@@ -137,7 +137,7 @@ class EOExecutor:
         return [input_kwargs or {} for input_kwargs in execution_kwargs]
 
     @staticmethod
-    def _parse_execution_names(execution_names: List[str] | None, execution_kwargs: Sequence) -> List[str]:
+    def _parse_execution_names(execution_names: list[str] | None, execution_kwargs: Sequence) -> list[str]:
         """Parses a list of execution names."""
         if execution_names is None:
             return [str(num) for num in range(1, len(execution_kwargs) + 1)]
@@ -149,13 +149,13 @@ class EOExecutor:
         return execution_names
 
     @staticmethod
-    def _parse_logs_filesystem(filesystem: FS | None, logs_folder: str) -> Tuple[FS, str]:
+    def _parse_logs_filesystem(filesystem: FS | None, logs_folder: str) -> tuple[FS, str]:
         """Ensures a filesystem and a file path relative to it."""
         if filesystem is None:
             return get_base_filesystem_and_path(logs_folder)
         return filesystem, logs_folder
 
-    def run(self, workers: int | None = 1, multiprocess: bool = True, **tqdm_kwargs: Any) -> List[WorkflowResults]:
+    def run(self, workers: int | None = 1, multiprocess: bool = True, **tqdm_kwargs: Any) -> list[WorkflowResults]:
         """Runs the executor with n workers.
 
         :param workers: Maximum number of workflows which will be executed in parallel. Default value is `1` which will
@@ -208,8 +208,8 @@ class EOExecutor:
 
     @classmethod
     def _run_execution(
-        cls, processing_args: List[_ProcessingData], run_params: _ExecutionRunParams
-    ) -> List[WorkflowResults]:
+        cls, processing_args: list[_ProcessingData], run_params: _ExecutionRunParams
+    ) -> list[WorkflowResults]:
         """Parallelizes the execution for each item of processing_args list."""
         return parallelize(
             cls._execute_workflow,
@@ -227,7 +227,7 @@ class EOExecutor:
         filter_logs_by_thread: bool,
         logs_filter: Filter | None,
         logs_handler_factory: _HandlerFactoryType,
-    ) -> Tuple[Logger | None, Handler | None]:
+    ) -> tuple[Logger | None, Handler | None]:
         """Adds a handler to a logger and returns them both. In case this fails it shows a warning."""
         if log_path:
             try:
@@ -304,7 +304,7 @@ class EOExecutor:
         """Provides a type of processing according to given parameters."""
         return _decide_processing_type(workers=workers, multiprocess=multiprocess)
 
-    def _prepare_general_stats(self, workers: int | None, processing_type: _ProcessingType) -> Dict[str, object]:
+    def _prepare_general_stats(self, workers: int | None, processing_type: _ProcessingType) -> dict[str, object]:
         """Prepares a dictionary with a general statistics about executions."""
         failed_count = sum(results.workflow_failed() for results in self.execution_results)
         return {
@@ -316,7 +316,7 @@ class EOExecutor:
             "workers": workers,
         }
 
-    def get_successful_executions(self) -> List[int]:
+    def get_successful_executions(self) -> list[int]:
         """Returns a list of IDs of successful executions. The IDs are integers from interval
         `[0, len(execution_kwargs) - 1]`, sorted in increasing order.
 
@@ -324,7 +324,7 @@ class EOExecutor:
         """
         return [idx for idx, results in enumerate(self.execution_results) if not results.workflow_failed()]
 
-    def get_failed_executions(self) -> List[int]:
+    def get_failed_executions(self) -> list[int]:
         """Returns a list of IDs of failed executions. The IDs are integers from interval
         `[0, len(execution_kwargs) - 1]`, sorted in increasing order.
 
@@ -363,7 +363,7 @@ class EOExecutor:
 
         return EOExecutorVisualization(self).make_report(include_logs=include_logs)
 
-    def get_log_paths(self, full_path: bool = True) -> List[str]:
+    def get_log_paths(self, full_path: bool = True) -> list[str]:
         """Returns a list of file paths containing logs.
 
         :param full_path: A flag to specify if it should return full absolute paths or paths relative to the
@@ -377,7 +377,7 @@ class EOExecutor:
             return [get_full_path(self.filesystem, path) for path in log_paths]
         return log_paths
 
-    def read_logs(self) -> List[str | None]:
+    def read_logs(self) -> list[str | None]:
         """Loads the content of log files if logs have been saved."""
         if not self.save_logs:
             return [None] * len(self.execution_kwargs)

--- a/core/eolearn/core/eoexecution.py
+++ b/core/eolearn/core/eoexecution.py
@@ -10,6 +10,8 @@ For the full list of contributors, see the CREDITS file in the root directory of
 
 This source code is licensed under the MIT license, see the LICENSE file in the root directory of this source tree.
 """
+from __future__ import annotations
+
 import concurrent.futures
 import datetime as dt
 import inspect

--- a/core/eolearn/core/eotask.py
+++ b/core/eolearn/core/eotask.py
@@ -17,7 +17,7 @@ import inspect
 import logging
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, Callable, Dict, Iterable, List, Tuple, Type, TypeVar
 
 from sentinelhub.exceptions import deprecated_function
 
@@ -82,17 +82,17 @@ class EOTask(metaclass=ABCMeta):
     @staticmethod
     def parse_feature(
         feature: SingleFeatureSpec,
-        eopatch: Optional[EOPatch] = None,
-        allowed_feature_types: Union[EllipsisType, Iterable[FeatureType], Callable[[FeatureType], bool]] = ...,
-    ) -> Tuple[FeatureType, Optional[str]]:
+        eopatch: EOPatch | None = None,
+        allowed_feature_types: EllipsisType | Iterable[FeatureType] | Callable[[FeatureType], bool] = ...,
+    ) -> Tuple[FeatureType, str | None]:
         """See `eolearn.core.utils.parse_feature`."""
         return parse_feature(feature, eopatch, allowed_feature_types)
 
     @staticmethod
     def parse_features(
         features: FeaturesSpecification,
-        eopatch: Optional[EOPatch] = None,
-        allowed_feature_types: Union[EllipsisType, Iterable[FeatureType], Callable[[FeatureType], bool]] = ...,
+        eopatch: EOPatch | None = None,
+        allowed_feature_types: EllipsisType | Iterable[FeatureType] | Callable[[FeatureType], bool] = ...,
     ) -> List[FeatureSpec]:
         """See `eolearn.core.utils.parse_features`."""
         return parse_features(features, eopatch, allowed_feature_types)
@@ -100,7 +100,7 @@ class EOTask(metaclass=ABCMeta):
     @staticmethod
     def get_feature_parser(
         features: FeaturesSpecification,
-        allowed_feature_types: Union[EllipsisType, Iterable[FeatureType], Callable[[FeatureType], bool]] = ...,
+        allowed_feature_types: EllipsisType | Iterable[FeatureType] | Callable[[FeatureType], bool] = ...,
     ) -> FeatureParser:
         """See :class:`FeatureParser<eolearn.core.utils.FeatureParser>`."""
         return FeatureParser(features, allowed_feature_types=allowed_feature_types)

--- a/core/eolearn/core/eotask.py
+++ b/core/eolearn/core/eotask.py
@@ -17,7 +17,7 @@ import inspect
 import logging
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Iterable, List, Tuple, Type, TypeVar
+from typing import Any, Callable, Iterable, TypeVar
 
 from sentinelhub.exceptions import deprecated_function
 
@@ -46,11 +46,11 @@ class EOTask(metaclass=ABCMeta):
         deprecated_function(EODeprecationWarning, PARSE_RENAMED_DEPRECATE_MSG)(parse_renamed_features)
     )
 
-    def __new__(cls: Type[Self], *args: Any, **kwargs: Any) -> Self:
+    def __new__(cls: type[Self], *args: Any, **kwargs: Any) -> Self:
         """Stores initialization parameters and the order to the instance attribute `init_args`."""
         self = super().__new__(cls)  # type: ignore[misc]
 
-        init_args: Dict[str, object] = {}
+        init_args: dict[str, object] = {}
         for arg, value in zip(inspect.getfullargspec(self.__init__).args[1 : len(args) + 1], args):
             init_args[arg] = repr(value)
         for arg in inspect.getfullargspec(self.__init__).args[len(args) + 1 :]:
@@ -84,7 +84,7 @@ class EOTask(metaclass=ABCMeta):
         feature: SingleFeatureSpec,
         eopatch: EOPatch | None = None,
         allowed_feature_types: EllipsisType | Iterable[FeatureType] | Callable[[FeatureType], bool] = ...,
-    ) -> Tuple[FeatureType, str | None]:
+    ) -> tuple[FeatureType, str | None]:
         """See `eolearn.core.utils.parse_feature`."""
         return parse_feature(feature, eopatch, allowed_feature_types)
 
@@ -93,7 +93,7 @@ class EOTask(metaclass=ABCMeta):
         features: FeaturesSpecification,
         eopatch: EOPatch | None = None,
         allowed_feature_types: EllipsisType | Iterable[FeatureType] | Callable[[FeatureType], bool] = ...,
-    ) -> List[FeatureSpec]:
+    ) -> list[FeatureSpec]:
         """See `eolearn.core.utils.parse_features`."""
         return parse_features(features, eopatch, allowed_feature_types)
 
@@ -113,4 +113,4 @@ class _PrivateTaskConfig:
     :param init_args: A dictionary of parameters and values used for EOTask initialization
     """
 
-    init_args: Dict[str, object]
+    init_args: dict[str, object]

--- a/core/eolearn/core/eoworkflow.py
+++ b/core/eolearn/core/eoworkflow.py
@@ -118,7 +118,7 @@ class EOWorkflow:
         return dag
 
     @classmethod
-    def from_endnodes(cls, *endnodes: EONode) -> "EOWorkflow":
+    def from_endnodes(cls, *endnodes: EONode) -> EOWorkflow:
         """Constructs the EOWorkflow from the end-nodes by recursively extracting nodes in the workflow structure."""
         all_nodes: set[EONode] = set()
         memo: dict[EONode, set[EONode]] = {}
@@ -128,7 +128,7 @@ class EOWorkflow:
 
     def execute(
         self, input_kwargs: dict[EONode, dict[str, object]] | None = None, raise_errors: bool = True
-    ) -> "WorkflowResults":
+    ) -> WorkflowResults:
         """Executes the workflow.
 
         :param input_kwargs: External input arguments to the workflow. They have to be in a form of a dictionary where
@@ -363,7 +363,7 @@ class WorkflowResults:
         """Informs if the EOWorkflow execution failed."""
         return self.error_node_uid is not None
 
-    def drop_outputs(self) -> "WorkflowResults":
+    def drop_outputs(self) -> WorkflowResults:
         """Creates a new WorkflowResults object without outputs which can take a lot of memory."""
         new_params = {
             param.name: {} if param.name == "outputs" else getattr(self, param.name)

--- a/core/eolearn/core/eoworkflow.py
+++ b/core/eolearn/core/eoworkflow.py
@@ -23,7 +23,7 @@ import datetime as dt
 import logging
 import traceback
 from dataclasses import dataclass, field, fields
-from typing import Dict, List, Sequence, Set, Tuple, cast
+from typing import Sequence, Tuple, cast
 
 from .eodata import EOPatch
 from .eonode import EONode, NodeStats
@@ -83,7 +83,7 @@ class EOWorkflow:
         return nodes
 
     @staticmethod
-    def _make_uid_dict(nodes: Sequence[EONode]) -> Dict[str, EONode]:
+    def _make_uid_dict(nodes: Sequence[EONode]) -> dict[str, EONode]:
         """Creates a dictionary mapping node IDs to nodes while checking uniqueness of tasks.
 
         :param nodes: The sequence of workflow nodes defining the computational graph
@@ -120,14 +120,14 @@ class EOWorkflow:
     @classmethod
     def from_endnodes(cls, *endnodes: EONode) -> "EOWorkflow":
         """Constructs the EOWorkflow from the end-nodes by recursively extracting nodes in the workflow structure."""
-        all_nodes: Set[EONode] = set()
-        memo: Dict[EONode, Set[EONode]] = {}
+        all_nodes: set[EONode] = set()
+        memo: dict[EONode, set[EONode]] = {}
         for endnode in endnodes:
             all_nodes = all_nodes.union(endnode.get_dependencies(_memo=memo))
         return cls(list(all_nodes))
 
     def execute(
-        self, input_kwargs: Dict[EONode, Dict[str, object]] | None = None, raise_errors: bool = True
+        self, input_kwargs: dict[EONode, dict[str, object]] | None = None, raise_errors: bool = True
     ) -> "WorkflowResults":
         """Executes the workflow.
 
@@ -142,7 +142,7 @@ class EOWorkflow:
         """
         start_time = dt.datetime.now()
 
-        out_degrees: Dict[str, int] = self.uid_dag.get_outdegrees()
+        out_degrees: dict[str, int] = self.uid_dag.get_outdegrees()
 
         input_kwargs = input_kwargs or {}
         self.validate_input_kwargs(input_kwargs)
@@ -162,7 +162,7 @@ class EOWorkflow:
         return results
 
     @staticmethod
-    def validate_input_kwargs(input_kwargs: Dict[EONode, Dict[str, object]]) -> None:
+    def validate_input_kwargs(input_kwargs: dict[EONode, dict[str, object]]) -> None:
         """Validates EOWorkflow input arguments provided by user and raises an error if something is wrong.
 
         :param input_kwargs: A dictionary mapping tasks to task execution arguments
@@ -187,8 +187,8 @@ class EOWorkflow:
                 )
 
     def _execute_nodes(
-        self, *, uid_input_kwargs: Dict[str, Dict[str, object]], out_degrees: Dict[str, int], raise_errors: bool
-    ) -> Tuple[dict, dict]:
+        self, *, uid_input_kwargs: dict[str, dict[str, object]], out_degrees: dict[str, int], raise_errors: bool
+    ) -> tuple[dict, dict]:
         """Executes workflow nodes in the predetermined order.
 
         :param uid_input_kwargs: External input arguments to the workflow.
@@ -196,7 +196,7 @@ class EOWorkflow:
             of tasks that depend on this task.)
         :return: Results of a workflow
         """
-        intermediate_results: Dict[str, object] = {}
+        intermediate_results: dict[str, object] = {}
         output_results = {}
         stats_dict = {}
 
@@ -221,8 +221,8 @@ class EOWorkflow:
         return output_results, stats_dict
 
     def _execute_node(
-        self, *, node: EONode, node_input_values: List[object], node_input_kwargs: Dict[str, object], raise_errors: bool
-    ) -> Tuple[object, NodeStats]:
+        self, *, node: EONode, node_input_values: list[object], node_input_kwargs: dict[str, object], raise_errors: bool
+    ) -> tuple[object, NodeStats]:
         """Executes a node in the workflow by running its task and returning the results.
 
         :param node: A node of the workflow.
@@ -259,8 +259,8 @@ class EOWorkflow:
 
     @staticmethod
     def _execute_task(
-        task: EOTask, task_args: List[object], task_kwargs: Dict[str, object], raise_errors: bool
-    ) -> Tuple[object, bool]:
+        task: EOTask, task_args: list[object], task_kwargs: dict[str, object], raise_errors: bool
+    ) -> tuple[object, bool]:
         """Executes an EOTask and handles any potential exceptions."""
         if raise_errors:
             return task.execute(*task_args, **task_kwargs), True
@@ -275,7 +275,7 @@ class EOWorkflow:
 
     @staticmethod
     def _relax_dependencies(
-        *, node: EONode, out_degrees: Dict[str, int], intermediate_results: Dict[str, object]
+        *, node: EONode, out_degrees: dict[str, int], intermediate_results: dict[str, object]
     ) -> None:
         """Relaxes dependencies incurred by `node` after it has been successfully executed. All the nodes it
         depended on are updated. If `node` was the last remaining node depending on a node `n` then `n`'s result
@@ -297,7 +297,7 @@ class EOWorkflow:
                 )
                 del intermediate_results[relevant_node.uid]
 
-    def get_nodes(self) -> List[EONode]:
+    def get_nodes(self) -> list[EONode]:
         """Returns an ordered list of all nodes within this workflow, ordered in the execution order.
 
         :return: List of all nodes withing workflow. The order of nodes is the same as the order of execution.
@@ -346,10 +346,10 @@ class EOWorkflow:
 class WorkflowResults:
     """An object containing results of an EOWorkflow execution."""
 
-    outputs: Dict[str, object]
+    outputs: dict[str, object]
     start_time: dt.datetime
     end_time: dt.datetime
-    stats: Dict[str, NodeStats]
+    stats: dict[str, NodeStats]
     error_node_uid: str | None = field(init=False, default=None)
 
     def __post_init__(self) -> None:

--- a/core/eolearn/core/eoworkflow.py
+++ b/core/eolearn/core/eoworkflow.py
@@ -23,7 +23,7 @@ import datetime as dt
 import logging
 import traceback
 from dataclasses import dataclass, field, fields
-from typing import Dict, List, Optional, Sequence, Set, Tuple, cast
+from typing import Dict, List, Sequence, Set, Tuple, cast
 
 from .eodata import EOPatch
 from .eonode import EONode, NodeStats
@@ -127,7 +127,7 @@ class EOWorkflow:
         return cls(list(all_nodes))
 
     def execute(
-        self, input_kwargs: Optional[Dict[EONode, Dict[str, object]]] = None, raise_errors: bool = True
+        self, input_kwargs: Dict[EONode, Dict[str, object]] | None = None, raise_errors: bool = True
     ) -> "WorkflowResults":
         """Executes the workflow.
 
@@ -304,7 +304,7 @@ class EOWorkflow:
         """
         return self._nodes[:]
 
-    def get_node_with_uid(self, uid: Optional[str], fail_if_missing: bool = False) -> Optional[EONode]:
+    def get_node_with_uid(self, uid: str | None, fail_if_missing: bool = False) -> EONode | None:
         """Returns node with give uid, if it exists in the workflow."""
         if uid in self._uid_dict:
             return self._uid_dict[uid]
@@ -320,7 +320,7 @@ class EOWorkflow:
         visualization = self._get_visualization()
         return visualization.get_dot()
 
-    def dependency_graph(self, filename: Optional[str] = None):  # type: ignore[no-untyped-def] # same as get_dot
+    def dependency_graph(self, filename: str | None = None):  # type: ignore[no-untyped-def] # same as get_dot
         """Visualize the computational graph.
 
         :param filename: Filename of the output image together with file extension. Supported formats: `png`, `jpg`,
@@ -350,7 +350,7 @@ class WorkflowResults:
     start_time: dt.datetime
     end_time: dt.datetime
     stats: Dict[str, NodeStats]
-    error_node_uid: Optional[str] = field(init=False, default=None)
+    error_node_uid: str | None = field(init=False, default=None)
 
     def __post_init__(self) -> None:
         """Checks if there is any node that failed during the workflow execution."""

--- a/core/eolearn/core/eoworkflow.py
+++ b/core/eolearn/core/eoworkflow.py
@@ -17,6 +17,8 @@ For the full list of contributors, see the CREDITS file in the root directory of
 
 This source code is licensed under the MIT license, see the LICENSE file in the root directory of this source tree.
 """
+from __future__ import annotations
+
 import datetime as dt
 import logging
 import traceback

--- a/core/eolearn/core/eoworkflow_tasks.py
+++ b/core/eolearn/core/eoworkflow_tasks.py
@@ -8,8 +8,6 @@ This source code is licensed under the MIT license, see the LICENSE file in the 
 """
 from __future__ import annotations
 
-from typing import Optional
-
 from .eodata import EOPatch
 from .eotask import EOTask
 from .types import FeaturesSpecification
@@ -19,13 +17,13 @@ from .utils.common import generate_uid
 class InputTask(EOTask):
     """Introduces data into an EOWorkflow, where the data can be specified at initialization or at execution."""
 
-    def __init__(self, value: Optional[object] = None):
+    def __init__(self, value: object | None = None):
         """
         :param value: Default value that the task should provide as a result. Can be overridden in execution arguments
         """
         self.value = value
 
-    def execute(self, *, value: Optional[object] = None) -> object:
+    def execute(self, *, value: object | None = None) -> object:
         """
         :param value: A value that the task should provide as its result. If not set uses the value from initialization
         :return: Directly returns `value`
@@ -36,7 +34,7 @@ class InputTask(EOTask):
 class OutputTask(EOTask):
     """Stores data as an output of `EOWorkflow` results."""
 
-    def __init__(self, name: Optional[str] = None, features: FeaturesSpecification = ...):
+    def __init__(self, name: str | None = None, features: FeaturesSpecification = ...):
         """
         :param name: A name under which the data will be saved in `WorkflowResults`, auto-generated if `None`
         :param features: A collection of features to be kept if the data is an `EOPatch`

--- a/core/eolearn/core/extra/ray.py
+++ b/core/eolearn/core/extra/ray.py
@@ -10,7 +10,7 @@ This source code is licensed under the MIT license, see the LICENSE file in the 
 """
 from __future__ import annotations
 
-from typing import Any, Callable, Collection, Generator, Iterable, List, Tuple, TypeVar, cast
+from typing import Any, Callable, Collection, Generator, Iterable, List, TypeVar, cast
 
 try:
     import ray
@@ -29,7 +29,7 @@ _OutputType = TypeVar("_OutputType")
 class RayExecutor(EOExecutor):
     """A special type of `EOExecutor` that works with Ray framework"""
 
-    def run(self, **tqdm_kwargs: Any) -> List[WorkflowResults]:  # type: ignore[override]
+    def run(self, **tqdm_kwargs: Any) -> list[WorkflowResults]:  # type: ignore[override]
         """Runs the executor using a Ray cluster
 
         Before calling this method make sure to initialize a Ray cluster using `ray.init`.
@@ -45,8 +45,8 @@ class RayExecutor(EOExecutor):
 
     @classmethod
     def _run_execution(
-        cls, processing_args: List[_ProcessingData], run_params: _ExecutionRunParams
-    ) -> List[WorkflowResults]:
+        cls, processing_args: list[_ProcessingData], run_params: _ExecutionRunParams
+    ) -> list[WorkflowResults]:
         """Runs ray execution"""
         futures = [_ray_workflow_executor.remote(workflow_args) for workflow_args in processing_args]
         return join_ray_futures(futures, **run_params.tqdm_kwargs)
@@ -66,7 +66,7 @@ def _ray_workflow_executor(workflow_args: _ProcessingData) -> WorkflowResults:
 
 def parallelize_with_ray(
     function: Callable[[_InputType], _OutputType], *params: Iterable[_InputType], **tqdm_kwargs: Any
-) -> List[_OutputType]:
+) -> list[_OutputType]:
     """Parallelizes function execution with Ray.
 
     Note that this function will automatically connect to a Ray cluster, if a connection wouldn't exist yet. But it
@@ -85,7 +85,7 @@ def parallelize_with_ray(
     return join_ray_futures(futures, **tqdm_kwargs)
 
 
-def join_ray_futures(futures: List[ray.ObjectRef], **tqdm_kwargs: Any) -> List[Any]:
+def join_ray_futures(futures: list[ray.ObjectRef], **tqdm_kwargs: Any) -> list[Any]:
     """Resolves futures, monitors progress, and returns a list of results.
 
     :param futures: A list of futures to be joined. Note that this list will be reduced into an empty list as a side
@@ -95,7 +95,7 @@ def join_ray_futures(futures: List[ray.ObjectRef], **tqdm_kwargs: Any) -> List[A
     :param tqdm_kwargs: Keyword arguments that will be propagated to `tqdm` progress bar.
     :return: A list of results in the order that corresponds with the order of the given input `futures`.
     """
-    results: List[Any | None] = [None] * len(futures)
+    results: list[Any | None] = [None] * len(futures)
     for position, result in join_ray_futures_iter(futures, **tqdm_kwargs):
         results[position] = result
 
@@ -103,8 +103,8 @@ def join_ray_futures(futures: List[ray.ObjectRef], **tqdm_kwargs: Any) -> List[A
 
 
 def join_ray_futures_iter(
-    futures: List[ray.ObjectRef], update_interval: float = 0.5, **tqdm_kwargs: Any
-) -> Generator[Tuple[int, Any], None, None]:
+    futures: list[ray.ObjectRef], update_interval: float = 0.5, **tqdm_kwargs: Any
+) -> Generator[tuple[int, Any], None, None]:
     """Resolves futures, monitors progress, and serves as an iterator over results.
 
     :param futures: A list of futures to be joined. Note that this list will be reduced into an empty list as a side
@@ -119,7 +119,7 @@ def join_ray_futures_iter(
 
     def _ray_wait_function(
         remaining_futures: Collection[ray.ObjectRef],
-    ) -> Tuple[Collection[ray.ObjectRef], Collection[ray.ObjectRef]]:
+    ) -> tuple[Collection[ray.ObjectRef], Collection[ray.ObjectRef]]:
         return ray.wait(remaining_futures, num_returns=len(remaining_futures), timeout=float(update_interval))
 
     return _base_join_futures_iter(_ray_wait_function, ray.get, futures, **tqdm_kwargs)

--- a/core/eolearn/core/extra/ray.py
+++ b/core/eolearn/core/extra/ray.py
@@ -8,6 +8,8 @@ For the full list of contributors, see the CREDITS file in the root directory of
 
 This source code is licensed under the MIT license, see the LICENSE file in the root directory of this source tree.
 """
+from __future__ import annotations
+
 from typing import Any, Callable, Collection, Generator, Iterable, List, Optional, Tuple, TypeVar, cast
 
 try:

--- a/core/eolearn/core/extra/ray.py
+++ b/core/eolearn/core/extra/ray.py
@@ -10,7 +10,7 @@ This source code is licensed under the MIT license, see the LICENSE file in the 
 """
 from __future__ import annotations
 
-from typing import Any, Callable, Collection, Generator, Iterable, List, Optional, Tuple, TypeVar, cast
+from typing import Any, Callable, Collection, Generator, Iterable, List, Tuple, TypeVar, cast
 
 try:
     import ray
@@ -95,7 +95,7 @@ def join_ray_futures(futures: List[ray.ObjectRef], **tqdm_kwargs: Any) -> List[A
     :param tqdm_kwargs: Keyword arguments that will be propagated to `tqdm` progress bar.
     :return: A list of results in the order that corresponds with the order of the given input `futures`.
     """
-    results: List[Optional[Any]] = [None] * len(futures)
+    results: List[Any | None] = [None] * len(futures)
     for position, result in join_ray_futures_iter(futures, **tqdm_kwargs):
         results[position] = result
 

--- a/core/eolearn/core/graph.py
+++ b/core/eolearn/core/graph.py
@@ -166,7 +166,7 @@ class DirectedGraph(Generic[_T]):
         return copy.copy(self._adj_dict[vertex])
 
     @staticmethod
-    def from_edges(edges: Sequence[tuple[_T, _T]]) -> "DirectedGraph[_T]":
+    def from_edges(edges: Sequence[tuple[_T, _T]]) -> DirectedGraph[_T]:
         """Return DirectedGraph created from edges.
         :param edges: Pairs of objects that describe all the edges of the graph
         """
@@ -176,7 +176,7 @@ class DirectedGraph(Generic[_T]):
         return dag
 
     @staticmethod
-    def _is_cyclic(graph: "DirectedGraph") -> bool:
+    def _is_cyclic(graph: DirectedGraph) -> bool:
         """True if the directed graph contains a cycle. False otherwise.
 
         The algorithm is naive, running in O(V^2) time, and not intended for serious use! For production purposes on

--- a/core/eolearn/core/graph.py
+++ b/core/eolearn/core/graph.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import collections
 import copy
-from typing import DefaultDict, Dict, Generic, Iterator, List, Sequence, Set, Tuple, TypeVar
+from typing import Generic, Iterator, Sequence, TypeVar
 
 _T = TypeVar("_T")
 
@@ -28,7 +28,7 @@ class DirectedGraph(Generic[_T]):
     :param adjacency_dict: A dictionary mapping vertices to lists of neighbors
     """
 
-    def __init__(self, adjacency_dict: Dict[_T, List[_T]] | None = None):
+    def __init__(self, adjacency_dict: dict[_T, list[_T]] | None = None):
         self._adj_dict = (
             collections.defaultdict(list, adjacency_dict) if adjacency_dict else collections.defaultdict(list)
         )
@@ -50,8 +50,8 @@ class DirectedGraph(Generic[_T]):
         """Returns iterator over the vertices of the graph."""
         return iter(self._vertices)
 
-    def _make_indegrees_dict(self) -> DefaultDict[_T, int]:
-        indegrees: DefaultDict[_T, int] = collections.defaultdict(int)
+    def _make_indegrees_dict(self) -> collections.defaultdict[_T, int]:
+        indegrees: collections.defaultdict[_T, int] = collections.defaultdict(int)
 
         for u_vertex in self._adj_dict:
             for v_vertex in self._adj_dict[u_vertex]:
@@ -59,7 +59,7 @@ class DirectedGraph(Generic[_T]):
 
         return indegrees
 
-    def get_indegrees(self) -> Dict[_T, int]:
+    def get_indegrees(self) -> dict[_T, int]:
         """Returns a dictionary containing in-degrees of vertices of the graph."""
         return dict(self._indegrees)
 
@@ -72,7 +72,7 @@ class DirectedGraph(Generic[_T]):
         """
         return self._indegrees[vertex]
 
-    def get_outdegrees(self) -> Dict[_T, int]:
+    def get_outdegrees(self) -> dict[_T, int]:
         """
         :return: dictionary of out-degrees, see get_outdegree
         """
@@ -87,13 +87,13 @@ class DirectedGraph(Generic[_T]):
         """
         return len(self._adj_dict[vertex])
 
-    def get_adj_dict(self) -> Dict[_T, list]:
+    def get_adj_dict(self) -> dict[_T, list]:
         """
         :return: adj_dict
         """
         return {vertex: copy.copy(neighbours) for vertex, neighbours in self._adj_dict.items()}
 
-    def get_vertices(self) -> Set[_T]:
+    def get_vertices(self) -> set[_T]:
         """Returns the set of vertices of the graph."""
         return set(self._vertices)
 
@@ -161,12 +161,12 @@ class DirectedGraph(Generic[_T]):
         """True if `u_vertex -> v_vertex` is an edge of the graph. False otherwise."""
         return v_vertex in self._adj_dict[u_vertex]
 
-    def get_neighbors(self, vertex: _T) -> List[_T]:
+    def get_neighbors(self, vertex: _T) -> list[_T]:
         """Returns the set of successor vertices of `vertex`."""
         return copy.copy(self._adj_dict[vertex])
 
     @staticmethod
-    def from_edges(edges: Sequence[Tuple[_T, _T]]) -> "DirectedGraph[_T]":
+    def from_edges(edges: Sequence[tuple[_T, _T]]) -> "DirectedGraph[_T]":
         """Return DirectedGraph created from edges.
         :param edges: Pairs of objects that describe all the edges of the graph
         """
@@ -197,7 +197,7 @@ class DirectedGraph(Generic[_T]):
                         stack.append(v)
         return False
 
-    def topologically_ordered_vertices(self) -> List[_T]:
+    def topologically_ordered_vertices(self) -> list[_T]:
         """Computes an ordering `<` of vertices so that for any two vertices `v` and `v'` we have that if `v˙ depends
         on `v'` then `v' < v`. In words, all dependencies of a vertex precede the vertex in this ordering.
 

--- a/core/eolearn/core/graph.py
+++ b/core/eolearn/core/graph.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import collections
 import copy
-from typing import DefaultDict, Dict, Generic, Iterator, List, Optional, Sequence, Set, Tuple, TypeVar
+from typing import DefaultDict, Dict, Generic, Iterator, List, Sequence, Set, Tuple, TypeVar
 
 _T = TypeVar("_T")
 
@@ -28,7 +28,7 @@ class DirectedGraph(Generic[_T]):
     :param adjacency_dict: A dictionary mapping vertices to lists of neighbors
     """
 
-    def __init__(self, adjacency_dict: Optional[Dict[_T, List[_T]]] = None):
+    def __init__(self, adjacency_dict: Dict[_T, List[_T]] | None = None):
         self._adj_dict = (
             collections.defaultdict(list, adjacency_dict) if adjacency_dict else collections.defaultdict(list)
         )

--- a/core/eolearn/core/graph.py
+++ b/core/eolearn/core/graph.py
@@ -7,6 +7,7 @@ For the full list of contributors, see the CREDITS file in the root directory of
 
 This source code is licensed under the MIT license, see the LICENSE file in the root directory of this source tree.
 """
+from __future__ import annotations
 
 import collections
 import copy

--- a/core/eolearn/core/utils/parallelize.py
+++ b/core/eolearn/core/utils/parallelize.py
@@ -7,6 +7,8 @@ For the full list of contributors, see the CREDITS file in the root directory of
 
 This source code is licensed under the MIT license, see the LICENSE file in the root directory of this source tree.
 """
+from __future__ import annotations
+
 import concurrent.futures
 import multiprocessing
 from concurrent.futures import FIRST_COMPLETED, Executor, Future, ProcessPoolExecutor, ThreadPoolExecutor

--- a/core/eolearn/core/utils/parallelize.py
+++ b/core/eolearn/core/utils/parallelize.py
@@ -13,14 +13,14 @@ import concurrent.futures
 import multiprocessing
 from concurrent.futures import FIRST_COMPLETED, Executor, Future, ProcessPoolExecutor, ThreadPoolExecutor
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable, Collection, Generator, Iterable, List, Optional, Tuple, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Callable, Collection, Generator, Iterable, List, Tuple, TypeVar, cast
 
 from tqdm.auto import tqdm
 
 if TYPE_CHECKING:
     from threading import Lock
 
-    MULTIPROCESSING_LOCK: Optional[Lock] = None
+    MULTIPROCESSING_LOCK: Lock | None = None
 else:
     MULTIPROCESSING_LOCK = None
 
@@ -39,7 +39,7 @@ class _ProcessingType(Enum):
     RAY = "ray"
 
 
-def _decide_processing_type(workers: Optional[int], multiprocess: bool) -> _ProcessingType:
+def _decide_processing_type(workers: int | None, multiprocess: bool) -> _ProcessingType:
     """Decides processing type according to given parameters.
 
     :param workers: A number of workers to be used (either threads or processes). If a single worker is given it will
@@ -57,7 +57,7 @@ def _decide_processing_type(workers: Optional[int], multiprocess: bool) -> _Proc
 def parallelize(
     function: Callable[..., _OutputType],
     *params: Iterable[Any],
-    workers: Optional[int],
+    workers: int | None,
     multiprocess: bool = True,
     **tqdm_kwargs: Any,
 ) -> List[_OutputType]:
@@ -142,7 +142,7 @@ def join_futures(futures: List[Future], **tqdm_kwargs: Any) -> List[Any]:
     :param tqdm_kwargs: Keyword arguments that will be propagated to `tqdm` progress bar.
     :return: A list of results in the order that corresponds with the order of the given input `futures`.
     """
-    results: List[Optional[Any]] = [None] * len(futures)
+    results: List[Any | None] = [None] * len(futures)
     for position, result in join_futures_iter(futures, **tqdm_kwargs):
         results[position] = result
 

--- a/core/eolearn/core/utils/parallelize.py
+++ b/core/eolearn/core/utils/parallelize.py
@@ -13,7 +13,7 @@ import concurrent.futures
 import multiprocessing
 from concurrent.futures import FIRST_COMPLETED, Executor, Future, ProcessPoolExecutor, ThreadPoolExecutor
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable, Collection, Generator, Iterable, List, Tuple, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Callable, Collection, Generator, Iterable, List, TypeVar, cast
 
 from tqdm.auto import tqdm
 
@@ -60,7 +60,7 @@ def parallelize(
     workers: int | None,
     multiprocess: bool = True,
     **tqdm_kwargs: Any,
-) -> List[_OutputType]:
+) -> list[_OutputType]:
     """Parallelizes the function on given parameters using the specified number of workers.
 
     :param function: A function to be parallelized.
@@ -120,7 +120,7 @@ def submit_and_monitor_execution(
     function: Callable[..., _OutputType],
     *params: Iterable[Any],
     **tqdm_kwargs: Any,
-) -> List[_OutputType]:
+) -> list[_OutputType]:
     """Performs the execution parallelization and monitors the process using a progress bar.
 
     :param executor: An object that performs parallelization.
@@ -132,7 +132,7 @@ def submit_and_monitor_execution(
     return join_futures(futures, **tqdm_kwargs)
 
 
-def join_futures(futures: List[Future], **tqdm_kwargs: Any) -> List[Any]:
+def join_futures(futures: list[Future], **tqdm_kwargs: Any) -> list[Any]:
     """Resolves futures, monitors progress, and returns a list of results.
 
     :param futures: A list of futures to be joined. Note that this list will be reduced into an empty list as a side
@@ -142,7 +142,7 @@ def join_futures(futures: List[Future], **tqdm_kwargs: Any) -> List[Any]:
     :param tqdm_kwargs: Keyword arguments that will be propagated to `tqdm` progress bar.
     :return: A list of results in the order that corresponds with the order of the given input `futures`.
     """
-    results: List[Any | None] = [None] * len(futures)
+    results: list[Any | None] = [None] * len(futures)
     for position, result in join_futures_iter(futures, **tqdm_kwargs):
         results[position] = result
 
@@ -150,8 +150,8 @@ def join_futures(futures: List[Future], **tqdm_kwargs: Any) -> List[Any]:
 
 
 def join_futures_iter(
-    futures: List[Future], update_interval: float = 0.5, **tqdm_kwargs: Any
-) -> Generator[Tuple[int, Any], None, None]:
+    futures: list[Future], update_interval: float = 0.5, **tqdm_kwargs: Any
+) -> Generator[tuple[int, Any], None, None]:
     """Resolves futures, monitors progress, and serves as an iterator over results.
 
     :param futures: A list of futures to be joined. Note that this list will be reduced into an empty list as a side
@@ -164,7 +164,7 @@ def join_futures_iter(
         in the original list to which `result` belongs to.
     """
 
-    def _wait_function(remaining_futures: Collection[Future]) -> Tuple[Collection[Future], Collection[Future]]:
+    def _wait_function(remaining_futures: Collection[Future]) -> tuple[Collection[Future], Collection[Future]]:
         done, not_done = concurrent.futures.wait(
             remaining_futures, timeout=float(update_interval), return_when=FIRST_COMPLETED
         )
@@ -177,11 +177,11 @@ def join_futures_iter(
 
 
 def _base_join_futures_iter(
-    wait_function: Callable[[Collection[_FutureType]], Tuple[Collection[_FutureType], Collection[_FutureType]]],
+    wait_function: Callable[[Collection[_FutureType]], tuple[Collection[_FutureType], Collection[_FutureType]]],
     get_result_function: Callable[[_FutureType], _OutputType],
-    futures: List[_FutureType],
+    futures: list[_FutureType],
     **tqdm_kwargs: Any,
-) -> Generator[Tuple[int, _OutputType], None, None]:
+) -> Generator[tuple[int, _OutputType], None, None]:
     """A generalized utility function that resolves futures, monitors progress, and serves as an iterator over
     results."""
     if not isinstance(futures, list):
@@ -200,7 +200,7 @@ def _base_join_futures_iter(
                 yield result_position, result
 
 
-def _make_copy_and_empty_given(items: List[_T]) -> List[_T]:
+def _make_copy_and_empty_given(items: list[_T]) -> list[_T]:
     """Removes items from the given list and returns its copy. The side effect of removing items is intentional."""
     items_copy = items[:]
     while items:

--- a/core/eolearn/core/utils/parsing.py
+++ b/core/eolearn/core/utils/parsing.py
@@ -9,7 +9,7 @@ This source code is licensed under the MIT license, see the LICENSE file in the 
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING, Callable, Iterable, List, Sequence, Tuple, Union, cast
+from typing import TYPE_CHECKING, Callable, Iterable, Sequence, Tuple, Union, cast
 
 from ..constants import FeatureType
 from ..types import (
@@ -106,7 +106,7 @@ class FeatureParser:
             )
         self._feature_specs = self._parse_features(features)
 
-    def _parse_features(self, features: FeaturesSpecification) -> List[_ParserFeaturesSpec]:
+    def _parse_features(self, features: FeaturesSpecification) -> list[_ParserFeaturesSpec]:
         """This method parses and validates input, returning a list of `(ftype, old_name, new_name)` triples.
 
         Due to typing issues the all-features requests are transformed from `(ftype, ...)` to `(ftype, None, None)`.
@@ -135,10 +135,10 @@ class FeatureParser:
     def _parse_dict(
         self,
         features: DictFeatureSpec,
-    ) -> List[_ParserFeaturesSpec]:
+    ) -> list[_ParserFeaturesSpec]:
         """Implements parsing and validation in case the input is a dictionary."""
 
-        feature_specs: List[_ParserFeaturesSpec] = []
+        feature_specs: list[_ParserFeaturesSpec] = []
 
         for feature_type, feature_names in features.items():
             feature_type = self._parse_feature_type(feature_type, message_about_position="keys of the dictionary")
@@ -160,10 +160,10 @@ class FeatureParser:
     def _parse_sequence(
         self,
         features: SingleFeatureSpec | SequenceFeatureSpec,
-    ) -> List[_ParserFeaturesSpec]:
+    ) -> list[_ParserFeaturesSpec]:
         """Implements parsing and validation in case the input is a tuple describing a single feature or a sequence."""
 
-        feature_specs: List[_ParserFeaturesSpec] = []
+        feature_specs: list[_ParserFeaturesSpec] = []
 
         # Check for possible singleton
         if 2 <= len(features) <= 3:
@@ -219,7 +219,7 @@ class FeatureParser:
         return feature_type
 
     @staticmethod
-    def _parse_feature_name(feature_type: FeatureType, name: object) -> Tuple[str, str]:
+    def _parse_feature_name(feature_type: FeatureType, name: object) -> tuple[str, str]:
         """Parses input in places where a feature name is expected, handling the cases of a name and renaming pair."""
         if isinstance(name, str):
             return name, name
@@ -247,14 +247,14 @@ class FeatureParser:
                 f" {specification} instead."
             )
 
-    def get_feature_specifications(self) -> List[Tuple[FeatureType, str | EllipsisType]]:
+    def get_feature_specifications(self) -> list[tuple[FeatureType, str | EllipsisType]]:
         """Returns the feature specifications in a more streamlined fashion.
 
         Requests for all features, e.g. `(FeatureType.DATA, ...)`, are returned directly.
         """
         return [(ftype, ... if fname is None else fname) for ftype, fname, _ in self._feature_specs]
 
-    def get_features(self, eopatch: EOPatch | None = None) -> List[FeatureSpec]:
+    def get_features(self, eopatch: EOPatch | None = None) -> list[FeatureSpec]:
         """Returns a list of `(feature_type, feature_name)` pairs.
 
         For features that specify renaming, the new name of the feature is ignored.
@@ -267,7 +267,7 @@ class FeatureParser:
         renamed_features = self.get_renamed_features(eopatch)
         return [feature[:2] for feature in renamed_features]  # pattern unpacking messes with typechecking
 
-    def get_renamed_features(self, eopatch: EOPatch | None = None) -> List[FeatureRenameSpec]:
+    def get_renamed_features(self, eopatch: EOPatch | None = None) -> list[FeatureRenameSpec]:
         """Returns a list of `(feature_type, old_name, new_name)` triples.
 
         For features without a specified renaming the new name is equal to the old one.
@@ -278,7 +278,7 @@ class FeatureParser:
 
         If `eopatch` is not provided the method fails if an all-feature request is in the specification.
         """
-        parsed_features: List[FeatureRenameSpec] = []
+        parsed_features: list[FeatureRenameSpec] = []
         for feature_spec in self._feature_specs:
             ftype, old_name, new_name = feature_spec
 
@@ -305,7 +305,7 @@ def parse_feature(
     feature: SingleFeatureSpec,
     eopatch: EOPatch | None = None,
     allowed_feature_types: EllipsisType | Iterable[FeatureType] | Callable[[FeatureType], bool] = ...,
-) -> Tuple[FeatureType, str | None]:
+) -> tuple[FeatureType, str | None]:
     """Parses input describing a single feature into a `(feature_type, feature_name)` pair.
 
     See :class:`FeatureParser<eolearn.core.utilities.FeatureParser>` for viable inputs.
@@ -337,7 +337,7 @@ def parse_features(
     features: FeaturesSpecification,
     eopatch: EOPatch | None = None,
     allowed_feature_types: EllipsisType | Iterable[FeatureType] | Callable[[FeatureType], bool] = ...,
-) -> List[FeatureSpec]:
+) -> list[FeatureSpec]:
     """Parses input describing features into a list of `(feature_type, feature_name)` pairs.
 
     See :class:`FeatureParser<eolearn.core.utilities.FeatureParser>` for viable inputs.
@@ -349,7 +349,7 @@ def parse_renamed_features(
     features: FeaturesSpecification,
     eopatch: EOPatch | None = None,
     allowed_feature_types: EllipsisType | Iterable[FeatureType] | Callable[[FeatureType], bool] = ...,
-) -> List[FeatureRenameSpec]:
+) -> list[FeatureRenameSpec]:
     """Parses input describing features into a list of `(feature_type, old_name, new_name)` triples.
 
     See :class:`FeatureParser<eolearn.core.utilities.FeatureParser>` for viable inputs.

--- a/core/eolearn/core/utils/parsing.py
+++ b/core/eolearn/core/utils/parsing.py
@@ -9,7 +9,7 @@ This source code is licensed under the MIT license, see the LICENSE file in the 
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING, Callable, Iterable, List, Optional, Sequence, Tuple, Union, cast
+from typing import TYPE_CHECKING, Callable, Iterable, List, Sequence, Tuple, Union, cast
 
 from ..constants import FeatureType
 from ..types import (
@@ -90,7 +90,7 @@ class FeatureParser:
     def __init__(
         self,
         features: FeaturesSpecification,
-        allowed_feature_types: Union[Iterable[FeatureType], Callable[[FeatureType], bool], EllipsisType] = ...,
+        allowed_feature_types: Iterable[FeatureType] | Callable[[FeatureType], bool] | EllipsisType = ...,
     ):
         """
         :param features: A collection of features in one of the supported formats
@@ -159,7 +159,7 @@ class FeatureParser:
 
     def _parse_sequence(
         self,
-        features: Union[SingleFeatureSpec, SequenceFeatureSpec],
+        features: SingleFeatureSpec | SequenceFeatureSpec,
     ) -> List[_ParserFeaturesSpec]:
         """Implements parsing and validation in case the input is a tuple describing a single feature or a sequence."""
 
@@ -200,7 +200,7 @@ class FeatureParser:
         parsed_name = self._parse_feature_name(feature_type, feature_name)
         return (feature_type, *parsed_name)
 
-    def _parse_feature_type(self, feature_type: Union[str, FeatureType], *, message_about_position: str) -> FeatureType:
+    def _parse_feature_type(self, feature_type: str | FeatureType, *, message_about_position: str) -> FeatureType:
         """Tries to extract a feature type if possible, fails otherwise.
 
         The parameter `message_about_position` is used for more informative error messages.
@@ -247,14 +247,14 @@ class FeatureParser:
                 f" {specification} instead."
             )
 
-    def get_feature_specifications(self) -> List[Tuple[FeatureType, Union[str, EllipsisType]]]:
+    def get_feature_specifications(self) -> List[Tuple[FeatureType, str | EllipsisType]]:
         """Returns the feature specifications in a more streamlined fashion.
 
         Requests for all features, e.g. `(FeatureType.DATA, ...)`, are returned directly.
         """
         return [(ftype, ... if fname is None else fname) for ftype, fname, _ in self._feature_specs]
 
-    def get_features(self, eopatch: Optional[EOPatch] = None) -> List[FeatureSpec]:
+    def get_features(self, eopatch: EOPatch | None = None) -> List[FeatureSpec]:
         """Returns a list of `(feature_type, feature_name)` pairs.
 
         For features that specify renaming, the new name of the feature is ignored.
@@ -267,7 +267,7 @@ class FeatureParser:
         renamed_features = self.get_renamed_features(eopatch)
         return [feature[:2] for feature in renamed_features]  # pattern unpacking messes with typechecking
 
-    def get_renamed_features(self, eopatch: Optional[EOPatch] = None) -> List[FeatureRenameSpec]:
+    def get_renamed_features(self, eopatch: EOPatch | None = None) -> List[FeatureRenameSpec]:
         """Returns a list of `(feature_type, old_name, new_name)` triples.
 
         For features without a specified renaming the new name is equal to the old one.
@@ -303,9 +303,9 @@ class FeatureParser:
 
 def parse_feature(
     feature: SingleFeatureSpec,
-    eopatch: Optional[EOPatch] = None,
-    allowed_feature_types: Union[EllipsisType, Iterable[FeatureType], Callable[[FeatureType], bool]] = ...,
-) -> Tuple[FeatureType, Optional[str]]:
+    eopatch: EOPatch | None = None,
+    allowed_feature_types: EllipsisType | Iterable[FeatureType] | Callable[[FeatureType], bool] = ...,
+) -> Tuple[FeatureType, str | None]:
     """Parses input describing a single feature into a `(feature_type, feature_name)` pair.
 
     See :class:`FeatureParser<eolearn.core.utilities.FeatureParser>` for viable inputs.
@@ -319,8 +319,8 @@ def parse_feature(
 
 def parse_renamed_feature(
     feature: SingleFeatureSpec,
-    eopatch: Optional[EOPatch] = None,
-    allowed_feature_types: Union[EllipsisType, Iterable[FeatureType], Callable[[FeatureType], bool]] = ...,
+    eopatch: EOPatch | None = None,
+    allowed_feature_types: EllipsisType | Iterable[FeatureType] | Callable[[FeatureType], bool] = ...,
 ) -> FeatureRenameSpec:
     """Parses input describing a single feature into a `(feature_type, old_name, new_name)` triple.
 
@@ -335,8 +335,8 @@ def parse_renamed_feature(
 
 def parse_features(
     features: FeaturesSpecification,
-    eopatch: Optional[EOPatch] = None,
-    allowed_feature_types: Union[EllipsisType, Iterable[FeatureType], Callable[[FeatureType], bool]] = ...,
+    eopatch: EOPatch | None = None,
+    allowed_feature_types: EllipsisType | Iterable[FeatureType] | Callable[[FeatureType], bool] = ...,
 ) -> List[FeatureSpec]:
     """Parses input describing features into a list of `(feature_type, feature_name)` pairs.
 
@@ -347,8 +347,8 @@ def parse_features(
 
 def parse_renamed_features(
     features: FeaturesSpecification,
-    eopatch: Optional[EOPatch] = None,
-    allowed_feature_types: Union[EllipsisType, Iterable[FeatureType], Callable[[FeatureType], bool]] = ...,
+    eopatch: EOPatch | None = None,
+    allowed_feature_types: EllipsisType | Iterable[FeatureType] | Callable[[FeatureType], bool] = ...,
 ) -> List[FeatureRenameSpec]:
     """Parses input describing features into a list of `(feature_type, old_name, new_name)` triples.
 

--- a/core/eolearn/core/utils/raster.py
+++ b/core/eolearn/core/utils/raster.py
@@ -56,7 +56,7 @@ def fast_nanpercentile(data: np.ndarray, percentile: float, *, method: str = "li
     return combined_data
 
 
-def constant_pad(
+def constant_pad(  # noqa: C901
     array: np.ndarray,
     multiple_of: Tuple[int, int],
     up_down_rule: Literal["even", "up", "down"] = "even",

--- a/core/eolearn/tests/test_eoexecutor.py
+++ b/core/eolearn/tests/test_eoexecutor.py
@@ -212,7 +212,7 @@ def test_with_lock(num_workers):
         handler.close()
         logger.removeHandler(handler)
 
-        with open(fp.name, "r") as log_file:
+        with open(fp.name) as log_file:
             lines = log_file.read().strip("\n ").split("\n")
 
         assert len(lines) == 2 * num_workers
@@ -235,7 +235,7 @@ def test_without_lock(num_workers):
         handler.close()
         logger.removeHandler(handler)
 
-        with open(fp.name, "r") as log_file:
+        with open(fp.name) as log_file:
             lines = log_file.read().strip("\n ").split("\n")
 
         assert len(lines) == 2 * num_workers

--- a/coregistration/eolearn/coregistration/coregistration.py
+++ b/coregistration/eolearn/coregistration/coregistration.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import logging
 import warnings
-from typing import Tuple
 
 import cv2
 import numpy as np
@@ -37,10 +36,10 @@ class ECCRegistrationTask(EOTask):
 
     def __init__(
         self,
-        registration_feature: Tuple[FeatureType, str],
-        reference_feature: Tuple[FeatureType, str],
+        registration_feature: tuple[FeatureType, str],
+        reference_feature: tuple[FeatureType, str],
         channel: int,
-        valid_mask_feature: Tuple[FeatureType, str] | None = None,
+        valid_mask_feature: tuple[FeatureType, str] | None = None,
         apply_to_features: FeaturesSpecification = ...,
         interpolation_mode: int = cv2.INTER_LINEAR,
         warp_mode: int = cv2.MOTION_TRANSLATION,
@@ -160,7 +159,7 @@ class ECCRegistrationTask(EOTask):
         new_eopatch[FeatureType.META_INFO, "warp_matrices"] = warp_matrices
         return new_eopatch
 
-    def warp(self, img: np.ndarray, warp_matrix: np.ndarray, shape: Tuple[int, int], flags: int) -> np.ndarray:
+    def warp(self, img: np.ndarray, warp_matrix: np.ndarray, shape: tuple[int, int], flags: int) -> np.ndarray:
         """Transform the target image with the estimated transformation matrix"""
         if warp_matrix.shape == (3, 3):
             return cv2.warpPerspective(

--- a/coregistration/eolearn/coregistration/coregistration.py
+++ b/coregistration/eolearn/coregistration/coregistration.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 import warnings
-from typing import Optional, Tuple
+from typing import Tuple
 
 import cv2
 import numpy as np
@@ -40,7 +40,7 @@ class ECCRegistrationTask(EOTask):
         registration_feature: Tuple[FeatureType, str],
         reference_feature: Tuple[FeatureType, str],
         channel: int,
-        valid_mask_feature: Optional[Tuple[FeatureType, str]] = None,
+        valid_mask_feature: Tuple[FeatureType, str] | None = None,
         apply_to_features: FeaturesSpecification = ...,
         interpolation_mode: int = cv2.INTER_LINEAR,
         warp_mode: int = cv2.MOTION_TRANSLATION,
@@ -98,7 +98,7 @@ class ECCRegistrationTask(EOTask):
         self,
         src: np.ndarray,
         trg: np.ndarray,
-        valid_mask: Optional[np.ndarray] = None,
+        valid_mask: np.ndarray | None = None,
         warp_mode: int = cv2.MOTION_TRANSLATION,
     ) -> np.ndarray:
         """Method that estimates the transformation between source and target image"""

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-  # noqa: UP009
 #
 # Configuration file for the Sphinx documentation builder.
 #
@@ -242,7 +242,7 @@ def copy_documentation_examples(source_folder, target_folder):
     files_to_include = ["core/images/eopatch.png"]
 
     for rst_file in ["examples.rst", "index.rst"]:
-        with open(rst_file, "r") as fp:
+        with open(rst_file) as fp:
             content = fp.read()
 
         for line in content.split("\n"):
@@ -271,7 +271,7 @@ def process_readme():
     """Function which will process README.md file and divide it into INTRO.md and INSTALL.md, which will be used in
     documentation
     """
-    with open("../../README.md", "r") as file:
+    with open("../../README.md") as file:
         readme = file.read()
 
     readme = readme.replace("# eo-learn", "# Introduction").replace("docs/source/", "")

--- a/features/eolearn/features/bands_extraction.py
+++ b/features/eolearn/features/bands_extraction.py
@@ -8,8 +8,6 @@ This source code is licensed under the MIT license, see the LICENSE file in the 
 """
 from __future__ import annotations
 
-from typing import List, Tuple
-
 import numpy as np
 
 from eolearn.core import MapFeatureTask
@@ -25,7 +23,7 @@ class EuclideanNormTask(MapFeatureTask):
     """
 
     def __init__(
-        self, input_feature: SingleFeatureSpec, output_feature: SingleFeatureSpec, bands: List[int] | None = None
+        self, input_feature: SingleFeatureSpec, output_feature: SingleFeatureSpec, bands: list[int] | None = None
     ):
         """
         :param input_feature: A source feature from which to take the subset of bands.
@@ -57,7 +55,7 @@ class NormalizedDifferenceIndexTask(MapFeatureTask):
         self,
         input_feature: SingleFeatureSpec,
         output_feature: SingleFeatureSpec,
-        bands: Tuple[int, int],
+        bands: tuple[int, int],
         acorvi_constant: float = 0,
         undefined_value: float = np.nan,
     ):

--- a/features/eolearn/features/bands_extraction.py
+++ b/features/eolearn/features/bands_extraction.py
@@ -8,7 +8,7 @@ This source code is licensed under the MIT license, see the LICENSE file in the 
 """
 from __future__ import annotations
 
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 import numpy as np
 
@@ -25,7 +25,7 @@ class EuclideanNormTask(MapFeatureTask):
     """
 
     def __init__(
-        self, input_feature: SingleFeatureSpec, output_feature: SingleFeatureSpec, bands: Optional[List[int]] = None
+        self, input_feature: SingleFeatureSpec, output_feature: SingleFeatureSpec, bands: List[int] | None = None
     ):
         """
         :param input_feature: A source feature from which to take the subset of bands.

--- a/features/eolearn/features/clustering.py
+++ b/features/eolearn/features/clustering.py
@@ -8,7 +8,7 @@ This source code is licensed under the MIT license, see the LICENSE file in the 
 """
 from __future__ import annotations
 
-from typing import Callable, Literal, Optional, Union
+from typing import Callable, Literal
 
 import numpy as np
 from sklearn.cluster import AgglomerativeClustering
@@ -31,13 +31,13 @@ class ClusteringTask(EOTask):
         self,
         features: FeatureSpec,
         new_feature_name: str,
-        distance_threshold: Optional[float] = None,
-        n_clusters: Optional[int] = None,
+        distance_threshold: float | None = None,
+        n_clusters: int | None = None,
         affinity: Literal["euclidean", "l1", "l2", "manhattan", "cosine"] = "cosine",
         linkage: Literal["ward", "complete", "average", "single"] = "single",
         remove_small: int = 0,
-        connectivity: Union[None, np.ndarray, Callable] = None,
-        mask_name: Optional[str] = None,
+        connectivity: None | np.ndarray | Callable = None,
+        mask_name: str | None = None,
     ):
         """Class constructor
 
@@ -67,7 +67,7 @@ class ClusteringTask(EOTask):
         self.linkage = linkage
         self.new_feature_name = new_feature_name
         self.n_clusters = n_clusters
-        self.compute_full_tree: Union[Literal["auto"], bool] = "auto" if distance_threshold is None else True
+        self.compute_full_tree: Literal["auto"] | bool = "auto" if distance_threshold is None else True
         self.remove_small = remove_small
         self.connectivity = connectivity
         self.mask_name = mask_name

--- a/features/eolearn/features/doubly_logistic_approximation.py
+++ b/features/eolearn/features/doubly_logistic_approximation.py
@@ -9,7 +9,6 @@ This source code is licensed under the MIT license, see the LICENSE file in the 
 from __future__ import annotations
 
 import itertools as it
-from typing import List
 
 import numpy as np
 from scipy.optimize import curve_fit
@@ -39,7 +38,7 @@ class DoublyLogisticApproximationTask(EOTask):
         self,
         feature: SingleFeatureSpec,
         new_feature: SingleFeatureSpec = (FeatureType.DATA_TIMELESS, "DOUBLY_LOGISTIC_PARAM"),
-        initial_parameters: List[float] | None = None,
+        initial_parameters: list[float] | None = None,
         valid_mask: SingleFeatureSpec | None = None,
     ):
         self.initial_parameters = initial_parameters

--- a/features/eolearn/features/doubly_logistic_approximation.py
+++ b/features/eolearn/features/doubly_logistic_approximation.py
@@ -9,7 +9,7 @@ This source code is licensed under the MIT license, see the LICENSE file in the 
 from __future__ import annotations
 
 import itertools as it
-from typing import List, Optional
+from typing import List
 
 import numpy as np
 from scipy.optimize import curve_fit
@@ -39,8 +39,8 @@ class DoublyLogisticApproximationTask(EOTask):
         self,
         feature: SingleFeatureSpec,
         new_feature: SingleFeatureSpec = (FeatureType.DATA_TIMELESS, "DOUBLY_LOGISTIC_PARAM"),
-        initial_parameters: Optional[List[float]] = None,
-        valid_mask: Optional[SingleFeatureSpec] = None,
+        initial_parameters: List[float] | None = None,
+        valid_mask: SingleFeatureSpec | None = None,
     ):
         self.initial_parameters = initial_parameters
         self.feature = self.parse_feature(feature)

--- a/features/eolearn/features/feature_manipulation.py
+++ b/features/eolearn/features/feature_manipulation.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import datetime as dt
 import logging
 from functools import partial
-from typing import Any, Callable, Dict, Iterable, List, Literal, Optional, Union, cast
+from typing import Any, Callable, Dict, Iterable, List, Literal, cast
 
 import numpy as np
 from geopandas import GeoDataFrame
@@ -40,7 +40,7 @@ class SimpleFilterTask(EOTask):
     def __init__(
         self,
         feature: SingleFeatureSpec,
-        filter_func: Union[Callable[[np.ndarray], bool], Callable[[dt.datetime], bool]],
+        filter_func: Callable[[np.ndarray], bool] | Callable[[dt.datetime], bool],
         filter_features: FeaturesSpecification = ...,
     ):
         """
@@ -219,10 +219,10 @@ class LinearFunctionTask(MapFeatureTask):
     def __init__(
         self,
         input_features: FeaturesSpecification,
-        output_features: Optional[FeaturesSpecification] = None,
+        output_features: FeaturesSpecification | None = None,
         slope: float = 1,
         intercept: float = 0,
-        dtype: Union[str, type, np.dtype, None] = None,
+        dtype: str | type | np.dtype | None = None,
     ):
         """
         :param input_features: Feature or features on which the function is used.

--- a/features/eolearn/features/feature_manipulation.py
+++ b/features/eolearn/features/feature_manipulation.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import datetime as dt
 import logging
 from functools import partial
-from typing import Any, Callable, Dict, Iterable, List, Literal, cast
+from typing import Any, Callable, Iterable, Literal, cast
 
 import numpy as np
 from geopandas import GeoDataFrame
@@ -55,12 +55,12 @@ class SimpleFilterTask(EOTask):
         self.filter_func = filter_func
         self.filter_features_parser = self.get_feature_parser(filter_features)
 
-    def _get_filtered_indices(self, feature_data: Iterable) -> List[int]:
+    def _get_filtered_indices(self, feature_data: Iterable) -> list[int]:
         """Get valid time indices from either a numpy array or a list of timestamps."""
         return [idx for idx, img in enumerate(feature_data) if self.filter_func(img)]
 
     @staticmethod
-    def _filter_vector_feature(gdf: GeoDataFrame, good_idxs: List[int], timestamps: List[dt.datetime]) -> GeoDataFrame:
+    def _filter_vector_feature(gdf: GeoDataFrame, good_idxs: list[int], timestamps: list[dt.datetime]) -> GeoDataFrame:
         """Filters rows that don't match with the timestamps that will be kept."""
         timestamps_to_keep = {timestamps[idx] for idx in good_idxs}
         return gdf[gdf[TIMESTAMP_COLUMN].isin(timestamps_to_keep)]
@@ -283,7 +283,7 @@ class SpatialResizeTask(EOTask):
         )
 
     def execute(self, eopatch: EOPatch) -> EOPatch:
-        resize_fun_kwargs: Dict[str, Any]
+        resize_fun_kwargs: dict[str, Any]
         if self.resize_type == ResizeParam.RESOLUTION:
             if not eopatch.bbox:
                 raise ValueError("Resolution-specified resizing can only be done on EOPatches with a defined BBox.")

--- a/features/eolearn/features/hog.py
+++ b/features/eolearn/features/hog.py
@@ -9,7 +9,7 @@ This source code is licensed under the MIT license, see the LICENSE file in the 
 from __future__ import annotations
 
 import itertools as it
-from typing import Optional, Tuple
+from typing import Tuple
 
 import numpy as np
 import skimage.feature
@@ -37,7 +37,7 @@ class HOGTask(EOTask):
         visualize: bool = True,
         hog_feature_vector: bool = False,
         block_norm: str = "L2-Hys",
-        visualize_feature_name: Optional[str] = None,
+        visualize_feature_name: str | None = None,
     ):
         """
         :param feature: A feature that will be used and a new feature name where data will be saved, e.g.

--- a/features/eolearn/features/hog.py
+++ b/features/eolearn/features/hog.py
@@ -9,7 +9,6 @@ This source code is licensed under the MIT license, see the LICENSE file in the 
 from __future__ import annotations
 
 import itertools as it
-from typing import Tuple
 
 import numpy as np
 import skimage.feature
@@ -32,8 +31,8 @@ class HOGTask(EOTask):
         self,
         feature: SingleFeatureSpec,
         orientations: int = 9,
-        pixels_per_cell: Tuple[int, int] = (8, 8),
-        cells_per_block: Tuple[int, int] = (3, 3),
+        pixels_per_cell: tuple[int, int] = (8, 8),
+        cells_per_block: tuple[int, int] = (3, 3),
         visualize: bool = True,
         hog_feature_vector: bool = False,
         block_norm: str = "L2-Hys",
@@ -59,7 +58,7 @@ class HOGTask(EOTask):
         self.hog_feature_vector = hog_feature_vector
         self.visualize_name = visualize_feature_name
 
-    def _compute_hog(self, data: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:  # pylint: disable=too-many-locals
+    def _compute_hog(self, data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:  # pylint: disable=too-many-locals
         num_times, height, width, num_bands = data.shape
         is_multichannel = num_bands != 1
         hog_result = np.empty(

--- a/features/eolearn/features/interpolation.py
+++ b/features/eolearn/features/interpolation.py
@@ -121,7 +121,7 @@ class InterpolationTask(EOTask):
         interpolation_object: Callable,
         *,
         resample_range: ResampleRangeType = None,
-        result_interval: Tuple[float, float] | None = None,
+        result_interval: tuple[float, float] | None = None,
         mask_feature: SingleFeatureSpec | None = None,
         copy_features: FeaturesSpecification | None = None,
         unknown_value: float = np.nan,
@@ -208,7 +208,7 @@ class InterpolationTask(EOTask):
         return np.logical_or(start_nan, end_nan)
 
     @staticmethod
-    def _get_unique_times(data: np.ndarray, times: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    def _get_unique_times(data: np.ndarray, times: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         """Replace duplicate acquisitions which have same values on the chosen timescale with their average.
         The average is calculated with numpy.nanmean, meaning that NaN values are ignored when calculating the average.
 
@@ -312,7 +312,7 @@ class InterpolationTask(EOTask):
             return partial(self.interpolation_object, xp=times, fp=series, left=np.nan, right=np.nan)
         return self.interpolation_object(times, series, **self.interpolation_parameters)
 
-    def get_resampled_timestamp(self, timestamps: List[dt.datetime]) -> List[dt.datetime]:
+    def get_resampled_timestamp(self, timestamps: list[dt.datetime]) -> list[dt.datetime]:
         """Takes a list of timestamps and generates new list of timestamps according to `resample_range`"""
         if self.resample_range is None:
             return timestamps
@@ -509,7 +509,7 @@ class ResamplingTask(InterpolationTask):
         interpolation_object: Callable,
         resample_range: ResampleRangeType,
         *,
-        result_interval: Tuple[float, float] | None = None,
+        result_interval: tuple[float, float] | None = None,
         unknown_value: float = np.nan,
         **interpolation_parameters: Any,
     ):

--- a/features/eolearn/features/interpolation.py
+++ b/features/eolearn/features/interpolation.py
@@ -13,7 +13,7 @@ import inspect
 import warnings
 from collections import defaultdict
 from functools import partial
-from typing import Any, Callable, Iterable, List, Optional, Tuple, Union, cast
+from typing import Any, Callable, Iterable, List, Tuple, Union, cast
 
 import dateutil
 import numpy as np
@@ -121,9 +121,9 @@ class InterpolationTask(EOTask):
         interpolation_object: Callable,
         *,
         resample_range: ResampleRangeType = None,
-        result_interval: Optional[Tuple[float, float]] = None,
-        mask_feature: Optional[SingleFeatureSpec] = None,
-        copy_features: Optional[FeaturesSpecification] = None,
+        result_interval: Tuple[float, float] | None = None,
+        mask_feature: SingleFeatureSpec | None = None,
+        copy_features: FeaturesSpecification | None = None,
         unknown_value: float = np.nan,
         filling_factor: int = 10,
         scale_time: int = 3600,
@@ -338,7 +338,7 @@ class InterpolationTask(EOTask):
 
     @staticmethod
     def _get_eopatch_time_series(
-        eopatch: EOPatch, ref_date: Optional[dt.datetime] = None, scale_time: int = 1
+        eopatch: EOPatch, ref_date: dt.datetime | None = None, scale_time: int = 1
     ) -> np.ndarray:
         """Returns a numpy array with seconds passed between the reference date and the timestamp of each image.
 
@@ -509,7 +509,7 @@ class ResamplingTask(InterpolationTask):
         interpolation_object: Callable,
         resample_range: ResampleRangeType,
         *,
-        result_interval: Optional[Tuple[float, float]] = None,
+        result_interval: Tuple[float, float] | None = None,
         unknown_value: float = np.nan,
         **interpolation_parameters: Any,
     ):

--- a/features/eolearn/features/radiometric_normalization.py
+++ b/features/eolearn/features/radiometric_normalization.py
@@ -9,7 +9,6 @@ This source code is licensed under the MIT license, see the LICENSE file in the 
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from typing import Optional
 
 import numpy as np
 
@@ -37,7 +36,7 @@ class ReferenceScenesTask(EOTask):
         self,
         feature: SingleFeatureSpec,
         valid_fraction_feature: SingleFeatureSpec,
-        max_scene_number: Optional[int] = None,
+        max_scene_number: int | None = None,
     ):
         self.renamed_feature = parse_renamed_feature(feature)
         self.valid_fraction_feature = self.parse_feature(valid_fraction_feature)

--- a/geometry/eolearn/geometry/morphology.py
+++ b/geometry/eolearn/geometry/morphology.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import itertools as it
 from enum import Enum
-from typing import Callable, List, Optional, Tuple, Union, cast
+from typing import Callable, List, Tuple, cast
 
 import numpy as np
 import skimage.filters.rank
@@ -35,7 +35,7 @@ class ErosionTask(EOTask):
         self,
         mask_feature: SingleFeatureSpec,
         disk_radius: int = 1,
-        erode_labels: Optional[List[int]] = None,
+        erode_labels: List[int] | None = None,
         no_data_label: int = 0,
     ):
         if not isinstance(disk_radius, int) or disk_radius is None or disk_radius < 1:
@@ -139,10 +139,10 @@ class MorphologicalFilterTask(MapFeatureTask):
     def __init__(
         self,
         input_features: FeaturesSpecification,
-        output_features: Optional[FeaturesSpecification] = None,
+        output_features: FeaturesSpecification | None = None,
         *,
-        morph_operation: Union[MorphologicalOperations, Callable],
-        struct_elem: Optional[np.ndarray] = None,
+        morph_operation: MorphologicalOperations | Callable,
+        struct_elem: np.ndarray | None = None,
     ):
         """
         :param input_features: Input features to be processed.

--- a/geometry/eolearn/geometry/morphology.py
+++ b/geometry/eolearn/geometry/morphology.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import itertools as it
 from enum import Enum
-from typing import Callable, List, Tuple, cast
+from typing import Callable, Tuple, cast
 
 import numpy as np
 import skimage.filters.rank
@@ -35,7 +35,7 @@ class ErosionTask(EOTask):
         self,
         mask_feature: SingleFeatureSpec,
         disk_radius: int = 1,
-        erode_labels: List[int] | None = None,
+        erode_labels: list[int] | None = None,
         no_data_label: int = 0,
     ):
         if not isinstance(disk_radius, int) or disk_radius is None or disk_radius < 1:

--- a/geometry/eolearn/geometry/transformations.py
+++ b/geometry/eolearn/geometry/transformations.py
@@ -13,7 +13,7 @@ import itertools as it
 import logging
 import warnings
 from functools import partial
-from typing import Any, Callable, Iterator, List, Tuple, cast
+from typing import Any, Callable, Iterator, Tuple, cast
 
 import numpy as np
 import pandas as pd
@@ -63,10 +63,10 @@ class VectorToRasterTask(EOTask):
         vector_input: GeoDataFrame | SingleFeatureSpec,
         raster_feature: SingleFeatureSpec,
         *,
-        values: None | float | List[float] = None,
+        values: None | float | list[float] = None,
         values_column: str | None = None,
-        raster_shape: None | Tuple[int, int] | SingleFeatureSpec = None,
-        raster_resolution: None | float | Tuple[float, float] = None,
+        raster_shape: None | tuple[int, int] | SingleFeatureSpec = None,
+        raster_resolution: None | float | tuple[float, float] = None,
         raster_dtype: np.dtype | type = np.uint8,
         no_data_value: float = 0,
         write_to_existing: bool = False,
@@ -125,7 +125,7 @@ class VectorToRasterTask(EOTask):
 
     def _parse_main_params(
         self, vector_input: GeoDataFrame | SingleFeatureSpec, raster_feature: SingleFeatureSpec
-    ) -> Tuple[GeoDataFrame | Tuple[FeatureType, str], Tuple[FeatureType, str]]:
+    ) -> tuple[GeoDataFrame | tuple[FeatureType, str], tuple[FeatureType, str]]:
         """Parsing first 2 parameters - what vector data will be used and in which raster feature it will be saved"""
         if not _is_geopandas_object(vector_input):
             vector_input = self.parse_feature(vector_input, allowed_feature_types=lambda fty: fty.is_vector())
@@ -135,7 +135,7 @@ class VectorToRasterTask(EOTask):
 
     def _get_vector_data_iterator(
         self, eopatch: EOPatch, join_per_value: bool
-    ) -> Iterator[Tuple[dt.datetime | None, ShapeIterator]]:
+    ) -> Iterator[tuple[dt.datetime | None, ShapeIterator]]:
         """Collects and prepares vector shapes for rasterization. It works as an iterator that returns pairs of
         `(timestamp or None, <iterator over shapes and values>)`
 
@@ -154,7 +154,7 @@ class VectorToRasterTask(EOTask):
             yield None, self._vector_data_to_shape_iterator(vector_data, join_per_value)
 
     def _preprocess_vector_data(
-        self, vector_data: GeoDataFrame, bbox: BBox, timestamps: List[dt.datetime]
+        self, vector_data: GeoDataFrame, bbox: BBox, timestamps: list[dt.datetime]
     ) -> GeoDataFrame:
         """Applies preprocessing steps on a dataframe with geometries and potential values and timestamps"""
         vector_data = self._reduce_vector_data(vector_data, timestamps)
@@ -183,7 +183,7 @@ class VectorToRasterTask(EOTask):
 
         return vector_data
 
-    def _reduce_vector_data(self, vector_data: GeoDataFrame, timestamps: List[dt.datetime]) -> GeoDataFrame:
+    def _reduce_vector_data(self, vector_data: GeoDataFrame, timestamps: list[dt.datetime]) -> GeoDataFrame:
         """Removes all redundant columns and rows."""
         columns_to_keep = ["geometry"]
         if self._rasterize_per_timestamp:
@@ -214,7 +214,7 @@ class VectorToRasterTask(EOTask):
 
         return zip(vector_data.geometry, values)
 
-    def _get_raster_shape(self, eopatch: EOPatch) -> Tuple[int, int]:
+    def _get_raster_shape(self, eopatch: EOPatch) -> tuple[int, int]:
         """Determines the shape of new raster feature, returns a pair (height, width)"""
         if isinstance(self.raster_shape, (tuple, list)) and len(self.raster_shape) == 2:
             if isinstance(self.raster_shape[0], int) and isinstance(self.raster_shape[1], int):
@@ -225,7 +225,7 @@ class VectorToRasterTask(EOTask):
 
         if self.raster_resolution:
             # parsing from strings is not denoted in types, so an explicit upcast is required
-            raw_resolution: str | float | Tuple[float, float] = self.raster_resolution
+            raw_resolution: str | float | tuple[float, float] = self.raster_resolution
             resolution = float(raw_resolution.strip("m")) if isinstance(raw_resolution, str) else raw_resolution
 
             width, height = bbox_to_dimensions(cast(BBox, eopatch.bbox), resolution)  # cast verified in execute
@@ -333,7 +333,7 @@ class RasterToVectorTask(EOTask):
         self,
         features: FeaturesSpecification,
         *,
-        values: List[int] | None = None,
+        values: list[int] | None = None,
         values_column: str = "VALUE",
         raster_dtype: None | np.dtype | type = None,
         **rasterio_params: Any,
@@ -436,7 +436,7 @@ def _is_geopandas_object(data: object) -> bool:
     return isinstance(data, (GeoDataFrame, GeoSeries))
 
 
-def _vector_is_timeless(vector_input: GeoDataFrame | Tuple[FeatureType, Any]) -> bool:
+def _vector_is_timeless(vector_input: GeoDataFrame | tuple[FeatureType, Any]) -> bool:
     """Used to check if the vector input (either geopandas object EOPatch Feature) is time independent"""
     if _is_geopandas_object(vector_input):
         return TIMESTAMP_COLUMN not in vector_input

--- a/io/eolearn/io/extra/geodb.py
+++ b/io/eolearn/io/extra/geodb.py
@@ -10,7 +10,7 @@ This source code is licensed under the MIT license, see the LICENSE file in the 
 """
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 from sentinelhub import CRS, BBox
 
@@ -48,7 +48,7 @@ class GeoDBVectorImportTask(_BaseVectorImportTask):
         self.geodb_db = geodb_db
         self.geodb_collection = geodb_collection
         self.geodb_kwargs = kwargs
-        self._dataset_crs: Optional[CRS] = None
+        self._dataset_crs: CRS | None = None
 
         super().__init__(feature=feature, reproject=reproject, clip=clip)
 
@@ -64,7 +64,7 @@ class GeoDBVectorImportTask(_BaseVectorImportTask):
 
         return self._dataset_crs
 
-    def _load_vector_data(self, bbox: Optional[BBox]) -> Any:
+    def _load_vector_data(self, bbox: BBox | None) -> Any:
         """Loads vector data from geoDB table"""
         prepared_bbox = bbox.transform_bounds(self.dataset_crs).geometry.bounds if bbox else None
 

--- a/io/eolearn/io/extra/geodb.py
+++ b/io/eolearn/io/extra/geodb.py
@@ -8,6 +8,7 @@ For the full list of contributors, see the CREDITS file in the root directory of
 
 This source code is licensed under the MIT license, see the LICENSE file in the root directory of this source tree.
 """
+from __future__ import annotations
 
 from typing import Any, Optional
 

--- a/io/eolearn/io/extra/meteoblue.py
+++ b/io/eolearn/io/extra/meteoblue.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import datetime as dt
 from abc import ABCMeta, abstractmethod
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Tuple
 
 import dateutil.parser
 import geopandas as gpd
@@ -45,10 +45,10 @@ class BaseMeteoblueTask(EOTask, metaclass=ABCMeta):
         self,
         feature: Tuple[FeatureType, str],
         apikey: str,
-        query: Optional[dict] = None,
-        units: Optional[dict] = None,
+        query: dict | None = None,
+        units: dict | None = None,
         time_difference: dt.timedelta = dt.timedelta(minutes=30),  # noqa: B008, RUF100
-        cache_folder: Optional[str] = None,
+        cache_folder: str | None = None,
         cache_max_age: int = 604800,
     ):
         """
@@ -74,7 +74,7 @@ class BaseMeteoblueTask(EOTask, metaclass=ABCMeta):
         self.time_difference = time_difference
 
     @staticmethod
-    def _get_modified_eopatch(eopatch: Optional[EOPatch], bbox: Optional[BBox]) -> Tuple[EOPatch, BBox]:
+    def _get_modified_eopatch(eopatch: EOPatch | None, bbox: BBox | None) -> Tuple[EOPatch, BBox]:
         if bbox is not None:
             if eopatch is None:
                 eopatch = EOPatch(bbox=bbox)
@@ -88,7 +88,7 @@ class BaseMeteoblueTask(EOTask, metaclass=ABCMeta):
             raise ValueError("Bounding box is not provided")
         return eopatch, eopatch.bbox
 
-    def _prepare_time_intervals(self, eopatch: EOPatch, time_interval: Optional[RawTimeIntervalType]) -> List[str]:
+    def _prepare_time_intervals(self, eopatch: EOPatch, time_interval: RawTimeIntervalType | None) -> List[str]:
         """Prepare a list of time intervals for which data will be collected from meteoblue services"""
         if not eopatch.timestamps and not time_interval:
             raise ValueError(
@@ -117,11 +117,11 @@ class BaseMeteoblueTask(EOTask, metaclass=ABCMeta):
 
     def execute(
         self,
-        eopatch: Optional[EOPatch] = None,
+        eopatch: EOPatch | None = None,
         *,
-        query: Optional[dict] = None,
-        bbox: Optional[BBox] = None,
-        time_interval: Optional[RawTimeIntervalType] = None,
+        query: dict | None = None,
+        bbox: BBox | None = None,
+        time_interval: RawTimeIntervalType | None = None,
     ) -> EOPatch:
         """Execute method that adds new meteoblue data into an EOPatch
 

--- a/io/eolearn/io/extra/meteoblue.py
+++ b/io/eolearn/io/extra/meteoblue.py
@@ -12,6 +12,8 @@ For the full list of contributors, see the CREDITS file in the root directory of
 
 This source code is licensed under the MIT license, see the LICENSE file in the root directory of this source tree.
 """
+from __future__ import annotations
+
 import datetime as dt
 from abc import ABCMeta, abstractmethod
 from typing import Any, List, Optional, Tuple

--- a/io/eolearn/io/extra/meteoblue.py
+++ b/io/eolearn/io/extra/meteoblue.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import datetime as dt
 from abc import ABCMeta, abstractmethod
-from typing import Any, List, Tuple
+from typing import Any
 
 import dateutil.parser
 import geopandas as gpd
@@ -43,7 +43,7 @@ class BaseMeteoblueTask(EOTask, metaclass=ABCMeta):
 
     def __init__(
         self,
-        feature: Tuple[FeatureType, str],
+        feature: tuple[FeatureType, str],
         apikey: str,
         query: dict | None = None,
         units: dict | None = None,
@@ -74,7 +74,7 @@ class BaseMeteoblueTask(EOTask, metaclass=ABCMeta):
         self.time_difference = time_difference
 
     @staticmethod
-    def _get_modified_eopatch(eopatch: EOPatch | None, bbox: BBox | None) -> Tuple[EOPatch, BBox]:
+    def _get_modified_eopatch(eopatch: EOPatch | None, bbox: BBox | None) -> tuple[EOPatch, BBox]:
         if bbox is not None:
             if eopatch is None:
                 eopatch = EOPatch(bbox=bbox)
@@ -88,7 +88,7 @@ class BaseMeteoblueTask(EOTask, metaclass=ABCMeta):
             raise ValueError("Bounding box is not provided")
         return eopatch, eopatch.bbox
 
-    def _prepare_time_intervals(self, eopatch: EOPatch, time_interval: RawTimeIntervalType | None) -> List[str]:
+    def _prepare_time_intervals(self, eopatch: EOPatch, time_interval: RawTimeIntervalType | None) -> list[str]:
         """Prepare a list of time intervals for which data will be collected from meteoblue services"""
         if not eopatch.timestamps and not time_interval:
             raise ValueError(
@@ -100,7 +100,7 @@ class BaseMeteoblueTask(EOTask, metaclass=ABCMeta):
             return [f"{serialized_start_time}/{serialized_end_time}"]
 
         timestamps = eopatch.timestamps
-        time_intervals: List[str] = []
+        time_intervals: list[str] = []
         for timestamp in timestamps:
             start_time = timestamp - self.time_difference
             end_time = timestamp + self.time_difference
@@ -112,7 +112,7 @@ class BaseMeteoblueTask(EOTask, metaclass=ABCMeta):
         return time_intervals
 
     @abstractmethod
-    def _get_data(self, query: dict) -> Tuple[Any, List[dt.datetime]]:
+    def _get_data(self, query: dict) -> tuple[Any, list[dt.datetime]]:
         """It should return an output feature object and a list of timestamps"""
 
     def execute(
@@ -169,7 +169,7 @@ class MeteoblueVectorTask(BaseMeteoblueTask):
     A meteoblue API key is required to retrieve data.
     """
 
-    def _get_data(self, query: dict) -> Tuple[gpd.GeoDataFrame, List[dt.datetime]]:
+    def _get_data(self, query: dict) -> tuple[gpd.GeoDataFrame, list[dt.datetime]]:
         """Provides a GeoDataFrame with information about weather control points and an empty list of timestamps"""
         result = self.client.querySync(query)
         dataframe = meteoblue_to_dataframe(result)
@@ -189,7 +189,7 @@ class MeteoblueRasterTask(BaseMeteoblueTask):
     A meteoblue API key is required to retrieve data.
     """
 
-    def _get_data(self, query: dict) -> Tuple[np.ndarray, List[dt.datetime]]:
+    def _get_data(self, query: dict) -> tuple[np.ndarray, list[dt.datetime]]:
         """Return a 4-dimensional numpy array of shape (time, height, width, weather variables) and a list of
         timestamps
         """
@@ -273,12 +273,12 @@ def meteoblue_to_numpy(result: Any) -> np.ndarray:
     return data.transpose((1, 2, 3, 0))
 
 
-def _meteoblue_timestamps_from_geometry(geometry_pb: Any) -> List[dt.datetime]:
+def _meteoblue_timestamps_from_geometry(geometry_pb: Any) -> list[dt.datetime]:
     """Transforms a protobuf geometry object into a list of datetime objects"""
     return list(pd.core.common.flatten(map(_meteoblue_timestamps_from_time_interval, geometry_pb.timeIntervals)))
 
 
-def _meteoblue_timestamps_from_time_interval(timestamp_pb: Any) -> List[dt.datetime]:
+def _meteoblue_timestamps_from_time_interval(timestamp_pb: Any) -> list[dt.datetime]:
     """Transforms a protobuf timestamp object into a list of datetime objects"""
     if timestamp_pb.timestrings:
         # Time intervals like weekly data, return an `array of strings` as timestamps

--- a/io/eolearn/io/geometry_io.py
+++ b/io/eolearn/io/geometry_io.py
@@ -7,6 +7,8 @@ For the full list of contributors, see the CREDITS file in the root directory of
 This source code is licensed under the MIT license, see the LICENSE file in the root directory of this source tree.
 """
 
+from __future__ import annotations
+
 import abc
 import logging
 from contextlib import nullcontext

--- a/io/eolearn/io/raster_io.py
+++ b/io/eolearn/io/raster_io.py
@@ -6,6 +6,8 @@ For the full list of contributors, see the CREDITS file in the root directory of
 
 This source code is licensed under the MIT license, see the LICENSE file in the root directory of this source tree.
 """
+from __future__ import annotations
+
 import datetime as dt
 import functools
 import logging

--- a/io/eolearn/io/sentinelhub_process.py
+++ b/io/eolearn/io/sentinelhub_process.py
@@ -47,8 +47,8 @@ class SentinelHubInputBaseTask(EOTask, metaclass=ABCMeta):
     def __init__(
         self,
         data_collection: DataCollection,
-        size: Tuple[int, int] | None = None,
-        resolution: float | Tuple[float, float] | None = None,
+        size: tuple[int, int] | None = None,
+        resolution: float | tuple[float, float] | None = None,
         cache_folder: str | None = None,
         config: SHConfig | None = None,
         max_threads: int | None = None,
@@ -129,7 +129,7 @@ class SentinelHubInputBaseTask(EOTask, metaclass=ABCMeta):
 
         return eopatch
 
-    def _get_size(self, bbox: BBox) -> Tuple[int, int]:
+    def _get_size(self, bbox: BBox) -> tuple[int, int]:
         """Get the size (width, height) for the request either from inputs, or from the (existing) eopatch"""
         if self.size is not None:
             return self.size
@@ -151,7 +151,7 @@ class SentinelHubInputBaseTask(EOTask, metaclass=ABCMeta):
         raise ValueError("Either the eopatch or the task must provide bbox, or they must be the same.")
 
     @abstractmethod
-    def _extract_data(self, eopatch: EOPatch, responses: List[Any], shape: Tuple[int, ...]) -> EOPatch:
+    def _extract_data(self, eopatch: EOPatch, responses: list[Any], shape: tuple[int, ...]) -> EOPatch:
         """Extract data from the received images and assign them to eopatch features"""
 
     @abstractmethod
@@ -160,14 +160,14 @@ class SentinelHubInputBaseTask(EOTask, metaclass=ABCMeta):
         bbox: BBox | None,
         size_x: int,
         size_y: int,
-        timestamps: List[dt.datetime] | None,
+        timestamps: list[dt.datetime] | None,
         time_interval: RawTimeIntervalType | None,
         geometry: Geometry | None,
-    ) -> List[SentinelHubRequest]:
+    ) -> list[SentinelHubRequest]:
         """Build requests"""
 
     @abstractmethod
-    def _get_timestamps(self, time_interval: RawTimeIntervalType | None, bbox: BBox) -> List[dt.datetime]:
+    def _get_timestamps(self, time_interval: RawTimeIntervalType | None, bbox: BBox) -> list[dt.datetime]:
         """Get the timestamp array needed as a parameter for downloading the images"""
 
 
@@ -180,8 +180,8 @@ class SentinelHubEvalscriptTask(SentinelHubInputBaseTask):
         features: FeaturesSpecification,
         evalscript: str,
         data_collection: DataCollection,
-        size: Tuple[int, int] | None = None,
-        resolution: float | Tuple[float, float] | None = None,
+        size: tuple[int, int] | None = None,
+        resolution: float | tuple[float, float] | None = None,
         maxcc: float | None = None,
         time_difference: dt.timedelta | None = None,
         mosaicking_order: str | MosaickingOrder | None = None,
@@ -192,7 +192,7 @@ class SentinelHubEvalscriptTask(SentinelHubInputBaseTask):
         downsampling: ResamplingType | None = None,
         aux_request_args: dict | None = None,
         session_loader: Callable[[], SentinelHubSession] | None = None,
-        timestamp_filter: Callable[[List[dt.datetime], dt.timedelta], List[dt.datetime]] = filter_times,
+        timestamp_filter: Callable[[list[dt.datetime], dt.timedelta], list[dt.datetime]] = filter_times,
     ):
         """
         :param features: Features to construct from the evalscript.
@@ -242,7 +242,7 @@ class SentinelHubEvalscriptTask(SentinelHubInputBaseTask):
         self.mosaicking_order = None if mosaicking_order is None else MosaickingOrder(mosaicking_order)
         self.aux_request_args = aux_request_args
 
-    def _parse_and_validate_features(self, features: FeaturesSpecification) -> List[FeatureRenameSpec]:
+    def _parse_and_validate_features(self, features: FeaturesSpecification) -> list[FeatureRenameSpec]:
         _features = parse_renamed_features(
             features, allowed_feature_types=lambda fty: fty.is_array() or fty == FeatureType.META_INFO
         )
@@ -253,7 +253,7 @@ class SentinelHubEvalscriptTask(SentinelHubInputBaseTask):
 
         raise ValueError("Cannot mix time dependent and timeless requests!")
 
-    def _create_response_objects(self) -> List[JsonDict]:
+    def _create_response_objects(self) -> list[JsonDict]:
         """Construct SentinelHubRequest output_responses from features"""
         responses = []
         for feat_type, feat_name, _ in self.features:
@@ -268,7 +268,7 @@ class SentinelHubEvalscriptTask(SentinelHubInputBaseTask):
 
         return responses
 
-    def _get_timestamps(self, time_interval: RawTimeIntervalType | None, bbox: BBox) -> List[dt.datetime]:
+    def _get_timestamps(self, time_interval: RawTimeIntervalType | None, bbox: BBox) -> list[dt.datetime]:
         """Get the timestamp array needed as a parameter for downloading the images"""
         if any(feat_type.is_timeless() for feat_type, _, _ in self.features if feat_type.is_array()):
             return []
@@ -288,13 +288,13 @@ class SentinelHubEvalscriptTask(SentinelHubInputBaseTask):
         bbox: BBox | None,
         size_x: int,
         size_y: int,
-        timestamps: List[dt.datetime] | None,
+        timestamps: list[dt.datetime] | None,
         time_interval: RawTimeIntervalType | None,
         geometry: Geometry | None,
-    ) -> List[SentinelHubRequest]:
+    ) -> list[SentinelHubRequest]:
         """Defines request timestamps and builds requests. In case `timestamps` is either `None` or an empty list it
         still has to create at least one request in order to obtain back number of bands of responses."""
-        dates: List[Tuple[dt.datetime | None, dt.datetime | None] | None]
+        dates: list[tuple[dt.datetime | None, dt.datetime | None] | None]
         if timestamps:
             dates = [(date - self.time_difference, date + self.time_difference) for date in timestamps]
         elif timestamps is None:
@@ -334,7 +334,7 @@ class SentinelHubEvalscriptTask(SentinelHubInputBaseTask):
             config=self.config,
         )
 
-    def _extract_data(self, eopatch: EOPatch, responses: List[Any], shape: Tuple[int, ...]) -> EOPatch:
+    def _extract_data(self, eopatch: EOPatch, responses: list[Any], shape: tuple[int, ...]) -> EOPatch:
         """Extract data from the received images and assign them to eopatch features"""
         # pylint: disable=arguments-renamed
         if len(self.features) == 1:
@@ -366,11 +366,11 @@ class SentinelHubInputTask(SentinelHubInputBaseTask):
     def __init__(
         self,
         data_collection: DataCollection,
-        size: Tuple[int, int] | None = None,
-        resolution: float | Tuple[float, float] | None = None,
-        bands_feature: Tuple[FeatureType, str] | None = None,
-        bands: List[str] | None = None,
-        additional_data: List[Tuple[FeatureType, str]] | None = None,
+        size: tuple[int, int] | None = None,
+        resolution: float | tuple[float, float] | None = None,
+        bands_feature: tuple[FeatureType, str] | None = None,
+        bands: list[str] | None = None,
+        additional_data: list[tuple[FeatureType, str]] | None = None,
         evalscript: str | None = None,
         maxcc: float | None = None,
         time_difference: dt.timedelta | None = None,
@@ -384,7 +384,7 @@ class SentinelHubInputTask(SentinelHubInputBaseTask):
         downsampling: ResamplingType | None = None,
         aux_request_args: dict | None = None,
         session_loader: Callable[[], SentinelHubSession] | None = None,
-        timestamp_filter: Callable[[List[dt.datetime], dt.timedelta], List[dt.datetime]] = filter_times,
+        timestamp_filter: Callable[[list[dt.datetime], dt.timedelta], list[dt.datetime]] = filter_times,
     ):
         """
         :param data_collection: Source of requested satellite data.
@@ -442,13 +442,13 @@ class SentinelHubInputTask(SentinelHubInputBaseTask):
             self.requested_bands = parse_data_collection_bands(data_collection, bands)
 
         self.requested_additional_bands = []
-        self.additional_data: List[FeatureRenameSpec] | None = None
+        self.additional_data: list[FeatureRenameSpec] | None = None
         if additional_data is not None:
             self.additional_data = parse_renamed_features(additional_data)  # parser gives too general type
             additional_bands = cast(List[str], [band for _, band, _ in self.additional_data])
             self.requested_additional_bands = parse_data_collection_bands(data_collection, additional_bands)
 
-    def _get_timestamps(self, time_interval: RawTimeIntervalType | None, bbox: BBox) -> List[dt.datetime]:
+    def _get_timestamps(self, time_interval: RawTimeIntervalType | None, bbox: BBox) -> list[dt.datetime]:
         """Get the timestamp array needed as a parameter for downloading the images"""
         if self.single_scene:
             return [time_interval[0]]  # type: ignore[index, list-item]
@@ -468,13 +468,13 @@ class SentinelHubInputTask(SentinelHubInputBaseTask):
         bbox: BBox | None,
         size_x: int,
         size_y: int,
-        timestamps: List[dt.datetime] | None,
+        timestamps: list[dt.datetime] | None,
         time_interval: RawTimeIntervalType | None,
         geometry: Geometry | None,
-    ) -> List[SentinelHubRequest]:
+    ) -> list[SentinelHubRequest]:
         """Build requests"""
         if timestamps is None:
-            intervals: List[RawTimeIntervalType | None] = [None]
+            intervals: list[RawTimeIntervalType | None] = [None]
         elif self.single_scene:
             intervals = [parse_time_interval(time_interval)]
         else:
@@ -523,7 +523,7 @@ class SentinelHubInputTask(SentinelHubInputBaseTask):
             config=self.config,
         )
 
-    def _extract_data(self, eopatch: EOPatch, responses: List[Any], shape: Tuple[int, ...]) -> EOPatch:
+    def _extract_data(self, eopatch: EOPatch, responses: list[Any], shape: tuple[int, ...]) -> EOPatch:
         """Extract data from the received images and assign them to eopatch features"""
         if len(self.requested_bands) + len(self.requested_additional_bands) == 1:
             # if only one band is requested the response is not a tar so we reshape it
@@ -539,7 +539,7 @@ class SentinelHubInputTask(SentinelHubInputBaseTask):
         return eopatch
 
     def _extract_additional_features(
-        self, eopatch: EOPatch, images: Iterable[np.ndarray], shape: Tuple[int, ...]
+        self, eopatch: EOPatch, images: Iterable[np.ndarray], shape: tuple[int, ...]
     ) -> None:
         """Extracts additional features from response into an EOPatch"""
         additional_data = cast(List[FeatureRenameSpec], self.additional_data)  # verified by `if` in _extract_data
@@ -547,7 +547,7 @@ class SentinelHubInputTask(SentinelHubInputBaseTask):
             tiffs = [tar[band_info.name + ".tif"] for tar in images]
             eopatch[ftype, new_name] = self._extract_array(tiffs, 0, shape, band_info.output_types[0])
 
-    def _extract_bands_feature(self, eopatch: EOPatch, images: Iterable[np.ndarray], shape: Tuple[int, ...]) -> None:
+    def _extract_bands_feature(self, eopatch: EOPatch, images: Iterable[np.ndarray], shape: tuple[int, ...]) -> None:
         """Extract the bands feature arrays and concatenate them along the last axis"""
         processed_bands = []
         for band_info in self.requested_bands:
@@ -559,7 +559,7 @@ class SentinelHubInputTask(SentinelHubInputBaseTask):
         eopatch[bands_feature] = np.concatenate(processed_bands, axis=-1)
 
     @staticmethod
-    def _extract_array(tiffs: List[np.ndarray], idx: int, shape: Tuple[int, ...], dtype: type | np.dtype) -> np.ndarray:
+    def _extract_array(tiffs: list[np.ndarray], idx: int, shape: tuple[int, ...], dtype: type | np.dtype) -> np.ndarray:
         """Extract a numpy array from the received tiffs"""
         feature_arrays = (np.atleast_3d(img)[..., idx] for img in tiffs)
         return np.asarray(list(feature_arrays), dtype=dtype).reshape(*shape, 1)
@@ -578,7 +578,7 @@ class SentinelHubDemTask(SentinelHubEvalscriptTask):
         **kwargs: Any,
     ):
         dem_band = data_collection.bands[0].name
-        renamed_feature: Tuple[FeatureType, str, str]
+        renamed_feature: tuple[FeatureType, str, str]
 
         if feature is None:
             renamed_feature = (FeatureType.DATA_TIMELESS, dem_band, dem_band)
@@ -614,7 +614,7 @@ class SentinelHubSen2corTask(SentinelHubInputTask):
 
     def __init__(
         self,
-        sen2cor_classification: Literal["SCL", "CLD", "SNW"] | List[Literal["SCL", "CLD", "SNW"]],
+        sen2cor_classification: Literal["SCL", "CLD", "SNW"] | list[Literal["SCL", "CLD", "SNW"]],
         data_collection: DataCollection = DataCollection.SENTINEL2_L2A,
         **kwargs: Any,
     ):
@@ -638,5 +638,5 @@ class SentinelHubSen2corTask(SentinelHubInputTask):
         if data_collection != DataCollection.SENTINEL2_L2A:
             raise ValueError("Sen2Cor classification layers are only available on Sentinel-2 L2A data.")
 
-        features: List[Tuple[FeatureType, str]] = [(classification_types[s2c], s2c) for s2c in sen2cor_classification]
+        features: list[tuple[FeatureType, str]] = [(classification_types[s2c], s2c) for s2c in sen2cor_classification]
         super().__init__(additional_data=features, data_collection=data_collection, **kwargs)

--- a/mask/eolearn/mask/cloud_mask.py
+++ b/mask/eolearn/mask/cloud_mask.py
@@ -486,7 +486,7 @@ class CloudMaskTask(EOTask):
 
         return multi_features.reshape(-1, multi_features.shape[-1])
 
-    def execute(self, eopatch: EOPatch) -> EOPatch:
+    def execute(self, eopatch: EOPatch) -> EOPatch:  # noqa: C901
         """Add selected features (cloud probabilities and masks) to an EOPatch instance.
 
         :param eopatch: Input `EOPatch` instance

--- a/mask/eolearn/mask/cloud_mask.py
+++ b/mask/eolearn/mask/cloud_mask.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 import os
 from functools import partial
-from typing import Protocol, Tuple, cast
+from typing import Protocol, cast
 
 import cv2
 import numpy as np
@@ -83,14 +83,14 @@ class CloudMaskTask(EOTask):
 
     def __init__(
         self,
-        data_feature: Tuple[FeatureType, str] = (FeatureType.DATA, "BANDS-S2-L1C"),
-        is_data_feature: Tuple[FeatureType, str] = (FeatureType.MASK, "IS_DATA"),
+        data_feature: tuple[FeatureType, str] = (FeatureType.DATA, "BANDS-S2-L1C"),
+        is_data_feature: tuple[FeatureType, str] = (FeatureType.MASK, "IS_DATA"),
         all_bands: bool = True,
-        processing_resolution: None | float | Tuple[float, float] = None,
+        processing_resolution: None | float | tuple[float, float] = None,
         max_proc_frames: int = 11,
-        mono_features: Tuple[str | None, str | None] | None = None,
-        multi_features: Tuple[str | None, str | None] | None = None,
-        mask_feature: Tuple[FeatureType, str] | None = (FeatureType.MASK, "CLM_INTERSSIM"),
+        mono_features: tuple[str | None, str | None] | None = None,
+        multi_features: tuple[str | None, str | None] | None = None,
+        mask_feature: tuple[FeatureType, str] | None = (FeatureType.MASK, "CLM_INTERSSIM"),
         mono_threshold: float = 0.4,
         multi_threshold: float = 0.5,
         average_over: int | None = 4,
@@ -178,7 +178,7 @@ class CloudMaskTask(EOTask):
             self.dil_kernel = None
 
     @staticmethod
-    def _parse_resolution_arg(resolution: None | float | Tuple[float, float]) -> Tuple[float, float] | None:
+    def _parse_resolution_arg(resolution: None | float | tuple[float, float]) -> tuple[float, float] | None:
         """Parses initialization resolution argument"""
         if isinstance(resolution, (int, float)):
             resolution = resolution, resolution
@@ -213,7 +213,7 @@ class CloudMaskTask(EOTask):
 
         return prediction if is_booster else prediction[..., 1]
 
-    def _scale_factors(self, reference_shape: Tuple[int, int], bbox: BBox) -> Tuple[Tuple[float, float], float]:
+    def _scale_factors(self, reference_shape: tuple[int, int], bbox: BBox) -> tuple[tuple[float, float], float]:
         """Compute the resampling factors for height and width of the input array and sigma
 
         :param reference_shape: Tuple specifying height and width in pixels of high-resolution array
@@ -300,7 +300,7 @@ class CloudMaskTask(EOTask):
         local_var: np.ndarray,
         rel_tdx: int,
         sigma: float,
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Calculate SSIM stats"""
         ssim_max = np.empty((1, *bands.shape[1:]), dtype=np.float32)
         ssim_mean = np.empty_like(ssim_max)
@@ -403,7 +403,7 @@ class CloudMaskTask(EOTask):
         bands: np.ndarray,
         is_data: np.ndarray,
         sigma: float,
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray]:
         """Calculates or updates the window average and variance. The calculation is done per 2D image along the
         temporal and band axes."""
         local_avg_func = partial(self._win_avg, sigma=sigma)
@@ -560,7 +560,7 @@ class CloudMaskTask(EOTask):
         return eopatch
 
 
-def _get_window_indices(num_of_elements: int, middle_idx: int, window_size: int) -> Tuple[int, int]:
+def _get_window_indices(num_of_elements: int, middle_idx: int, window_size: int) -> tuple[int, int]:
     """
     Returns the minimum and maximum indices to be used for indexing, lower inclusive and upper exclusive.
     The window has the following properties:

--- a/mask/eolearn/mask/cloud_mask.py
+++ b/mask/eolearn/mask/cloud_mask.py
@@ -6,6 +6,8 @@ For the full list of contributors, see the CREDITS file in the root directory of
 
 This source code is licensed under the MIT license, see the LICENSE file in the root directory of this source tree.
 """
+from __future__ import annotations
+
 import logging
 import os
 from functools import partial

--- a/mask/eolearn/mask/cloud_mask.py
+++ b/mask/eolearn/mask/cloud_mask.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 import os
 from functools import partial
-from typing import Optional, Protocol, Tuple, Union, cast
+from typing import Protocol, Tuple, cast
 
 import cv2
 import numpy as np
@@ -86,17 +86,17 @@ class CloudMaskTask(EOTask):
         data_feature: Tuple[FeatureType, str] = (FeatureType.DATA, "BANDS-S2-L1C"),
         is_data_feature: Tuple[FeatureType, str] = (FeatureType.MASK, "IS_DATA"),
         all_bands: bool = True,
-        processing_resolution: Union[None, float, Tuple[float, float]] = None,
+        processing_resolution: None | float | Tuple[float, float] = None,
         max_proc_frames: int = 11,
-        mono_features: Optional[Tuple[Optional[str], Optional[str]]] = None,
-        multi_features: Optional[Tuple[Optional[str], Optional[str]]] = None,
-        mask_feature: Optional[Tuple[FeatureType, str]] = (FeatureType.MASK, "CLM_INTERSSIM"),
+        mono_features: Tuple[str | None, str | None] | None = None,
+        multi_features: Tuple[str | None, str | None] | None = None,
+        mask_feature: Tuple[FeatureType, str] | None = (FeatureType.MASK, "CLM_INTERSSIM"),
         mono_threshold: float = 0.4,
         multi_threshold: float = 0.5,
-        average_over: Optional[int] = 4,
-        dilation_size: Optional[int] = 2,
-        mono_classifier: Optional[ClassifierType] = None,
-        multi_classifier: Optional[ClassifierType] = None,
+        average_over: int | None = 4,
+        dilation_size: int | None = 2,
+        mono_classifier: ClassifierType | None = None,
+        multi_classifier: ClassifierType | None = None,
     ):
         """
         :param data_feature: A data feature which stores raw Sentinel-2 reflectance bands.
@@ -178,7 +178,7 @@ class CloudMaskTask(EOTask):
             self.dil_kernel = None
 
     @staticmethod
-    def _parse_resolution_arg(resolution: Union[None, float, Tuple[float, float]]) -> Optional[Tuple[float, float]]:
+    def _parse_resolution_arg(resolution: None | float | Tuple[float, float]) -> Tuple[float, float] | None:
         """Parses initialization resolution argument"""
         if isinstance(resolution, (int, float)):
             resolution = resolution, resolution
@@ -364,10 +364,10 @@ class CloudMaskTask(EOTask):
         img_size = height * width
         multi_proba = np.empty(n_times * img_size)
 
-        local_avg: Optional[np.ndarray] = None
-        local_var: Optional[np.ndarray] = None
-        prev_left: Optional[int] = None
-        prev_right: Optional[int] = None
+        local_avg: np.ndarray | None = None
+        local_var: np.ndarray | None = None
+        prev_left: int | None = None
+        prev_right: int | None = None
 
         for t_idx in range(n_times):
             # Extract temporal window indices
@@ -398,8 +398,8 @@ class CloudMaskTask(EOTask):
 
     def _update_batches(
         self,
-        local_avg: Optional[np.ndarray],
-        local_var: Optional[np.ndarray],
+        local_avg: np.ndarray | None,
+        local_var: np.ndarray | None,
         bands: np.ndarray,
         is_data: np.ndarray,
         sigma: float,

--- a/mask/eolearn/mask/mask_counting.py
+++ b/mask/eolearn/mask/mask_counting.py
@@ -8,7 +8,7 @@ This source code is licensed under the MIT license, see the LICENSE file in the 
 """
 from __future__ import annotations
 
-from typing import Iterator, List
+from typing import Iterator
 
 import numpy as np
 
@@ -23,7 +23,7 @@ class ClassFrequencyTask(MapFeatureTask):
         self,
         input_feature: FeaturesSpecification,
         output_feature: FeaturesSpecification,
-        classes: List[int],
+        classes: list[int],
         no_data_value: int = 0,
     ):
         """

--- a/mask/eolearn/mask/mask_counting.py
+++ b/mask/eolearn/mask/mask_counting.py
@@ -8,7 +8,7 @@ This source code is licensed under the MIT license, see the LICENSE file in the 
 """
 from __future__ import annotations
 
-from typing import Iterator, List, Union
+from typing import Iterator, List
 
 import numpy as np
 
@@ -44,10 +44,8 @@ class ClassFrequencyTask(MapFeatureTask):
 
     def map_method(self, feature: np.ndarray) -> np.ndarray:
         """Map method being applied to the feature that calculates the frequencies."""
-        count_valid: Union[int, np.ndarray] = np.count_nonzero(feature != self.no_data_value, axis=0)
-        class_counts: Iterator[Union[int, np.ndarray]] = (
-            np.count_nonzero(feature == scl, axis=0) for scl in self.classes
-        )
+        count_valid: int | np.ndarray = np.count_nonzero(feature != self.no_data_value, axis=0)
+        class_counts: Iterator[int | np.ndarray] = (np.count_nonzero(feature == scl, axis=0) for scl in self.classes)
 
         with np.errstate(invalid="ignore"):
             class_frequencies = [np.divide(count, count_valid, dtype=np.float32) for count in class_counts]

--- a/mask/eolearn/mask/masking.py
+++ b/mask/eolearn/mask/masking.py
@@ -8,7 +8,7 @@ This source code is licensed under the MIT license, see the LICENSE file in the 
 """
 from __future__ import annotations
 
-from typing import Callable, Dict, Iterable, Literal
+from typing import Callable, Iterable, Literal
 
 import numpy as np
 
@@ -33,7 +33,7 @@ class JoinMasksTask(ZipFeatureTask):
         """
         self.join_method: Callable[[np.ndarray, np.ndarray], np.ndarray]
         if isinstance(join_operation, str):
-            methods: Dict[str, Callable[[np.ndarray, np.ndarray], np.ndarray]] = {
+            methods: dict[str, Callable[[np.ndarray, np.ndarray], np.ndarray]] = {
                 "and": np.logical_and,
                 "or": np.logical_or,
                 "xor": np.logical_xor,

--- a/mask/eolearn/mask/masking.py
+++ b/mask/eolearn/mask/masking.py
@@ -8,7 +8,7 @@ This source code is licensed under the MIT license, see the LICENSE file in the 
 """
 from __future__ import annotations
 
-from typing import Callable, Dict, Iterable, Literal, Union
+from typing import Callable, Dict, Iterable, Literal
 
 import numpy as np
 
@@ -24,7 +24,7 @@ class JoinMasksTask(ZipFeatureTask):
         self,
         input_features: FeaturesSpecification,
         output_feature: SingleFeatureSpec,
-        join_operation: Union[Literal["and", "or", "xor"], Callable] = "and",
+        join_operation: Literal["and", "or", "xor"] | Callable = "and",
     ):
         """
         :param input_features: Mask features to be joined together.

--- a/mask/eolearn/mask/snow_mask.py
+++ b/mask/eolearn/mask/snow_mask.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import itertools
 import logging
 from abc import ABCMeta
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Tuple
 
 import numpy as np
 from skimage.morphology import binary_dilation, disk
@@ -134,7 +134,7 @@ class TheiaSnowMaskTask(BaseSnowMaskTask):
         dem_params: Tuple[float, float] = (100, 0.1),
         red_params: Tuple[float, float, float, float, float] = (12, 0.3, 0.1, 0.2, 0.040),
         ndsi_params: Tuple[float, float, float] = (0.4, 0.15, 0.001),
-        b10_index: Optional[int] = None,
+        b10_index: int | None = None,
         **kwargs: Any,
     ):
         """
@@ -185,7 +185,7 @@ class TheiaSnowMaskTask(BaseSnowMaskTask):
         return resize_images(downscaled, new_size=(height, width)).squeeze()
 
     def _adjust_cloud_mask(
-        self, bands: np.ndarray, cloud_mask: np.ndarray, dem: np.ndarray, b10: Optional[np.ndarray]
+        self, bands: np.ndarray, cloud_mask: np.ndarray, dem: np.ndarray, b10: np.ndarray | None
     ) -> np.ndarray:
         """Adjust existing cloud mask using cirrus band if L1C data and resampled red band
 
@@ -201,7 +201,7 @@ class TheiaSnowMaskTask(BaseSnowMaskTask):
 
     def _apply_first_pass(
         self, bands: np.ndarray, ndsi: np.ndarray, clm: np.ndarray, dem: np.ndarray, clm_temp: np.ndarray
-    ) -> Tuple[np.ndarray, Optional[np.ndarray], np.ndarray]:
+    ) -> Tuple[np.ndarray, np.ndarray | None, np.ndarray]:
         """Apply first pass of snow detection"""
         snow_mask_pass1 = ~clm_temp & (ndsi > self.ndsi_params[0]) & (bands[..., 1] > self.red_params[3])
 
@@ -232,7 +232,7 @@ class TheiaSnowMaskTask(BaseSnowMaskTask):
         dem: np.ndarray,
         clm_temp: np.ndarray,
         snow_mask_pass1: np.ndarray,
-        snow_frac: Optional[np.ndarray],
+        snow_frac: np.ndarray | None,
         dem_edges: np.ndarray,
     ) -> np.ndarray:
         """Second pass of snow detection"""

--- a/mask/eolearn/mask/snow_mask.py
+++ b/mask/eolearn/mask/snow_mask.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import itertools
 import logging
 from abc import ABCMeta
-from typing import Any, List, Tuple
+from typing import Any
 
 import numpy as np
 from skimage.morphology import binary_dilation, disk
@@ -30,7 +30,7 @@ class BaseSnowMaskTask(EOTask, metaclass=ABCMeta):
     def __init__(
         self,
         data_feature: FeatureSpec,
-        band_indices: List[int],
+        band_indices: list[int],
         dilation_size: int = 0,
         undefined_value: int = 0,
         mask_name: str = "SNOW_MASK",
@@ -66,7 +66,7 @@ class SnowMaskTask(BaseSnowMaskTask):
     def __init__(
         self,
         data_feature: FeatureSpec,
-        band_indices: List[int],
+        band_indices: list[int],
         ndsi_threshold: float = 0.4,
         brightness_threshold: float = 0.3,
         **kwargs: Any,
@@ -128,12 +128,12 @@ class TheiaSnowMaskTask(BaseSnowMaskTask):
     def __init__(
         self,
         data_feature: FeatureSpec,
-        band_indices: List[int],
+        band_indices: list[int],
         cloud_mask_feature: FeatureSpec,
         dem_feature: FeatureSpec,
-        dem_params: Tuple[float, float] = (100, 0.1),
-        red_params: Tuple[float, float, float, float, float] = (12, 0.3, 0.1, 0.2, 0.040),
-        ndsi_params: Tuple[float, float, float] = (0.4, 0.15, 0.001),
+        dem_params: tuple[float, float] = (100, 0.1),
+        red_params: tuple[float, float, float, float, float] = (12, 0.3, 0.1, 0.2, 0.040),
+        ndsi_params: tuple[float, float, float] = (0.4, 0.15, 0.001),
         b10_index: int | None = None,
         **kwargs: Any,
     ):
@@ -201,7 +201,7 @@ class TheiaSnowMaskTask(BaseSnowMaskTask):
 
     def _apply_first_pass(
         self, bands: np.ndarray, ndsi: np.ndarray, clm: np.ndarray, dem: np.ndarray, clm_temp: np.ndarray
-    ) -> Tuple[np.ndarray, np.ndarray | None, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray | None, np.ndarray]:
         """Apply first pass of snow detection"""
         snow_mask_pass1 = ~clm_temp & (ndsi > self.ndsi_params[0]) & (bands[..., 1] > self.red_params[3])
 

--- a/ml_tools/eolearn/ml_tools/sampling.py
+++ b/ml_tools/eolearn/ml_tools/sampling.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from abc import ABCMeta
 from math import sqrt
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Tuple, Union, cast
 
 import numpy as np
 from shapely.geometry import Point, Polygon
@@ -21,7 +21,7 @@ from eolearn.core.types import FeaturesSpecification, SingleFeatureSpec
 _FractionType = Union[float, Dict[int, float]]
 
 
-def random_point_in_triangle(triangle: Polygon, rng: Optional[np.random.Generator] = None) -> Point:
+def random_point_in_triangle(triangle: Polygon, rng: np.random.Generator | None = None) -> Point:
     """Selects a random point from an interior of a triangle.
 
     :param triangle: A triangle polygon.
@@ -44,7 +44,7 @@ def random_point_in_triangle(triangle: Polygon, rng: Optional[np.random.Generato
 def sample_by_values(
     image: np.ndarray,
     n_samples_per_value: Dict[int, int],
-    rng: Optional[np.random.Generator] = None,
+    rng: np.random.Generator | None = None,
     replace: bool = False,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Sample points from image with the amount of samples specified for each value.
@@ -133,7 +133,7 @@ class BaseSamplingTask(EOTask, metaclass=ABCMeta):
         self,
         features_to_sample: FeaturesSpecification,
         *,
-        mask_of_samples: Optional[Tuple[FeatureType, str]] = None,
+        mask_of_samples: Tuple[FeatureType, str] | None = None,
     ):
         """
         :param features_to_sample: Features that will be spatially sampled according to given sampling parameters.
@@ -180,7 +180,7 @@ class FractionSamplingTask(BaseSamplingTask):
         features_to_sample: FeaturesSpecification,
         sampling_feature: SingleFeatureSpec,
         fraction: _FractionType,
-        exclude_values: Optional[List[int]] = None,
+        exclude_values: List[int] | None = None,
         replace: bool = False,
         **kwargs: Any,
     ):
@@ -230,9 +230,7 @@ class FractionSamplingTask(BaseSamplingTask):
             return {val: round(n * fraction[val]) for val, n in available.items() if val in fraction}
         return {val: round(n * self.fraction) for val, n in available.items()}
 
-    def execute(
-        self, eopatch: EOPatch, *, seed: Optional[int] = None, fraction: Optional[_FractionType] = None
-    ) -> EOPatch:
+    def execute(self, eopatch: EOPatch, *, seed: int | None = None, fraction: _FractionType | None = None) -> EOPatch:
         """Execute random spatial sampling of specified features of eopatch
 
         :param eopatch: Input eopatch to be sampled
@@ -296,7 +294,7 @@ class BlockSamplingTask(BaseSamplingTask):
 
         return np.ones((height, width), dtype=np.uint8)
 
-    def execute(self, eopatch: EOPatch, *, seed: Optional[int] = None, amount: Optional[float] = None) -> EOPatch:
+    def execute(self, eopatch: EOPatch, *, seed: int | None = None, amount: float | None = None) -> EOPatch:
         """Execute a spatial sampling on features from a given EOPatch
 
         :param eopatch: Input eopatch to be sampled

--- a/ml_tools/eolearn/ml_tools/sampling.py
+++ b/ml_tools/eolearn/ml_tools/sampling.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from abc import ABCMeta
 from math import sqrt
-from typing import Any, Dict, List, Tuple, Union, cast
+from typing import Any, Dict, Union, cast
 
 import numpy as np
 from shapely.geometry import Point, Polygon
@@ -43,10 +43,10 @@ def random_point_in_triangle(triangle: Polygon, rng: np.random.Generator | None 
 
 def sample_by_values(
     image: np.ndarray,
-    n_samples_per_value: Dict[int, int],
+    n_samples_per_value: dict[int, int],
     rng: np.random.Generator | None = None,
     replace: bool = False,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """Sample points from image with the amount of samples specified for each value.
 
     :param image: A 2-dimensional numpy array
@@ -72,8 +72,8 @@ def sample_by_values(
 
 
 def expand_to_grids(
-    rows: np.ndarray, columns: np.ndarray, sample_size: Tuple[int, int] = (1, 1)
-) -> Tuple[np.ndarray, np.ndarray]:
+    rows: np.ndarray, columns: np.ndarray, sample_size: tuple[int, int] = (1, 1)
+) -> tuple[np.ndarray, np.ndarray]:
     """Expands sampled points into blocks and returns a pair of arrays. Each array represents a grid of indices
     of pixel locations, the first one row indices and the second one column indices. Each array is of shape
     `(N * sample_height, sample_width)`, where each element represent a row or column index in an original array
@@ -105,7 +105,7 @@ def expand_to_grids(
     return row_grids, column_grids
 
 
-def get_mask_of_samples(image_shape: Tuple[int, int], row_grid: np.ndarray, column_grid: np.ndarray) -> np.ndarray:
+def get_mask_of_samples(image_shape: tuple[int, int], row_grid: np.ndarray, column_grid: np.ndarray) -> np.ndarray:
     """Creates a mask of counts how many times each pixel has been sampled.
 
     :param image_shape: Height and width of a sampled image.
@@ -133,7 +133,7 @@ class BaseSamplingTask(EOTask, metaclass=ABCMeta):
         self,
         features_to_sample: FeaturesSpecification,
         *,
-        mask_of_samples: Tuple[FeatureType, str] | None = None,
+        mask_of_samples: tuple[FeatureType, str] | None = None,
     ):
         """
         :param features_to_sample: Features that will be spatially sampled according to given sampling parameters.
@@ -180,7 +180,7 @@ class FractionSamplingTask(BaseSamplingTask):
         features_to_sample: FeaturesSpecification,
         sampling_feature: SingleFeatureSpec,
         fraction: _FractionType,
-        exclude_values: List[int] | None = None,
+        exclude_values: list[int] | None = None,
         replace: bool = False,
         **kwargs: Any,
     ):
@@ -221,7 +221,7 @@ class FractionSamplingTask(BaseSamplingTask):
                 f"The fraction input is {fraction} but needs to be a number or a dictionary mapping labels to numbers."
             )
 
-    def _calculate_amount_per_value(self, image: np.ndarray, fraction: _FractionType) -> Dict[int, int]:
+    def _calculate_amount_per_value(self, image: np.ndarray, fraction: _FractionType) -> dict[int, int]:
         """Calculates the number of samples needed for each value present in mask according to the fraction parameter"""
         uniques, counts = np.unique(image, return_counts=True)
         available = {val: n for val, n in zip(uniques, counts) if val not in self.exclude_values}
@@ -266,7 +266,7 @@ class BlockSamplingTask(BaseSamplingTask):
         self,
         features_to_sample: FeaturesSpecification,
         amount: float,
-        sample_size: Tuple[int, int] = (1, 1),
+        sample_size: tuple[int, int] = (1, 1),
         replace: bool = False,
         **kwargs: Any,
     ):
@@ -330,8 +330,8 @@ class GridSamplingTask(BaseSamplingTask):
     def __init__(
         self,
         features_to_sample: FeaturesSpecification,
-        sample_size: Tuple[int, int] = (1, 1),
-        stride: Tuple[int, int] = (1, 1),
+        sample_size: tuple[int, int] = (1, 1),
+        stride: tuple[int, int] = (1, 1),
         **kwargs: Any,
     ):
         """
@@ -351,7 +351,7 @@ class GridSamplingTask(BaseSamplingTask):
         if not all(value > 0 for value in self.sample_size + self.stride):
             raise ValueError("Both sample_size and stride should have only positive values")
 
-    def _sample_regular_grid(self, image_shape: Tuple[int, int]) -> Tuple[np.ndarray, np.ndarray]:
+    def _sample_regular_grid(self, image_shape: tuple[int, int]) -> tuple[np.ndarray, np.ndarray]:
         """Samples points from a regular grid and returns indices of rows and columns"""
         rows = np.arange(0, image_shape[0] - self.sample_size[0] + 1, self.stride[0])
         columns = np.arange(0, image_shape[1] - self.sample_size[1] + 1, self.stride[1])

--- a/ml_tools/eolearn/ml_tools/train_test_split.py
+++ b/ml_tools/eolearn/ml_tools/train_test_split.py
@@ -9,7 +9,7 @@ This source code is licensed under the MIT license, see the LICENSE file in the 
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, List
+from typing import Any
 
 import numpy as np
 
@@ -68,9 +68,9 @@ class TrainTestSplitTask(EOTask):
         self,
         input_feature: SingleFeatureSpec,
         output_feature: SingleFeatureSpec,
-        bins: float | List[Any],
+        bins: float | list[Any],
         split_type: TrainTestSplitType = TrainTestSplitType.PER_PIXEL,
-        ignore_values: List[int] | None = None,
+        ignore_values: list[int] | None = None,
     ):
         """
         :param input_feature: The input feature to guide the split.

--- a/ml_tools/eolearn/ml_tools/train_test_split.py
+++ b/ml_tools/eolearn/ml_tools/train_test_split.py
@@ -9,7 +9,7 @@ This source code is licensed under the MIT license, see the LICENSE file in the 
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, List, Optional, Union
+from typing import Any, List
 
 import numpy as np
 
@@ -68,9 +68,9 @@ class TrainTestSplitTask(EOTask):
         self,
         input_feature: SingleFeatureSpec,
         output_feature: SingleFeatureSpec,
-        bins: Union[float, List[Any]],
+        bins: float | List[Any],
         split_type: TrainTestSplitType = TrainTestSplitType.PER_PIXEL,
-        ignore_values: Optional[List[int]] = None,
+        ignore_values: List[int] | None = None,
     ):
         """
         :param input_feature: The input feature to guide the split.
@@ -92,7 +92,7 @@ class TrainTestSplitTask(EOTask):
         self.ignore_values = set() if ignore_values is None else set(ignore_values)
         self.split_type = TrainTestSplitType(split_type)
 
-    def execute(self, eopatch: EOPatch, *, seed: Optional[int] = None) -> EOPatch:
+    def execute(self, eopatch: EOPatch, *, seed: int | None = None) -> EOPatch:
         """
         :param eopatch: input EOPatch
         :param seed: An argument to be passed to numpy.random.seed function.

--- a/ml_tools/eolearn/ml_tools/utils.py
+++ b/ml_tools/eolearn/ml_tools/utils.py
@@ -21,7 +21,7 @@ from eolearn.core.exceptions import EODeprecationWarning
 @deprecated_function(
     category=EODeprecationWarning, message_suffix="Please use `numpy.lib.stride_tricks.sliding_window_view` instead."
 )
-def rolling_window(
+def rolling_window(  # noqa: C901
     array: np.ndarray,
     window: Any = (0,),
     asteps: Optional[Any] = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ select = [
     "RUF", # ruff rules
     "NPY", # numpy
     "I",   # isort
-    # "UP",  # pyupgrade
+    "UP",  # pyupgrade
     "FA",  # checks where future import of annotations would make types nicer
 ]
 fix = true
@@ -42,7 +42,7 @@ fixable = [
     "F401",  # remove redundant imports
     "UP007", # use new-style union type annotations
     "UP006", # use new-style built-in type annotations
-    # "UP037", # remove quotes around types when not necessary
+    "UP037", # remove quotes around types when not necessary
     "FA100", # import future annotations where necessary (not autofixable ATM)
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,13 +36,13 @@ select = [
     # "UP",  # pyupgrade
     "FA",  # checks where future import of annotations would make types nicer
 ]
-fix = false
+fix = true
 fixable = [
     "I",     # sort imports
     "F401",  # remove redundant imports
     "UP007", # use new-style type annotations
-    "UP006", # use new-style type annotations
-    "UP037", # remove quotes around types when not necessary
+    # "UP006", # use new-style type annotations
+    # "UP037", # remove quotes around types when not necessary
     "FA100", # import future annotations where necessary (not autofixable ATM)
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,22 +3,8 @@ line-length = 120
 preview = true
 
 [tool.ruff]
-exclude = [".git", "__pycache__", "build", "dist"]
-ignore = [
-    "C408",   # complains about `dict()` calls, we use them to avoid too many " in the code
-    "SIM117", # wants to always combine `with` statements, gets ugly for us
-    "SIM108", # tries to aggresively inline `if`, not always readable
-    "A003",   # complains when ATTRIBUTES shadow builtins, we have objects that implement `filter` and such
-    "COM812", # trailing comma missing, fights with black
-    "PD011",  # suggests `.to_numpy` instead of `.values`, also does this for non-pandas objects...
-    # potentially fixable
-    "B904",  # want `raise ... from None` instead of just `raise ...`
-    "B028",  # always demands a stacklevel argument when warning
-    "PT011", # complains for `pytest.raises(ValueError)` but we use it a lot
-]
-fixable = ["I", "F401"]
-fix = true
 line-length = 120
+target-version = "py38"
 select = [
     "F",   # pyflakes
     "E",   # pycodestyle
@@ -47,14 +33,36 @@ select = [
     "RUF", # ruff rules
     "NPY", # numpy
     "I",   # isort
+    "UP",  # pyupgrade
+    "FA",  # checks where future import of annotations would make types nicer
 ]
-target-version = "py38"
+fix = false
+fixable = [
+    "I",     # sort imports
+    "F401",  # remove redundant imports
+    "UP007", # use new-style type annotations
+    "UP006", # use new-style type annotations
+    "UP037", # remove quotes around types when not necessary
+    "FA100", # import future annotations where necessary (not autofixable ATM)
+]
+ignore = [
+    "C408",   # complains about `dict()` calls, we use them to avoid too many " in the code
+    "SIM117", # wants to always combine `with` statements, gets ugly for us
+    "SIM108", # tries to aggresively inline `if`, not always readable
+    "A003",   # complains when ATTRIBUTES shadow builtins, we have objects that implement `filter` and such
+    "COM812", # trailing comma missing, fights with black
+    "PD011",  # suggests `.to_numpy` instead of `.values`, also does this for non-pandas objects...
+    # potentially fixable
+    "B904",  # want `raise ... from None` instead of just `raise ...`
+    "B028",  # always demands a stacklevel argument when warning
+    "PT011", # complains for `pytest.raises(ValueError)` but we use it a lot
+    "UP024", # wants to switch IOError with OSError
+]
+per-file-ignores = { "__init__.py" = ["F401"] }
+exclude = [".git", "__pycache__", "build", "dist"]
 
-[tool.ruff.mccabe]
-max-complexity = 15
 
 [tool.ruff.isort]
-# required-imports = ["from __future__ import annotations"]
 section-order = [
     "future",
     "standard-library",
@@ -64,12 +72,8 @@ section-order = [
     "local-folder",
 ]
 known-first-party = ["eolearn"]
+sections = { our-packages = ["sentinelhub"] }
 
-[tool.ruff.isort.sections]
-our-packages = ["sentinelhub"]
-
-[tool.ruff.per-file-ignores]
-"__init__.py" = ["F401"]
 
 [tool.pylint.format]
 max-line-length = 120
@@ -124,11 +128,13 @@ source = [
 omit = ["*/setup.py", "*/tests/*", "*/__init__.py"]
 
 [tool.nbqa.addopts]
-ruff = ["--extend-ignore=E402,T201,B015,B018,NPY002"]
+ruff = ["--extend-ignore=E402,T201,B015,B018,NPY002,UP,FA"]
 # E402 -> imports on top
 # T201 -> print found
 # B015 & B018 -> useless expression (used to show values in ipynb)
 # NPY002 -> use RNG instead of old numpy.random
+# UP -> suggestions for new-style classes (future import might confuse readers)
+# FA -> necessary future annotations import
 
 [tool.mypy]
 follow_imports = "normal"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ select = [
     "RUF", # ruff rules
     "NPY", # numpy
     "I",   # isort
-    "UP",  # pyupgrade
-    "FA",  # checks where future import of annotations would make types nicer
+    # "UP",  # pyupgrade
+    # "FA",  # checks where future import of annotations would make types nicer
 ]
 fix = false
 fixable = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ fix = true
 fixable = [
     "I",     # sort imports
     "F401",  # remove redundant imports
-    "UP007", # use new-style type annotations
-    # "UP006", # use new-style type annotations
+    "UP007", # use new-style union type annotations
+    "UP006", # use new-style built-in type annotations
     # "UP037", # remove quotes around types when not necessary
     "FA100", # import future annotations where necessary (not autofixable ATM)
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ select = [
     "NPY", # numpy
     "I",   # isort
     # "UP",  # pyupgrade
-    # "FA",  # checks where future import of annotations would make types nicer
+    "FA",  # checks where future import of annotations would make types nicer
 ]
 fix = false
 fixable = [

--- a/visualization/eolearn/visualization/eoexecutor.py
+++ b/visualization/eolearn/visualization/eoexecutor.py
@@ -6,6 +6,8 @@ For the full list of contributors, see the CREDITS file in the root directory of
 
 This source code is licensed under the MIT license, see the LICENSE file in the root directory of this source tree.
 """
+from __future__ import annotations
+
 import base64
 import datetime as dt
 import importlib

--- a/visualization/eolearn/visualization/eoexecutor.py
+++ b/visualization/eolearn/visualization/eoexecutor.py
@@ -15,7 +15,7 @@ import inspect
 import os
 import warnings
 from collections import defaultdict
-from typing import Any, DefaultDict, Dict, List, Tuple, cast
+from typing import Any, cast
 
 import fs
 import graphviz
@@ -99,12 +99,12 @@ class EOExecutorVisualization:
         dot = self.eoexecutor.workflow.dependency_graph()
         return base64.b64encode(dot.pipe()).decode()
 
-    def _get_exception_stats(self) -> List[Tuple[str, str, List[Tuple[str, int]]]]:
+    def _get_exception_stats(self) -> list[tuple[str, str, list[tuple[str, int]]]]:
         """Creates aggregated stats about exceptions"""
         formatter = HtmlFormatter()
         lexer = pygments.lexers.get_lexer_by_name("python", stripall=True)
 
-        exception_stats: DefaultDict[str, DefaultDict[str, int]] = defaultdict(lambda: defaultdict(lambda: 0))
+        exception_stats: defaultdict[str, defaultdict[str, int]] = defaultdict(lambda: defaultdict(lambda: 0))
 
         for workflow_results in self.eoexecutor.execution_results:
             if not workflow_results.error_node_uid:
@@ -119,8 +119,8 @@ class EOExecutorVisualization:
         return self._to_ordered_stats(exception_stats)
 
     def _to_ordered_stats(
-        self, exception_stats: DefaultDict[str, DefaultDict[str, int]]
-    ) -> List[Tuple[str, str, List[Tuple[str, int]]]]:
+        self, exception_stats: defaultdict[str, defaultdict[str, int]]
+    ) -> list[tuple[str, str, list[tuple[str, int]]]]:
         """Exception stats get ordered by nodes in their execution order in workflows. Exception stats that happen
         for the same node get ordered by number of occurrences in a decreasing order.
         """
@@ -136,10 +136,10 @@ class EOExecutorVisualization:
 
         return ordered_exception_stats
 
-    def _get_node_descriptions(self) -> List[Dict[str, Any]]:
+    def _get_node_descriptions(self) -> list[dict[str, Any]]:
         """Prepares a list of node names and initialization parameters of their tasks"""
         descriptions = []
-        name_counts: Dict[str, int] = defaultdict(lambda: 0)
+        name_counts: dict[str, int] = defaultdict(lambda: 0)
 
         for node in self.eoexecutor.workflow.get_nodes():
             node_name = node.get_name(name_counts[node.get_name()])
@@ -158,7 +158,7 @@ class EOExecutorVisualization:
 
         return descriptions
 
-    def _render_task_sources(self, formatter: pygments.formatter.Formatter) -> Dict[str, Any]:
+    def _render_task_sources(self, formatter: pygments.formatter.Formatter) -> dict[str, Any]:
         """Renders source code of EOTasks"""
         lexer = pygments.lexers.get_lexer_by_name("python", stripall=True)
         sources = {}

--- a/visualization/eolearn/visualization/eopatch.py
+++ b/visualization/eolearn/visualization/eopatch.py
@@ -12,7 +12,7 @@ import datetime as dt
 import itertools as it
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -72,11 +72,11 @@ class PlotConfig:
     subplot_width: float | int = 8
     subplot_height: float | int = 8
     interpolation: str = "none"
-    subplot_kwargs: Dict[str, object] = field(default_factory=dict)
+    subplot_kwargs: dict[str, object] = field(default_factory=dict)
     show_title: bool = True
-    title_kwargs: Dict[str, object] = field(default_factory=dict)
-    label_kwargs: Dict[str, object] = field(default_factory=dict)
-    bbox_kwargs: Dict[str, object] = field(default_factory=dict)
+    title_kwargs: dict[str, object] = field(default_factory=dict)
+    label_kwargs: dict[str, object] = field(default_factory=dict)
+    bbox_kwargs: dict[str, object] = field(default_factory=dict)
 
 
 class MatplotlibVisualization:
@@ -89,10 +89,10 @@ class MatplotlibVisualization:
         *,
         axes: np.ndarray | None = None,
         config: PlotConfig | None = None,
-        times: List[int] | slice | None = None,
-        channels: List[int] | slice | None = None,
-        channel_names: List[str] | None = None,
-        rgb: Tuple[int, int, int] | None = None,
+        times: list[int] | slice | None = None,
+        channels: list[int] | slice | None = None,
+        channel_names: list[str] | None = None,
+        rgb: tuple[int, int, int] | None = None,
     ):
         """
         :param eopatch: An EOPatch with a feature to plot.
@@ -157,7 +157,7 @@ class MatplotlibVisualization:
             return self._plot_bar(data, title=feature_name)
         return self._plot_time_series(data, timestamps=timestamps, title=feature_name)
 
-    def collect_and_prepare_feature(self, eopatch: EOPatch) -> Tuple[Any, List[dt.datetime]]:
+    def collect_and_prepare_feature(self, eopatch: EOPatch) -> tuple[Any, list[dt.datetime]]:
         """Collects a feature from EOPatch and modifies it according to plotting parameters"""
         feature_type, _ = self.feature
         data = eopatch[self.feature]
@@ -210,7 +210,7 @@ class MatplotlibVisualization:
         return dataframe[filtered_rows]
 
     def _plot_raster_grid(
-        self, raster: np.ndarray, timestamps: List[dt.datetime] | None = None, title: str | None = None
+        self, raster: np.ndarray, timestamps: list[dt.datetime] | None = None, title: str | None = None
     ) -> np.ndarray:
         """Plots a grid of raster images"""
         rows, _, _, columns = raster.shape
@@ -238,7 +238,7 @@ class MatplotlibVisualization:
         return axes
 
     def _plot_time_series(
-        self, series: np.ndarray, timestamps: List[dt.datetime] | None = None, title: str | None = None
+        self, series: np.ndarray, timestamps: list[dt.datetime] | None = None, title: str | None = None
     ) -> np.ndarray:
         """Plots time series feature."""
         axes = self._provide_axes(nrows=1, ncols=1, title=title)
@@ -339,6 +339,6 @@ class MatplotlibVisualization:
 
         return axes
 
-    def _get_label_kwargs(self) -> Dict[str, object]:
+    def _get_label_kwargs(self) -> dict[str, object]:
         """Provides `matplotlib` arguments for writing labels in plots."""
         return {"fontsize": 12, **self.config.label_kwargs}

--- a/visualization/eolearn/visualization/eopatch.py
+++ b/visualization/eolearn/visualization/eopatch.py
@@ -12,7 +12,7 @@ import datetime as dt
 import itertools as it
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -32,7 +32,7 @@ class PlotBackend(Enum):
     MATPLOTLIB = "matplotlib"
 
 
-def plot_eopatch(*args: Any, backend: Union[PlotBackend, str] = PlotBackend.MATPLOTLIB, **kwargs: Any) -> object:
+def plot_eopatch(*args: Any, backend: PlotBackend | str = PlotBackend.MATPLOTLIB, **kwargs: Any) -> object:
     """The main `EOPatch` plotting function. It pr
 
     :param args: Positional arguments to be propagated to a plotting backend.
@@ -66,11 +66,11 @@ class PlotConfig:
         box.
     """
 
-    rgb_factor: Optional[float] = 3.5
-    timestamp_column: Optional[str] = TIMESTAMP_COLUMN
+    rgb_factor: float | None = 3.5
+    timestamp_column: str | None = TIMESTAMP_COLUMN
     geometry_column: str = "geometry"
-    subplot_width: Union[float, int] = 8
-    subplot_height: Union[float, int] = 8
+    subplot_width: float | int = 8
+    subplot_height: float | int = 8
     interpolation: str = "none"
     subplot_kwargs: Dict[str, object] = field(default_factory=dict)
     show_title: bool = True
@@ -87,12 +87,12 @@ class MatplotlibVisualization:
         eopatch: EOPatch,
         feature: SingleFeatureSpec,
         *,
-        axes: Optional[np.ndarray] = None,
-        config: Optional[PlotConfig] = None,
-        times: Union[List[int], slice, None] = None,
-        channels: Union[List[int], slice, None] = None,
-        channel_names: Optional[List[str]] = None,
-        rgb: Optional[Tuple[int, int, int]] = None,
+        axes: np.ndarray | None = None,
+        config: PlotConfig | None = None,
+        times: List[int] | slice | None = None,
+        channels: List[int] | slice | None = None,
+        channel_names: List[str] | None = None,
+        rgb: Tuple[int, int, int] | None = None,
     ):
         """
         :param eopatch: An EOPatch with a feature to plot.
@@ -210,7 +210,7 @@ class MatplotlibVisualization:
         return dataframe[filtered_rows]
 
     def _plot_raster_grid(
-        self, raster: np.ndarray, timestamps: Optional[List[dt.datetime]] = None, title: Optional[str] = None
+        self, raster: np.ndarray, timestamps: List[dt.datetime] | None = None, title: str | None = None
     ) -> np.ndarray:
         """Plots a grid of raster images"""
         rows, _, _, columns = raster.shape
@@ -238,7 +238,7 @@ class MatplotlibVisualization:
         return axes
 
     def _plot_time_series(
-        self, series: np.ndarray, timestamps: Optional[List[dt.datetime]] = None, title: Optional[str] = None
+        self, series: np.ndarray, timestamps: List[dt.datetime] | None = None, title: str | None = None
     ) -> np.ndarray:
         """Plots time series feature."""
         axes = self._provide_axes(nrows=1, ncols=1, title=title)
@@ -254,7 +254,7 @@ class MatplotlibVisualization:
             axis.legend()
         return axes
 
-    def _plot_bar(self, values: np.ndarray, title: Optional[str] = None) -> np.ndarray:
+    def _plot_bar(self, values: np.ndarray, title: str | None = None) -> np.ndarray:
         """Make a bar plot from values."""
         axes = self._provide_axes(nrows=1, ncols=1, title=title)
         axis = axes.flatten()[0]
@@ -265,7 +265,7 @@ class MatplotlibVisualization:
         return axes
 
     def _plot_vector_feature(
-        self, dataframe: GeoDataFrame, timestamp_column: Optional[str] = None, title: Optional[str] = None
+        self, dataframe: GeoDataFrame, timestamp_column: str | None = None, title: str | None = None
     ) -> np.ndarray:
         """Plots a GeoDataFrame vector feature"""
         rows = len(dataframe[timestamp_column].unique()) if timestamp_column else 1
@@ -288,7 +288,7 @@ class MatplotlibVisualization:
 
         return axes
 
-    def _plot_bbox(self, axes: Optional[np.ndarray] = None, target_crs: Optional[CRS] = None) -> np.ndarray:
+    def _plot_bbox(self, axes: np.ndarray | None = None, target_crs: CRS | None = None) -> np.ndarray:
         """Plot a bounding box"""
         bbox = self.eopatch.bbox
         if bbox is None:
@@ -314,9 +314,7 @@ class MatplotlibVisualization:
 
         return axes
 
-    def _provide_axes(
-        self, *, nrows: int, ncols: int, title: Optional[str] = None, **subplot_kwargs: Any
-    ) -> np.ndarray:
+    def _provide_axes(self, *, nrows: int, ncols: int, title: str | None = None, **subplot_kwargs: Any) -> np.ndarray:
         """Either provides an existing grid of axes or creates new one"""
         if self.axes is not None:
             return self.axes

--- a/visualization/eolearn/visualization/eoworkflow.py
+++ b/visualization/eolearn/visualization/eoworkflow.py
@@ -6,6 +6,8 @@ For the full list of contributors, see the CREDITS file in the root directory of
 
 This source code is licensed under the MIT license, see the LICENSE file in the root directory of this source tree.
 """
+from __future__ import annotations
+
 from typing import Dict, List, Optional, Sequence
 
 from graphviz import Digraph

--- a/visualization/eolearn/visualization/eoworkflow.py
+++ b/visualization/eolearn/visualization/eoworkflow.py
@@ -8,7 +8,7 @@ This source code is licensed under the MIT license, see the LICENSE file in the 
 """
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Sequence
+from typing import Dict, List, Sequence
 
 from graphviz import Digraph
 
@@ -24,7 +24,7 @@ class EOWorkflowVisualization:
         """
         self.nodes = nodes
 
-    def dependency_graph(self, filename: Optional[str] = None) -> Digraph:
+    def dependency_graph(self, filename: str | None = None) -> Digraph:
         """Visualize the computational graph.
 
         :param filename: Filename of the output image together with file extension. Supported formats: `png`, `jpg`,

--- a/visualization/eolearn/visualization/eoworkflow.py
+++ b/visualization/eolearn/visualization/eoworkflow.py
@@ -8,7 +8,7 @@ This source code is licensed under the MIT license, see the LICENSE file in the 
 """
 from __future__ import annotations
 
-from typing import Dict, List, Sequence
+from typing import Sequence
 
 from graphviz import Digraph
 
@@ -56,10 +56,10 @@ class EOWorkflowVisualization:
         return dot
 
     @staticmethod
-    def _get_node_uid_to_dot_name_mapping(nodes: Sequence[EONode]) -> Dict[str, str]:
+    def _get_node_uid_to_dot_name_mapping(nodes: Sequence[EONode]) -> dict[str, str]:
         """Creates mapping between EONode classes and names used in DOT graph. To do that, it has to collect nodes with
         the same name and assign them different indices."""
-        dot_name_to_nodes: Dict[str, List[EONode]] = {}
+        dot_name_to_nodes: dict[str, list[EONode]] = {}
         for node in nodes:
             dot_name_to_nodes[node.get_name()] = dot_name_to_nodes.get(node.get_name(), [])
             dot_name_to_nodes[node.get_name()].append(node)


### PR DESCRIPTION
I would suggest you go through commit by commit and skip the big two (the new-style union autofix and new style builtins autofix).

I tried to simplify and reorder the pyproject.toml. The ruff section got very long due to us using nearly every code it has :smile_cat: 