### PR TITLE
Change typevar names

### DIFF
--- a/core/eolearn/core/extra/ray.py
+++ b/core/eolearn/core/extra/ray.py
@@ -22,8 +22,8 @@ from ..eoworkflow import WorkflowResults
 from ..utils.parallelize import _base_join_futures_iter, _ProcessingType
 
 # pylint: disable=invalid-name
-_InputType = TypeVar("_InputType")
-_OutputType = TypeVar("_OutputType")
+InputType = TypeVar("InputType")
+OutputType = TypeVar("OutputType")
 
 
 class RayExecutor(EOExecutor):
@@ -65,8 +65,8 @@ def _ray_workflow_executor(workflow_args: _ProcessingData) -> WorkflowResults:
 
 
 def parallelize_with_ray(
-    function: Callable[[_InputType], _OutputType], *params: Iterable[_InputType], **tqdm_kwargs: Any
-) -> list[_OutputType]:
+    function: Callable[[InputType], OutputType], *params: Iterable[InputType], **tqdm_kwargs: Any
+) -> list[OutputType]:
     """Parallelizes function execution with Ray.
 
     Note that this function will automatically connect to a Ray cluster, if a connection wouldn't exist yet. But it

--- a/core/eolearn/core/graph.py
+++ b/core/eolearn/core/graph.py
@@ -13,14 +13,14 @@ import collections
 import copy
 from typing import Generic, Iterator, Sequence, TypeVar
 
-_T = TypeVar("_T")
+T = TypeVar("T")
 
 
 class CyclicDependencyError(ValueError):
     """This error is raised when trying to get a topological ordering of a `DirectedGraph`."""
 
 
-class DirectedGraph(Generic[_T]):
+class DirectedGraph(Generic[T]):
     """A directed graph using adjacency-list representation. The graph is multi-edge.
 
     Constructs a new graph from an adjacency list. If adjacency_dict is None, an empty graph is constructed.
@@ -28,7 +28,7 @@ class DirectedGraph(Generic[_T]):
     :param adjacency_dict: A dictionary mapping vertices to lists of neighbors
     """
 
-    def __init__(self, adjacency_dict: dict[_T, list[_T]] | None = None):
+    def __init__(self, adjacency_dict: dict[T, list[T]] | None = None):
         self._adj_dict = (
             collections.defaultdict(list, adjacency_dict) if adjacency_dict else collections.defaultdict(list)
         )
@@ -39,19 +39,19 @@ class DirectedGraph(Generic[_T]):
         """Returns the number of vertices in the graph."""
         return len(self._vertices)
 
-    def __contains__(self, vertex: _T) -> bool:
+    def __contains__(self, vertex: T) -> bool:
         """True if `vertex` is a vertex of the graph. False otherwise.
 
         :param vertex: Vertex
         """
         return vertex in self._vertices
 
-    def __iter__(self) -> Iterator[_T]:
+    def __iter__(self) -> Iterator[T]:
         """Returns iterator over the vertices of the graph."""
         return iter(self._vertices)
 
-    def _make_indegrees_dict(self) -> collections.defaultdict[_T, int]:
-        indegrees: collections.defaultdict[_T, int] = collections.defaultdict(int)
+    def _make_indegrees_dict(self) -> collections.defaultdict[T, int]:
+        indegrees: collections.defaultdict[T, int] = collections.defaultdict(int)
 
         for u_vertex in self._adj_dict:
             for v_vertex in self._adj_dict[u_vertex]:
@@ -59,11 +59,11 @@ class DirectedGraph(Generic[_T]):
 
         return indegrees
 
-    def get_indegrees(self) -> dict[_T, int]:
+    def get_indegrees(self) -> dict[T, int]:
         """Returns a dictionary containing in-degrees of vertices of the graph."""
         return dict(self._indegrees)
 
-    def get_indegree(self, vertex: _T) -> int:
+    def get_indegree(self, vertex: T) -> int:
         """Returns the in-degree of the vertex.
 
         The in-degree is the number of vertices `vertex'` such that `vertex' -> vertex` is an edge of the graph.
