### PR TITLE
Fix mypy issue which causes failing build

### DIFF
--- a/mask/eolearn/mask/cloud_mask.py
+++ b/mask/eolearn/mask/cloud_mask.py
@@ -190,7 +190,7 @@ class CloudMaskTask(EOTask):
         """An instance of pre-trained mono-temporal cloud classifier. Loaded only the first time it is required."""
         if self._mono_classifier is None:
             path = os.path.join(self.MODELS_FOLDER, self.MONO_CLASSIFIER_NAME)
-            self._mono_classifier = Booster(model_file=path)
+            self._mono_classifier = cast(ClassifierType, Booster(model_file=path))
 
         return self._mono_classifier
 
@@ -199,7 +199,7 @@ class CloudMaskTask(EOTask):
         """An instance of pre-trained multi-temporal cloud classifier. Loaded only the first time it is required."""
         if self._multi_classifier is None:
             path = os.path.join(self.MODELS_FOLDER, self.MULTI_CLASSIFIER_NAME)
-            self._multi_classifier = Booster(model_file=path)
+            self._multi_classifier = cast(ClassifierType, Booster(model_file=path))
 
         return self._multi_classifier
 

--- a/mask/requirements.txt
+++ b/mask/requirements.txt
@@ -1,6 +1,6 @@
 # using headless version of opencv, otherwise gitlab runners fail
 eo-learn-core
-lightgbm>=2.0.11
+lightgbm>=2.0.11,<4.0.0
 numpy
 opencv-python-headless
 scikit-image>=0.13.0


### PR DESCRIPTION
Mypy complained about the provided `Booster` class when it was used in place of the custom `ClassifierType` Protocol. Since the `Booster` class in principle corresponds to the `ClassifierType` protocol, I just manually cast the former to the latter.