### PR TITLE
Refactor feature io classes

### DIFF
--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -411,8 +411,8 @@ class FeatureIO(Generic[T], metaclass=ABCMeta):
     def _load_value(self) -> T:
         """Loads the value from the storage."""
 
-    @abstractmethod
     @classmethod
+    @abstractmethod
     def save(cls, data: T, filesystem: FS, feature_path: str, compress_level: int = 0) -> None:
         """Method for saving a feature. The path is assumed to be filesystem path but without file extensions.
 

--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -377,14 +377,14 @@ class FeatureIO(Generic[T], metaclass=ABCMeta):
         :param path: A path in the filesystem
         :param filesystem: A filesystem object
         """
-        self._check_path_has_valid_extension(path)
+        self._check_path_extension(path)
 
         self.path = path
         self.filesystem = filesystem
 
         self.loaded_value: T | None = None
 
-    def _check_path_has_valid_extension(self, path: str) -> None:
+    def _check_path_extension(self, path: str) -> None:
         filename = fs.path.basename(path)
         expected_extension = f".{self.get_file_extension()}"
         if not filename.endswith(expected_extension):
@@ -426,7 +426,7 @@ class FeatureIOGZip(FeatureIO[T], metaclass=ABCMeta):
     Uses GZip to compress files when required.
     """
 
-    def _check_path_has_valid_extension(self, path: str) -> None:
+    def _check_path_extension(self, path: str) -> None:
         filename = fs.path.basename(path)
         expected_extension = f".{self.get_file_extension()}"
         compressed_extension = expected_extension + f".{MimeType.GZIP.extension}"

--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -377,16 +377,18 @@ class FeatureIO(Generic[T], metaclass=ABCMeta):
         :param path: A path in the filesystem
         :param filesystem: A filesystem object
         """
-        filename = fs.path.basename(path)
-        expected_extension = f".{self.get_file_format().extension}"
-        compressed_extension = expected_extension + f".{MimeType.GZIP.extension}"
-        if not filename.endswith((expected_extension, compressed_extension)):
-            raise ValueError(f"FeatureIO expects a filepath with the {expected_extension} file extension, got {path}")
+        self._check_path_has_valid_extension(path)
 
         self.path = path
         self.filesystem = filesystem
 
         self.loaded_value: T | None = None
+
+    def _check_path_has_valid_extension(self, path: str) -> None:
+        filename = fs.path.basename(path)
+        expected_extension = f".{self.get_file_format().extension}"
+        if not filename.endswith(expected_extension):
+            raise ValueError(f"FeatureIO expects a filepath with the {expected_extension} file extension, got {path}")
 
     @classmethod
     @abstractmethod
@@ -423,6 +425,13 @@ class FeatureIOGZip(FeatureIO[T], metaclass=ABCMeta):
 
     Uses GZip to compress files when required.
     """
+
+    def _check_path_has_valid_extension(self, path: str) -> None:
+        filename = fs.path.basename(path)
+        expected_extension = f".{self.get_file_format().extension}"
+        compressed_extension = expected_extension + f".{MimeType.GZIP.extension}"
+        if not filename.endswith((expected_extension, compressed_extension)):
+            raise ValueError(f"FeatureIO expects a filepath with the {expected_extension} file extension, got {path}")
 
     def _load_value(self) -> T:
         with self.filesystem.openbin(self.path, "r") as file_handle:

--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -386,14 +386,14 @@ class FeatureIO(Generic[T], metaclass=ABCMeta):
 
     def _check_path_has_valid_extension(self, path: str) -> None:
         filename = fs.path.basename(path)
-        expected_extension = f".{self.get_file_format().extension}"
+        expected_extension = f".{self.get_file_extension()}"
         if not filename.endswith(expected_extension):
             raise ValueError(f"FeatureIO expects a filepath with the {expected_extension} file extension, got {path}")
 
     @classmethod
     @abstractmethod
-    def get_file_format(cls) -> MimeType:
-        """The type of files handled by the FeatureIO."""
+    def get_file_extension(cls) -> str:
+        """The extension of files handled by the FeatureIO."""
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.path})"
@@ -428,7 +428,7 @@ class FeatureIOGZip(FeatureIO[T], metaclass=ABCMeta):
 
     def _check_path_has_valid_extension(self, path: str) -> None:
         filename = fs.path.basename(path)
-        expected_extension = f".{self.get_file_format().extension}"
+        expected_extension = f".{self.get_file_extension()}"
         compressed_extension = expected_extension + f".{MimeType.GZIP.extension}"
         if not filename.endswith((expected_extension, compressed_extension)):
             raise ValueError(f"FeatureIO expects a filepath with the {expected_extension} file extension, got {path}")
@@ -456,7 +456,7 @@ class FeatureIOGZip(FeatureIO[T], metaclass=ABCMeta):
         overwritten).
         """
         gz_extension = ("." + MimeType.GZIP.extension) if compress_level else ""