@@ -72,13 +72,13 @@ class DirectedGraph(Generic[_T]):
         """
         return self._indegrees[vertex]
 
-    def get_outdegrees(self) -> dict[_T, int]:
+    def get_outdegrees(self) -> dict[T, int]:
         """
         :return: dictionary of out-degrees, see get_outdegree
         """
         return {vertex: len(self._adj_dict[vertex]) for vertex in self._adj_dict}
 
-    def get_outdegree(self, vertex: _T) -> int:
+    def get_outdegree(self, vertex: T) -> int:
         """Returns the out-degree of the vertex.
 
         The out-degree is the number of vertices `vertex'` such that `vertex -> vertex'` is an edge of the graph.
@@ -87,17 +87,17 @@ class DirectedGraph(Generic[_T]):
         """
         return len(self._adj_dict[vertex])
 
-    def get_adj_dict(self) -> dict[_T, list]:
+    def get_adj_dict(self) -> dict[T, list]:
         """
         :return: adj_dict
         """
         return {vertex: copy.copy(neighbours) for vertex, neighbours in self._adj_dict.items()}
 
-    def get_vertices(self) -> set[_T]:
+    def get_vertices(self) -> set[T]:
         """Returns the set of vertices of the graph."""
         return set(self._vertices)
 
-    def add_edge(self, u_vertex: _T, v_vertex: _T) -> None:
+    def add_edge(self, u_vertex: T, v_vertex: T) -> None:
         """Adds the edge `u_vertex -> v_vertex` to the graph if the edge is not already present.
 
         :param u_vertex: Vertex
@@ -108,7 +108,7 @@ class DirectedGraph(Generic[_T]):
         self._indegrees[v_vertex] += 1
         self._adj_dict[u_vertex].append(v_vertex)
 
-    def del_edge(self, u_vertex: _T, v_vertex: _T) -> bool:
+    def del_edge(self, u_vertex: T, v_vertex: T) -> bool:
         """Removes the edge `u_vertex -> v_vertex` from the graph if the edge is present.
 
         :param u_vertex: Vertex
@@ -122,7 +122,7 @@ class DirectedGraph(Generic[_T]):
 
         return False
 
-    def add_vertex(self, vertex: _T) -> bool:
+    def add_vertex(self, vertex: T) -> bool:
         """Adds a new vertex to the graph if not present.
 
         :param vertex: Vertex
@@ -134,7 +134,7 @@ class DirectedGraph(Generic[_T]):
 
         return False
 
