### PR TITLE
Switch "no timestamps" value to `None`

### DIFF
--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -285,7 +285,9 @@ class EOPatch:
 
     @timestamps.setter
     def timestamps(self, value: Iterable[dt.datetime] | None) -> None:
-        if isinstance(value, Iterable) and all(isinstance(time, (dt.date, str)) for time in value):
+        if value is None:
+            self._timestamps = None
+        elif isinstance(value, Iterable) and all(isinstance(time, (dt.date, str)) for time in value):
             self._timestamps = [parse_time(time, force_datetime=True) for time in value]
         else:
             raise TypeError(f"Cannot assign {value} as timestamps. Should be a sequence of datetime.datetime objects.")
@@ -381,7 +383,7 @@ class EOPatch:
         if feature_type == FeatureType.BBOX:
             raise ValueError("The BBox of an EOPatch should never be undefined.")
         if feature_type == FeatureType.TIMESTAMPS:
-            self[feature_type] = []
+            self[feature_type] = None
         else:
             self[feature_type] = {}
 

--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -222,7 +222,7 @@ class EOPatch:
     """
 
     # establish types of property value holders
-    _timestamps: list[dt.datetime]
+    _timestamps: list[dt.datetime] | None
     _bbox: BBox | None
     _meta_info: FeatureIOJson | _FeatureDictJson
 
@@ -265,10 +265,10 @@ class EOPatch:
         )
         self.meta_info: MutableMapping[str, Any] = _FeatureDictJson(meta_info or {}, FeatureType.META_INFO)
         self.bbox = bbox
-        self.timestamps = timestamps or []
+        self.timestamps = timestamps
 
     @property
-    def timestamp(self) -> list[dt.datetime]:
+    def timestamp(self) -> list[dt.datetime] | None:
         """A property for handling the deprecated timestamp attribute."""
         warn(TIMESTAMP_RENAME_WARNING, category=EODeprecationWarning, stacklevel=2)
         return self.timestamps
@@ -279,16 +279,22 @@ class EOPatch:
         self.timestamps = value
 
     @property
-    def timestamps(self) -> list[dt.datetime]:
+    def timestamps(self) -> list[dt.datetime] | None:
         """A property for handling the `timestamps` attribute."""
         return self._timestamps
 
     @timestamps.setter
-    def timestamps(self, value: Iterable[dt.datetime]) -> None:
+    def timestamps(self, value: Iterable[dt.datetime] | None) -> None:
         if isinstance(value, Iterable) and all(isinstance(time, (dt.date, str)) for time in value):
             self._timestamps = [parse_time(time, force_datetime=True) for time in value]
         else:
             raise TypeError(f"Cannot assign {value} as timestamps. Should be a sequence of datetime.datetime objects.")
+
+    def get_timestamps(self) -> list[dt.datetime]:
+        """Returns the `timestamps` attribute if timestamps if the EOPatch is temporally defined. Fails otherwise."""
+        if self._timestamps is None:
+            raise RuntimeError("The EOPatch does not contain timestamps.")
+        return self._timestamps
 
     @property
     def bbox(self) -> BBox | None:

--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -292,10 +292,10 @@ class EOPatch:
         else:
             raise TypeError(f"Cannot assign {value} as timestamps. Should be a sequence of datetime.datetime objects.")
 
-    def get_timestamps(self) -> list[dt.datetime]:
+    def get_timestamps(self, message_on_failure: str = "The EOPatch does not contain timestamps.") -> list[dt.datetime]:
         """Returns the `timestamps` attribute if timestamps if the EOPatch is temporally defined. Fails otherwise."""
         if self._timestamps is None:
-            raise RuntimeError("The EOPatch does not contain timestamps.")
+            raise RuntimeError(message_on_failure)
         return self._timestamps
 
     @property

--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -695,10 +695,11 @@ class EOPatch:
         :param timestamps: keep frames with date found in this list
         :return: set of removed frames' dates
         """
-        remove_from_patch = set(self.timestamps).difference(timestamps)
-        remove_from_patch_idxs = [self.timestamps.index(rm_date) for rm_date in remove_from_patch]
-        good_timestamp_idxs = [idx for idx, _ in enumerate(self.timestamps) if idx not in remove_from_patch_idxs]
-        good_timestamps = [date for idx, date in enumerate(self.timestamps) if idx not in remove_from_patch_idxs]
+        old_timestamps = self.get_timestamps()
+        remove_from_patch = set(old_timestamps).difference(timestamps)
+        remove_from_patch_idxs = [old_timestamps.index(rm_date) for rm_date in remove_from_patch]
+        good_timestamp_idxs = [idx for idx, _ in enumerate(old_timestamps) if idx not in remove_from_patch_idxs]
+        good_timestamps = [date for idx, date in enumerate(old_timestamps) if idx not in remove_from_patch_idxs]
 
         for ftype in FeatureType:
             if ftype.is_timeless() or ftype.is_meta() or ftype.is_vector():

