### PR TITLE
Automate timestamp saving

### DIFF
--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -570,6 +570,7 @@ class EOPatch:
         compress_level: int = 0,
         filesystem: FS | None = None,
         *,
+        save_timestamps: bool | Literal["auto"] = "auto",
         use_zarr: bool = False,
         temporal_selection: None | slice | list[int] = None,
     ) -> None:
@@ -583,6 +584,8 @@ class EOPatch:
             to 9 (highest compression).
         :param filesystem: An existing filesystem object. If not given it will be initialized according to the `path`
             parameter.
+        :save_timestamps: Whether to save the timestamps of the EOPatch. By default they are saved whenever temporal
+            features are being saved.
         :param use_zarr: Saves numpy-array based features into Zarr files. Requires ZARR extra dependencies.
         :param temporal_selection: Writes all of the data to the chosen temporal indices of preexisting arrays. Can be
             used for saving data in multiple steps for memory optimization.
@@ -598,6 +601,7 @@ class EOPatch:
             features=features,
             compress_level=compress_level,
             overwrite_permission=OverwritePermission(overwrite_permission),
+            save_timestamps=save_timestamps,
             use_zarr=use_zarr,
             temporal_selection=temporal_selection,
         )
@@ -609,6 +613,7 @@ class EOPatch:
         lazy_loading: bool = False,
         filesystem: FS | None = None,
         *,
+        load_timestamps: bool | Literal["auto"] = "auto",
         temporal_selection: None | slice | list[int] = None,
     ) -> EOPatch:
         """Method to load an EOPatch from a storage into memory.
@@ -618,6 +623,8 @@ class EOPatch:
         :param lazy_loading: If `True` features will be lazy loaded.
         :param filesystem: An existing filesystem object. If not given it will be initialized according to the `path`
             parameter.
+        :load_timestamps: Whether to load the timestamps of the EOPatch. By default they are loaded whenever temporal
+            features are being loaded.
         :param temporal_selection: Only loads data corresponding to the chosen indices.
         :return: Loaded EOPatch
         """
@@ -626,7 +633,7 @@ class EOPatch:
             path = "/"
 
         bbox_io, timestamps_io, features_dict = load_eopatch_content(
-            filesystem, path, features=features, temporal_selection=temporal_selection
+            filesystem, path, features=features, temporal_selection=temporal_selection, load_timestamps=load_timestamps
         )
         eopatch = EOPatch(bbox=None if bbox_io is None else bbox_io.load())
 