-    def del_vertex(self, vertex: _T) -> bool:
+    def del_vertex(self, vertex: T) -> bool:
         """Removes the vertex `vertex` and all incident edges from the graph.
 
         **Note** that this is an expensive operation that should be avoided!
@@ -157,20 +157,20 @@ class DirectedGraph(Generic[_T]):
         self._vertices.remove(vertex)
         return True
 
-    def is_edge(self, u_vertex: _T, v_vertex: _T) -> bool:
+    def is_edge(self, u_vertex: T, v_vertex: T) -> bool:
         """True if `u_vertex -> v_vertex` is an edge of the graph. False otherwise."""
         return v_vertex in self._adj_dict[u_vertex]
 
-    def get_neighbors(self, vertex: _T) -> list[_T]:
+    def get_neighbors(self, vertex: T) -> list[T]:
         """Returns the set of successor vertices of `vertex`."""
         return copy.copy(self._adj_dict[vertex])
 
     @staticmethod
-    def from_edges(edges: Sequence[tuple[_T, _T]]) -> DirectedGraph[_T]:
+    def from_edges(edges: Sequence[tuple[T, T]]) -> DirectedGraph[T]:
         """Return DirectedGraph created from edges.
         :param edges: Pairs of objects that describe all the edges of the graph
         """
-        dag: DirectedGraph = DirectedGraph[_T]()
+        dag: DirectedGraph = DirectedGraph[T]()
         for _u, _v in edges:
             dag.add_edge(_u, _v)
         return dag
@@ -197,7 +197,7 @@ class DirectedGraph(Generic[_T]):
                         stack.append(v)
         return False
 
-    def topologically_ordered_vertices(self) -> list[_T]:
+    def topologically_ordered_vertices(self) -> list[T]:
         """Computes an ordering `<` of vertices so that for any two vertices `v` and `v'` we have that if `v˙ depends
         on `v'` then `v' < v`. In words, all dependencies of a vertex precede the vertex in this ordering.
 

--- a/core/eolearn/core/utils/parallelize.py
+++ b/core/eolearn/core/utils/parallelize.py
@@ -25,9 +25,9 @@ else:
     MULTIPROCESSING_LOCK = None
 
 # pylint: disable=invalid-name
-_T = TypeVar("_T")
-_FutureType = TypeVar("_FutureType")
-_OutputType = TypeVar("_OutputType")
+T = TypeVar("T")
+FutureType = TypeVar("FutureType")
+OutputType = TypeVar("OutputType")
 
 
 class _ProcessingType(Enum):
@@ -55,12 +55,12 @@ def _decide_processing_type(workers: int | None, multiprocess: bool) -> _Process
 
 
 def parallelize(
-    function: Callable[..., _OutputType],
+    function: Callable[..., OutputType],
     *params: Iterable[Any],
     workers: int | None,
     multiprocess: bool = True,
     **tqdm_kwargs: Any,
-) -> list[_OutputType]:
+) -> list[OutputType]:
     """Parallelizes the function on given parameters using the specified number of workers.
 
     :param function: A function to be parallelized.
@@ -98,7 +98,7 @@ def parallelize(
         MULTIPROCESSING_LOCK = None
 
 
-def execute_with_mp_lock(function: Callable[..., _OutputType], *args: Any, **kwargs: Any) -> _OutputType:
+def execute_with_mp_lock(function: Callable[..., OutputType], *args: Any, **kwargs: Any) -> OutputType:
     """A helper utility function that executes a given function with multiprocessing lock if the process is being
     executed in a multiprocessing mode.
 
@@ -117,10 +117,10 @@ def execute_with_mp_lock(function: Callable[..., _OutputType], *args: Any, **kwa
 
 def submit_and_monitor_execution(
     executor: Executor,
-    function: Callable[..., _OutputType],
+    function: Callable[..., OutputType],
     *params: Iterable[Any],
     **tqdm_kwargs: Any,
-) -> list[_OutputType]:
+) -> list[OutputType]:
     """Performs the execution parallelization and monitors the process using a progress bar.
 
     :param executor: An object that performs parallelization.
@@ -177,16 +177,16 @@ def join_futures_iter(
 
 
 def _base_join_futures_iter(
-    wait_function: Callable[[Collection[_FutureType]], tuple[Collection[_FutureType], Collection[_FutureType]]],
-    get_result_function: Callable[[_FutureType], _OutputType],
-    futures: list[_FutureType],
+    wait_function: Callable[[Collection[FutureType]], tuple[Collection[FutureType], Collection[FutureType]]],
+    get_result_function: Callable[[FutureType], OutputType],
+    futures: list[FutureType],
     **tqdm_kwargs: Any,
-) -> Generator[tuple[int, _OutputType], None, None]:
+) -> Generator[tuple[int, OutputType], None, None]:
     """A generalized utility function that resolves futures, monitors progress, and serves as an iterator over
     results."""
     if not isinstance(futures, list):
         raise ValueError(f"Parameters 'futures' should be a list but {type(futures)} was given")
-    remaining_futures: Collection[_FutureType] = _make_copy_and_empty_given(futures)
+    remaining_futures: Collection[FutureType] = _make_copy_and_empty_given(futures)
 
     id_to_position_map = {id(future): index for index, future in enumerate(remaining_futures)}
 
@@ -200,7 +200,7 @@ def _base_join_futures_iter(
                 yield result_position, result
 
 
-def _make_copy_and_empty_given(items: list[_T]) -> list[_T]:
+def _make_copy_and_empty_given(items: list[T]) -> list[T]:
     """Removes items from the given list and returns its copy. The side effect of removing items is intentional."""
     items_copy = items[:]
     while items:


### PR DESCRIPTION
The `_` prefix was originally added to avoid issues with docs, but it turns out there are no issues with docs (type vars are not included) and the prefix-free notation is easier on the eyes in IDEs