-        path = f"{feature_path}.{cls.get_file_format().extension}{gz_extension}"
+        path = f"{feature_path}.{cls.get_file_extension()}{gz_extension}"
 
         if isinstance(filesystem, (OSFS, TempFS)):
             with TempFS(temp_dir=filesystem.root_path) as tempfs:
@@ -487,8 +487,8 @@ class FeatureIONumpy(FeatureIOGZip[np.ndarray]):
     """FeatureIO object specialized for Numpy arrays."""
 
     @classmethod
-    def get_file_format(cls) -> MimeType:
-        return MimeType.NPY
+    def get_file_extension(cls) -> str:
+        return MimeType.NPY.extension
 
     def _read_from_file(self, file: BinaryIO | gzip.GzipFile) -> np.ndarray:
         return np.load(file, allow_pickle=True)
@@ -502,8 +502,8 @@ class FeatureIOGeoDf(FeatureIOGZip[gpd.GeoDataFrame]):
     """FeatureIO object specialized for GeoDataFrames."""
 
     @classmethod
-    def get_file_format(cls) -> MimeType:
-        return MimeType.GPKG
+    def get_file_extension(cls) -> str:
+        return MimeType.GPKG.extension
 
     def _read_from_file(self, file: BinaryIO | gzip.GzipFile) -> gpd.GeoDataFrame:
         dataframe = gpd.read_file(file)
@@ -535,8 +535,8 @@ class FeatureIOJson(FeatureIOGZip[T]):
     """FeatureIO object specialized for JSON-like objects."""
 
     @classmethod
-    def get_file_format(cls) -> MimeType:
-        return MimeType.JSON
+    def get_file_extension(cls) -> str:
+        return MimeType.JSON.extension
 
     def _read_from_file(self, file: BinaryIO | gzip.GzipFile) -> T:
         return json.load(file)
@@ -566,8 +566,8 @@ class FeatureIOBBox(FeatureIOGZip[BBox]):
     """FeatureIO object specialized for BBox objects."""
 
     @classmethod
-    def get_file_format(cls) -> MimeType:
-        return MimeType.GEOJSON
+    def get_file_extension(cls) -> str:
+        return MimeType.GEOJSON.extension
 
     def _read_from_file(self, file: BinaryIO | gzip.GzipFile) -> BBox:
         json_data = json.load(file)

--- a/core/eolearn/tests/test_eodata_io.py
+++ b/core/eolearn/tests/test_eodata_io.py
@@ -368,7 +368,7 @@ def test_feature_io(constructor: type[FeatureIO], data: Any, compress_level: int
     Test cases do not include subfolders, because subfolder management is currently done by the `save_eopatch` function.
     """
 
-    file_extension = "." + str(constructor.get_file_format().extension)
+    file_extension = f".{constructor.get_file_extension()}"
     file_extension = file_extension if compress_level == 0 else file_extension + ".gz"
     file_name = "name"
     with TempFS("testing_file_sistem") as temp_fs:


### PR DESCRIPTION
This is meant to set the stage for the future Zarr backend

When prototyping it became obvious that the burnt-in GZIP only made sense when all compression was done through it. With Zarr that will no longer be the case. Decided to do it separately to keep MRs small.

I also moved away from shpy MimeType class for file extensions, because it's annoying to first update sh-py whenever we add a new supported file format

I still do not like how `save` has a `compression_level` since that is again very GZIP specific, but I'd prefer to resolve that at a later point, when I have a better idea on how to handle FeatureIO classes with different parameters (since we'll have temporal indices and whatnot).