--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -30,6 +30,7 @@ from typing import (
     Generic,
     Iterator,
     List,
+    Literal,
     Mapping,
     MutableMapping,
     Optional,
@@ -104,6 +105,7 @@ def save_eopatch(
     patch_location: str,
     *,
     features: FeaturesSpecification,
+    save_timestamps: bool | Literal["auto"] = "auto",  # noqa: ARG001
     overwrite_permission: OverwritePermission,
     compress_level: int,
     use_zarr: bool,
@@ -243,7 +245,9 @@ def _remove_old_style_metainfo(
 def load_eopatch_content(
     filesystem: FS,
     patch_location: str,
+    *,
     features: FeaturesSpecification,
+    load_timestamps: bool | Literal["auto"] = "auto",  # noqa: ARG001
     temporal_selection: None | slice | list[int],
 ) -> PatchContentType:
     """A utility function used by `EOPatch.load` method."""

--- a/core/eolearn/core/eoworkflow_tasks.py
+++ b/core/eolearn/core/eoworkflow_tasks.py
@@ -53,7 +53,8 @@ class OutputTask(EOTask):
     def execute(self, data: object) -> object:
         """
         :param data: input data
-        :return: Same data, to be stored in results (for `EOPatch` returns shallow copy containing only `features`)
+        :return: Same data, to be stored in results. For `EOPatch` returns shallow copy containing `features` and
+            possibly BBox and timestamps (see `copy` method of `EOPatch`).
         """
         if isinstance(data, EOPatch):
             return data.copy(features=self.features)

--- a/core/eolearn/tests/test_eodata.py
+++ b/core/eolearn/tests/test_eodata.py
@@ -264,7 +264,27 @@ def test_copy_features(test_eopatch: EOPatch) -> None:
     eopatch_copy = test_eopatch.copy(features=[feature])
     assert test_eopatch != eopatch_copy
     assert eopatch_copy[feature] is test_eopatch[feature]
-    assert eopatch_copy.timestamps is None
+    assert len(eopatch_copy.data) == 0
+
+
+@pytest.mark.parametrize("deep", [True, False])
+@pytest.mark.parametrize(
+    ("copy_timestamps", "features", "should_copy"),
+    [
+        ("auto", ..., True),
+        ("auto", [(FeatureType.MASK_TIMELESS, ...)], False),
+        ("auto", [(FeatureType.DATA, ...)], True),
+        ("auto", [(FeatureType.TIMESTAMPS, ...)], True),  # provides backwards compatibility
+        (False, [(FeatureType.DATA, ...)], False),
+        (True, [(FeatureType.DATA, ...)], True),
+        (True, [], True),
+        (True, {FeatureType.MASK_TIMELESS: ...}, True),
+    ],
+    ids=str,
+)
+def test_copy_timestamps(test_eopatch: EOPatch, deep, copy_timestamps, features, should_copy):
+    eopatch_copy = test_eopatch.copy(features=features, deep=deep, copy_timestamps=copy_timestamps)
+    assert (eopatch_copy.timestamps is not None) == should_copy
 
 
 @pytest.mark.parametrize(

--- a/core/eolearn/tests/test_eodata_io.py
+++ b/core/eolearn/tests/test_eodata_io.py
@@ -254,6 +254,29 @@ def test_save_timestamps(eopatch, fs_loader, save_timestamps, features, should_s
 
 @mock_s3
 @pytest.mark.parametrize("fs_loader", FS_LOADERS)
+@pytest.mark.parametrize(
+    ("load_timestamps", "features", "should_load"),
+    [
+        ("auto", ..., True),
+        ("auto", [(FeatureType.MASK_TIMELESS, ...)], False),
+        ("auto", [(FeatureType.DATA, ...)], True),
+        ("auto", [(FeatureType.TIMESTAMPS, ...)], True),  # provides backwards compatibility
+        (False, [(FeatureType.DATA, ...)], False),
+        (True, [(FeatureType.DATA, ...)], True),
+        (True, [], True),
+        (True, {FeatureType.MASK_TIMELESS: ...}, True),
+    ],
+    ids=str,
+)
+def test_load_timestamps(eopatch, fs_loader, load_timestamps, features, should_load):
+    with fs_loader() as temp_fs:
+        eopatch.save("/", filesystem=temp_fs)
+        loaded_patch = EOPatch.load("/", filesystem=temp_fs, features=features, load_timestamps=load_timestamps)
+        assert (loaded_patch.timestamps is not None) == should_load
+
+
+@mock_s3
+@pytest.mark.parametrize("fs_loader", FS_LOADERS)
 @pytest.mark.parametrize("use_zarr", [True, False])
 def test_temporally_empty_patch_io(fs_loader, use_zarr: bool):
     _skip_when_appropriate(fs_loader, use_zarr)

--- a/core/eolearn/tests/test_eodata_io.py
+++ b/core/eolearn/tests/test_eodata_io.py
@@ -232,6 +232,28 @@ def test_bbox_always_saved(eopatch, fs_loader, use_zarr: bool):
 
 @mock_s3
 @pytest.mark.parametrize("fs_loader", FS_LOADERS)
+@pytest.mark.parametrize(
+    ("save_timestamps", "features", "should_save"),
+    [
+        ("auto", ..., True),
+        ("auto", [(FeatureType.MASK_TIMELESS, ...)], False),
+        ("auto", [(FeatureType.DATA, ...)], True),
+        ("auto", [(FeatureType.TIMESTAMPS, ...)], True),  # provides backwards compatibility
+        (False, [(FeatureType.DATA, ...)], False),
+        (True, [(FeatureType.DATA, ...)], True),
+        (True, [], True),
+        (True, {FeatureType.MASK_TIMELESS: ...}, True),
+    ],
+    ids=str,
+)
+def test_save_timestamps(eopatch, fs_loader, save_timestamps, features, should_save):
+    with fs_loader() as temp_fs:
+        eopatch.save("/", filesystem=temp_fs, features=features, save_timestamps=save_timestamps)
+        assert temp_fs.exists("/timestamps.json") == should_save
+
+
+@mock_s3
+@pytest.mark.parametrize("fs_loader", FS_LOADERS)
 @pytest.mark.parametrize("use_zarr", [True, False])
 def test_temporally_empty_patch_io(fs_loader, use_zarr: bool):
     _skip_when_appropriate(fs_loader, use_zarr)

--- a/core/eolearn/tests/test_eodata_io.py
+++ b/core/eolearn/tests/test_eodata_io.py
@@ -170,10 +170,11 @@ def test_overwriting_non_empty_folder(eopatch, fs_loader, use_zarr: bool):
     [
         (..., ...),
         ([(FeatureType.DATA, ...), FeatureType.TIMESTAMPS], [(FeatureType.DATA, ...), FeatureType.TIMESTAMPS]),
-        ([(FeatureType.DATA, "data"), FeatureType.TIMESTAMPS], [(FeatureType.DATA, ...)]),
+        ([(FeatureType.DATA, "data"), FeatureType.MASK_TIMELESS], [(FeatureType.DATA, ...)]),
         ([(FeatureType.META_INFO, ...)], [(FeatureType.META_INFO, "something")]),
         ([(FeatureType.DATA, "data"), FeatureType.TIMESTAMPS], ...),
     ],
+    ids=str,
 )
 def test_save_load_partial(
     eopatch: EOPatch,

--- a/core/eolearn/tests/test_eoworkflow_tasks.py
+++ b/core/eolearn/tests/test_eoworkflow_tasks.py
@@ -30,14 +30,14 @@ def test_input_task():
 
 def test_output_task(test_eopatch):
     """Tests basic functionalities of OutputTask"""
-    task = OutputTask(name="my-task", features=[FeatureType.BBOX, (FeatureType.DATA, "NDVI")])
+    task = OutputTask(name="my-task", features=[(FeatureType.DATA, "NDVI")])
 
     assert task.name == "my-task"
 
     new_eopatch = task.execute(test_eopatch)
     assert id(new_eopatch) != id(test_eopatch)
 
-    assert len(new_eopatch.get_features()) == 2
+    assert len(new_eopatch.get_features()) == 3
     assert new_eopatch.bbox == test_eopatch.bbox
 
 


### PR DESCRIPTION
The users have control over whether or not timestamps get saved, but it's set to `"auto"` by default which saves/loads timestamps if there are any temporal features being saved/loaded.

In the future any temporal-information-containing eopatches will REQUIRE timestamps. If users dont save/load them, it's their problem, should've left it on "auto".