### PR TITLE
fix bug where temporally-partial saving overwrites timestamps

### DIFF
--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -123,7 +123,7 @@ def save_eopatch(
     _check_collisions(overwrite_permission, eopatch_features, file_information)
 
     if save_timestamps == "auto":
-        save_timestamps = any(ftype.is_temporal() for ftype, _ in eopatch_features)
+        save_timestamps = any(ftype.is_temporal() for ftype, _ in eopatch_features) and temporal_selection is None
 
     # Data must be collected before any tinkering with files due to lazy-loading
     data_for_saving = list(

--- a/core/eolearn/tests/test_eodata_io.py
+++ b/core/eolearn/tests/test_eodata_io.py
@@ -655,7 +655,9 @@ def test_partial_temporal_saving_into_existing(eopatch: EOPatch, temporal_select
         expected_data = eopatch.data["data"].copy()
         expected_data[temporal_selection] = 2
 
-        assert_array_equal(EOPatch.load(path="patch-folder", filesystem=temp_fs).data["data"], expected_data)
+        loaded_patch = EOPatch.load(path="patch-folder", filesystem=temp_fs)
+        assert_array_equal(loaded_patch.data["data"], expected_data)
+        assert_array_equal(loaded_patch.timestamps, eopatch.timestamps)
 
 
 @mock_s3
@@ -674,7 +676,9 @@ def test_partial_temporal_saving_infer(eopatch: EOPatch):
         expected_data = eopatch.data["data"].copy()
         expected_data[[1, 3, 4]] = 2
 
-        assert_array_equal(EOPatch.load(path="patch-folder", filesystem=temp_fs).data["data"], expected_data)
+        loaded_patch = EOPatch.load(path="patch-folder", filesystem=temp_fs)
+        assert_array_equal(loaded_patch.data["data"], expected_data)
+        assert_array_equal(loaded_patch.timestamps, eopatch.timestamps)
 
 
 @mock_s3


### PR DESCRIPTION
Bug occurred when we merged temporally-partial saving and the changes to timestamp saving.