### PR TITLE
Fix temporally empty io

### DIFF
--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -177,7 +177,7 @@ def _yield_savers(
         bbox: BBox = eopatch.bbox  # mypy has problems
         yield partial(FeatureIOBBox.save, bbox, filesystem, get_file_path(BBOX_FILENAME), compress_level)
 
-    if eopatch.timestamps and FeatureType.TIMESTAMPS in meta_features and temporal_selection is None:
+    if eopatch.timestamps is not None and FeatureType.TIMESTAMPS in meta_features and temporal_selection is None:
         path = get_file_path(TIMESTAMPS_FILENAME)
         yield partial(FeatureIOTimestamps.save, eopatch.timestamps, filesystem, path, compress_level)
 

--- a/core/eolearn/tests/test_eodata_io.py
+++ b/core/eolearn/tests/test_eodata_io.py
@@ -233,6 +233,17 @@ def test_bbox_always_saved(eopatch, fs_loader, use_zarr: bool):
 @mock_s3
 @pytest.mark.parametrize("fs_loader", FS_LOADERS)
 @pytest.mark.parametrize("use_zarr", [True, False])
+def test_temporally_empty_patch_io(fs_loader, use_zarr: bool):
+    _skip_when_appropriate(fs_loader, use_zarr)
+    eopatch = EOPatch(bbox=DUMMY_BBOX, data={"data": np.ones((0, 1, 2, 3))}, timestamps=[])
+    with fs_loader() as temp_fs:
+        eopatch.save("/", filesystem=temp_fs, use_zarr=use_zarr)
+        assert eopatch == EOPatch.load("/", filesystem=temp_fs)
+
+
+@mock_s3
+@pytest.mark.parametrize("fs_loader", FS_LOADERS)
+@pytest.mark.parametrize("use_zarr", [True, False])
 @pytest.mark.usefixtures("_silence_warnings")
 def test_overwrite_failure(fs_loader, use_zarr: bool):
     _skip_when_appropriate(fs_loader, use_zarr)


### PR DESCRIPTION
EOPatches with a null-sized temporal dimension did not save timestamps correctly.