--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -292,7 +292,9 @@ class EOPatch:
         else:
             raise TypeError(f"Cannot assign {value} as timestamps. Should be a sequence of datetime.datetime objects.")
 
-    def get_timestamps(self, message_on_failure: str = "This EOPatch does not contain timestamps.") -> list[dt.datetime]:
+    def get_timestamps(
+        self, message_on_failure: str = "This EOPatch does not contain timestamps."
+    ) -> list[dt.datetime]:
         """Returns the `timestamps` attribute if the EOPatch is temporally defined. Fails otherwise."""
         if self._timestamps is None:
             raise RuntimeError(message_on_failure)

--- a/core/eolearn/core/eodata_merge.py
+++ b/core/eolearn/core/eodata_merge.py
@@ -121,15 +121,15 @@ def _return_if_equal_operation(arrays: np.ndarray) -> bool:
 
 def _merge_timestamps(
     eopatches: Sequence[EOPatch], reduce_timestamps: bool
-) -> tuple[list[dt.datetime], list[np.ndarray]]:
+) -> tuple[list[dt.datetime] | None, list[np.ndarray]]:
     """Merges together timestamps from EOPatches. It also prepares a list of masks, one for each EOPatch, how
     timestamps should be ordered and joined together.
     """
-    timestamps_per_eopatch = [eopatch.timestamps for eopatch in eopatches]
+    timestamps_per_eopatch = [eopatch.timestamps or [] for eopatch in eopatches]
     all_timestamps = [timestamp for eopatch_timestamps in timestamps_per_eopatch for timestamp in eopatch_timestamps]
 
     if not all_timestamps:
-        return [], [np.array([], dtype=np.int32) for _ in range(len(eopatches))]
+        return None, [np.array([], dtype=np.int32) for _ in range(len(eopatches))]
 
     if reduce_timestamps:
         unique_timestamps, order_mask = np.unique(all_timestamps, return_inverse=True)  # type: ignore[call-overload]

--- a/core/eolearn/core/eodata_merge.py
+++ b/core/eolearn/core/eodata_merge.py
@@ -125,11 +125,14 @@ def _merge_timestamps(
     """Merges together timestamps from EOPatches. It also prepares a list of masks, one for each EOPatch, how
     timestamps should be ordered and joined together.
     """
+    if all(eopatch.timestamps is None for eopatch in eopatches):
+        return None, [np.array([], dtype=np.int32) for _ in range(len(eopatches))]
+
     timestamps_per_eopatch = [eopatch.timestamps or [] for eopatch in eopatches]
     all_timestamps = [timestamp for eopatch_timestamps in timestamps_per_eopatch for timestamp in eopatch_timestamps]
 
     if not all_timestamps:
-        return None, [np.array([], dtype=np.int32) for _ in range(len(eopatches))]
+        return [], [np.array([], dtype=np.int32) for _ in range(len(eopatches))]
 
     if reduce_timestamps:
         unique_timestamps, order_mask = np.unique(all_timestamps, return_inverse=True)  # type: ignore[call-overload]

--- a/core/eolearn/tests/test_eodata.py
+++ b/core/eolearn/tests/test_eodata.py
@@ -264,7 +264,7 @@ def test_copy_features(test_eopatch: EOPatch) -> None:
     eopatch_copy = test_eopatch.copy(features=[feature])
     assert test_eopatch != eopatch_copy
     assert eopatch_copy[feature] is test_eopatch[feature]
-    assert eopatch_copy.timestamps == []
+    assert eopatch_copy.timestamps is None
 
 
 @pytest.mark.parametrize(

--- a/core/eolearn/tests/test_eodata_merge.py
+++ b/core/eolearn/tests/test_eodata_merge.py
@@ -95,6 +95,21 @@ def test_failed_time_dependent_merge():
         merge_eopatches(eop2, eop1)
 
 
+def test_temporally_empty_merge():
+    """Merging patches without a temporal definition should return a temporally undefined patch. However merging a patch
+    with an empty temporal axis should not result in a temporally undefined EOPatch."""
+    eop1 = EOPatch(bbox=DUMMY_BBOX, data={"bands": np.ones((0, 4, 5, 2))}, timestamps=[])
+    eop2 = EOPatch(bbox=DUMMY_BBOX, mask_timeless={"mask": np.ones((4, 5, 2), dtype=np.int8)}, timestamps=None)
+    result = EOPatch(
+        bbox=DUMMY_BBOX,
+        data={"bands": np.ones((0, 4, 5, 2))},
+        mask_timeless={"mask": np.ones((4, 5, 2), dtype=np.int8)},
+        timestamps=[],
+    )
+    assert merge_eopatches(eop2, eop2).timestamps is None, "Faulty temporal definition added."
+    assert merge_eopatches(eop1, eop2) == result
+
+
 def test_timeless_merge():
     eop1 = EOPatch(
         bbox=DUMMY_BBOX,

--- a/features/eolearn/features/doubly_logistic_approximation.py
+++ b/features/eolearn/features/doubly_logistic_approximation.py
@@ -92,7 +92,7 @@ class DoublyLogisticApproximationTask(EOTask):
         """
         data = eopatch[self.feature].squeeze(axis=3)
 
-        times = np.asarray([time.toordinal() for time in eopatch.timestamps])
+        times = np.asarray([time.toordinal() for time in eopatch.get_timestamps()])
         times = (times - times[0]) / (times[-1] - times[0])
 
         time, height, width = data.shape

--- a/features/eolearn/features/feature_manipulation.py
+++ b/features/eolearn/features/feature_manipulation.py
@@ -84,7 +84,7 @@ class SimpleFilterTask(EOTask):
                 if feature_type.is_array():
                     data = data[good_idxs]
                 else:
-                    data = self._filter_vector_feature(data, good_idxs, eopatch.timestamps)
+                    data = self._filter_vector_feature(data, good_idxs, eopatch.get_timestamps())
 
             filtered_eopatch[feature] = data
 

--- a/features/eolearn/features/interpolation.py
+++ b/features/eolearn/features/interpolation.py
@@ -384,8 +384,8 @@ class InterpolationTask(EOTask):
 
         # Resample times
         times = self._get_eopatch_time_series(eopatch, scale_time=self.scale_time)
-        new_eopatch.timestamps = self.get_resampled_timestamp(eopatch.timestamps)
-        total_diff = int((new_eopatch.timestamps[0].date() - eopatch.timestamps[0].date()).total_seconds())
+        new_eopatch.timestamps = self.get_resampled_timestamp(eopatch.get_timestamps())
+        total_diff = int((new_eopatch.get_timestamps()[0].date() - eopatch.get_timestamps()[0].date()).total_seconds())
         resampled_times = (
             self._get_eopatch_time_series(new_eopatch, scale_time=self.scale_time) + total_diff // self.scale_time
         )

--- a/features/eolearn/features/temporal_features.py
+++ b/features/eolearn/features/temporal_features.py
@@ -212,7 +212,7 @@ class AddMaxMinNDVISlopeIndicesTask(EOTask):
 
         ndvi = np.ma.array(eopatch.data[self.data_feature], dtype=np.float32, mask=~valid_data_mask.astype(bool))
 
-        all_dates = np.asarray([x.toordinal() for x in eopatch.timestamps])
+        all_dates = np.asarray([x.toordinal() for x in eopatch.get_timestamps()])
 
         if ndvi.ndim == 4:
             h, w = ndvi.shape[1:3]

--- a/io/eolearn/io/extra/meteoblue.py
+++ b/io/eolearn/io/extra/meteoblue.py
@@ -90,16 +90,17 @@ class BaseMeteoblueTask(EOTask, metaclass=ABCMeta):
 
     def _prepare_time_intervals(self, eopatch: EOPatch, time_interval: RawTimeIntervalType | None) -> list[str]:
         """Prepare a list of time intervals for which data will be collected from meteoblue services"""
-        if not eopatch.timestamps and not time_interval:
-            raise ValueError(
-                "Time interval should either be defined with `eopatch.timestamps` or `time_interval` parameter"
-            )
+        timestamps = eopatch.timestamps
 
-        if time_interval:
+        if timestamps is None:
+            if not time_interval:
+                raise ValueError(
+                    "Time interval should either be defined with `eopatch.timestamps` or `time_interval` parameter"
+                )
+
             serialized_start_time, serialized_end_time = serialize_time(parse_time_interval(time_interval))
             return [f"{serialized_start_time}/{serialized_end_time}"]
 
-        timestamps = eopatch.timestamps
         time_intervals: list[str] = []
         for timestamp in timestamps:
             start_time = timestamp - self.time_difference

--- a/visualization/eolearn/visualization/eopatch.py
+++ b/visualization/eolearn/visualization/eopatch.py
@@ -157,7 +157,7 @@ class MatplotlibVisualization:
             return self._plot_bar(data, title=feature_name)
         return self._plot_time_series(data, timestamps=timestamps, title=feature_name)
 
-    def collect_and_prepare_feature(self, eopatch: EOPatch) -> tuple[Any, list[dt.datetime]]:
+    def collect_and_prepare_feature(self, eopatch: EOPatch) -> tuple[Any, list[dt.datetime] | None]:
         """Collects a feature from EOPatch and modifies it according to plotting parameters"""
         feature_type, _ = self.feature
         data = eopatch[self.feature]


### PR DESCRIPTION
This establishes a separation of Patches with no temporal dimension and those with a zero-sized temporal dimension.

Also forces users to think about the possibility of not having timestamps available.

The `get_timestamps` method was added because most of the time we want an error to be raised if timestamps are missing.