### PR TITLE
Simple Feature Parsers

### DIFF
--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -35,16 +35,23 @@ class CopyTask(EOTask):
     It copies feature type dictionaries but not the data itself.
     """
 
-    def __init__(self, features: FeaturesSpecification = ..., *, deep: bool = False):
+    def __init__(
+        self,
+        features: FeaturesSpecification = ...,
+        *,
+        deep: bool = False,
+        copy_timestamps: bool | Literal["auto"] = "auto",
+    ):
         """
         :param features: A collection of features or feature types that will be copied into a new EOPatch.
         :param deep: Whether the copy should be a deep or shallow copy.
         """
         self.features = features
         self.deep = deep
+        self.copy_timestamps = copy_timestamps
 
     def execute(self, eopatch: EOPatch) -> EOPatch:
-        return eopatch.copy(features=self.features, deep=self.deep)
+        return eopatch.copy(features=self.features, deep=self.deep, copy_timestamps=self.copy_timestamps)
 
 
 @deprecated_class(EODeprecationWarning, "Use `CopyTask` with the configuration `deep=True`.")

--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -25,7 +25,7 @@ from .eodata import EOPatch
 from .eodata_merge import merge_eopatches
 from .eotask import EOTask
 from .exceptions import EODeprecationWarning
-from .types import EllipsisType, FeatureSpec, FeaturesSpecification, SingleFeatureSpec
+from .types import EllipsisType, FeaturesSpecification, SingleFeatureSpec
 from .utils.fs import get_filesystem, pickle_fs, unpickle_fs
 
 
@@ -227,7 +227,7 @@ class LoadTask(IOTask):
 class AddFeatureTask(EOTask):
     """Adds a feature to the given EOPatch."""
 
-    def __init__(self, feature: FeatureSpec):
+    def __init__(self, feature: tuple[FeatureType, str]):
         """
         :param feature: Feature to be added
         """
@@ -335,7 +335,7 @@ class InitializeFeatureTask(EOTask):
     def __init__(
         self,
         features: FeaturesSpecification,
-        shape: tuple[int, ...] | FeatureSpec,
+        shape: tuple[int, ...] | tuple[FeatureType, str],
         init_value: int = 0,
         dtype: np.dtype | type = np.uint8,
     ):

--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -25,7 +25,7 @@ from .eodata import EOPatch
 from .eodata_merge import merge_eopatches
 from .eotask import EOTask
 from .exceptions import EODeprecationWarning
-from .types import EllipsisType, FeaturesSpecification, SingleFeatureSpec
+from .types import EllipsisType, FeaturesSpecification
 from .utils.fs import get_filesystem, pickle_fs, unpickle_fs
 
 
@@ -530,7 +530,7 @@ class ZipFeatureTask(EOTask):
     def __init__(
         self,
         input_features: FeaturesSpecification,
-        output_feature: SingleFeatureSpec,
+        output_feature: tuple[FeatureType, str],
         zip_function: Callable | None = None,
         **kwargs: Any,
     ):

--- a/core/eolearn/core/core_tasks.py
+++ b/core/eolearn/core/core_tasks.py
@@ -231,7 +231,7 @@ class AddFeatureTask(EOTask):
         """
         :param feature: Feature to be added
         """
-        self.feature_type, self.feature_name = self.parse_feature(feature)
+        self.feature = self.parse_feature(feature)
 
     def execute(self, eopatch: EOPatch, data: object) -> EOPatch:
         """Returns the EOPatch with added features.
@@ -240,11 +240,7 @@ class AddFeatureTask(EOTask):
         :param data: data to be added to the feature
         :return: input EOPatch with the specified feature
         """
-        if self.feature_name is None:
-            eopatch[self.feature_type] = data
-        else:
-            eopatch[self.feature_type][self.feature_name] = data
-
+        eopatch[self.feature] = data
         return eopatch
 
 

--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -632,8 +632,7 @@ class EOPatch:
         feature_list: list[FeatureSpec] = []
         for feature_type in FeatureType:
             if feature_type is FeatureType.BBOX or feature_type is FeatureType.TIMESTAMPS:
-                if feature_type in self:
-                    feature_list.append((feature_type, None))
+                pass
             else:
                 for feature_name in self[feature_type]:
                     feature_list.append((feature_type, feature_name))

--- a/core/eolearn/core/eodata.py
+++ b/core/eolearn/core/eodata.py
@@ -40,7 +40,7 @@ from sentinelhub.exceptions import deprecated_function
 from .constants import TIMESTAMP_COLUMN, FeatureType, OverwritePermission
 from .eodata_io import FeatureIO, load_eopatch_content, save_eopatch
 from .exceptions import EODeprecationWarning, TemporalDimensionWarning
-from .types import EllipsisType, FeatureSpec, FeaturesSpecification
+from .types import EllipsisType, FeaturesSpecification
 from .utils.common import deep_eq, is_discrete_type
 from .utils.fs import get_filesystem
 from .utils.parsing import parse_features
@@ -408,7 +408,7 @@ class EOPatch:
         else:
             setattr(self, ftype_attr, value)
 
-    def __delitem__(self, feature: FeatureType | FeatureSpec) -> None:
+    def __delitem__(self, feature: FeatureType | tuple[FeatureType, str]) -> None:
         """Deletes the selected feature type or feature."""
         if isinstance(feature, tuple):
             feature_type, feature_name = feature
@@ -624,12 +624,12 @@ class EOPatch:
 
         raise ValueError(f"Features of type {feature_type} do not have a spatial dimension or are not arrays.")
 
-    def get_features(self) -> list[FeatureSpec]:
+    def get_features(self) -> list[tuple[FeatureType, str]]:
         """Returns a list of all non-empty features of EOPatch.
 
         :return: List of non-empty features
         """
-        feature_list: list[FeatureSpec] = []
+        feature_list: list[tuple[FeatureType, str]] = []
         for feature_type in FeatureType:
             if feature_type is FeatureType.BBOX or feature_type is FeatureType.TIMESTAMPS:
                 pass
@@ -787,7 +787,7 @@ class EOPatch:
 
     def plot(
         self,
-        feature: FeatureSpec,
+        feature: tuple[FeatureType, str],
         *,
         times: list[int] | slice | None = None,
         channels: list[int] | slice | None = None,

--- a/core/eolearn/core/eodata_io.py
+++ b/core/eolearn/core/eodata_io.py
@@ -55,7 +55,7 @@ from sentinelhub.exceptions import SHUserWarning, deprecated_function
 
 from .constants import TIMESTAMP_COLUMN, FeatureType, OverwritePermission
 from .exceptions import EODeprecationWarning
-from .types import EllipsisType, FeatureSpec, FeaturesSpecification
+from .types import EllipsisType, FeaturesSpecification
 from .utils.fs import get_full_path, split_all_extensions
 from .utils.parsing import FeatureParser
 
@@ -76,6 +76,7 @@ PatchContentType: TypeAlias = Tuple[
     Optional[List[datetime.datetime]],
     Dict[Tuple[FeatureType, str], "FeatureIO"],
 ]
+Features: TypeAlias = List[Tuple[FeatureType, str]]
 
 
 BBOX_FILENAME = "bbox"
@@ -199,7 +200,7 @@ def _remove_old_eopatch(filesystem: FS, patch_location: str) -> None:
 def _yield_savers(
     *,
     eopatch: EOPatch,
-    features: list[FeatureSpec],
+    features: Features,
     patch_location: str,
     filesystem: FS,
     compress_level: int,
@@ -453,7 +454,7 @@ def walk_feature_type_folder(filesystem: FS, folder_path: str) -> Iterator[tuple
 
 
 def _check_collisions(
-    overwrite_permission: OverwritePermission, eopatch_features: list[FeatureSpec], existing_files: FilesystemDataInfo
+    overwrite_permission: OverwritePermission, eopatch_features: Features, existing_files: FilesystemDataInfo
 ) -> None:
     """Checks for possible name collisions to avoid unintentional overwriting."""
     if overwrite_permission is OverwritePermission.ADD_ONLY:
@@ -467,7 +468,7 @@ def _check_collisions(
         _check_letter_case_collisions(eopatch_features, FilesystemDataInfo())
 
 
-def _check_add_only_permission(eopatch_features: list[FeatureSpec], filesystem_features: FilesystemDataInfo) -> None:
+def _check_add_only_permission(eopatch_features: Features, filesystem_features: FilesystemDataInfo) -> None:
     """Checks that no existing feature will be overwritten."""
     unique_filesystem_features = {_to_lowercase(*feature) for feature, _ in filesystem_features.iterate_features()}
     unique_eopatch_features = {_to_lowercase(*feature) for feature in eopatch_features}
@@ -477,7 +478,7 @@ def _check_add_only_permission(eopatch_features: list[FeatureSpec], filesystem_f
         raise ValueError(f"Cannot save features {intersection} with overwrite_permission=OverwritePermission.ADD_ONLY")
 
 
-def _check_letter_case_collisions(eopatch_features: list[FeatureSpec], filesystem_features: FilesystemDataInfo) -> None:
+def _check_letter_case_collisions(eopatch_features: Features, filesystem_features: FilesystemDataInfo) -> None:
     """Check that features have no name clashes (ignoring case) with other EOPatch features and saved features."""
     lowercase_features = {_to_lowercase(*feature) for feature in eopatch_features}
 

--- a/core/eolearn/core/eodata_merge.py
+++ b/core/eolearn/core/eodata_merge.py
@@ -23,7 +23,7 @@ from sentinelhub import BBox
 from .constants import FeatureType
 from .eodata import EOPatch
 from .exceptions import EORuntimeWarning
-from .types import FeatureSpec, FeaturesSpecification
+from .types import FeaturesSpecification
 from .utils.parsing import FeatureParser
 
 OperationInputType = Union[Literal[None, "concatenate", "min", "max", "mean", "median"], Callable]
@@ -161,7 +161,7 @@ def _check_if_optimize(eopatches: Sequence[EOPatch], operation_input: OperationI
 
 def _merge_time_dependent_raster_feature(
     eopatches: Sequence[EOPatch],
-    feature: FeatureSpec,
+    feature: tuple[FeatureType, str],
     operation: Callable,
     order_mask_per_eopatch: Sequence[np.ndarray],
     optimize: bool,
@@ -204,7 +204,7 @@ def _merge_time_dependent_raster_feature(
 
 def _extract_and_join_time_dependent_feature_values(
     eopatches: Sequence[EOPatch],
-    feature: FeatureSpec,
+    feature: tuple[FeatureType, str],
     order_mask_per_eopatch: Sequence[np.ndarray],
     optimize: bool,
 ) -> tuple[np.ndarray, np.ndarray]:
@@ -238,7 +238,7 @@ def _is_strictly_increasing(array: np.ndarray) -> bool:
 
 
 def _merge_timeless_raster_feature(
-    eopatches: Sequence[EOPatch], feature: FeatureSpec, operation: Callable
+    eopatches: Sequence[EOPatch], feature: tuple[FeatureType, str], operation: Callable
 ) -> np.ndarray:
     """Merges numpy arrays of a timeless raster feature with a given operation."""
     arrays = _extract_feature_values(eopatches, feature)
@@ -255,7 +255,7 @@ def _merge_timeless_raster_feature(
         ) from exception
 
 
-def _merge_vector_feature(eopatches: Sequence[EOPatch], feature: FeatureSpec) -> GeoDataFrame:
+def _merge_vector_feature(eopatches: Sequence[EOPatch], feature: tuple[FeatureType, str]) -> GeoDataFrame:
     """Merges GeoDataFrames of a vector feature."""
     dataframes = _extract_feature_values(eopatches, feature)
 
@@ -301,7 +301,7 @@ def _get_common_bbox(eopatches: Sequence[EOPatch]) -> BBox | None:
     raise ValueError("Cannot merge EOPatches because they are defined for different bounding boxes.")
 
 
-def _extract_feature_values(eopatches: Sequence[EOPatch], feature: FeatureSpec) -> list[Any]:
+def _extract_feature_values(eopatches: Sequence[EOPatch], feature: tuple[FeatureType, str]) -> list[Any]:
     """A helper function that extracts a feature values from those EOPatches where a feature exists."""
     feature_type, feature_name = feature
     return [eopatch[feature] for eopatch in eopatches if feature_name in eopatch[feature_type]]

--- a/core/eolearn/core/eodata_merge.py
+++ b/core/eolearn/core/eodata_merge.py
@@ -86,7 +86,6 @@ def merge_eopatches(
             merged_eopatch[feature] = _merge_vector_feature(eopatches, feature)
 
         if feature_type is FeatureType.META_INFO:
-            feature_name = cast(str, feature_name)  # parser makes sure of it
             merged_eopatch[feature] = _select_meta_info_feature(eopatches, feature_name)
 
     return merged_eopatch

--- a/core/eolearn/core/eotask.py
+++ b/core/eolearn/core/eotask.py
@@ -24,7 +24,7 @@ from sentinelhub.exceptions import deprecated_function
 from .constants import FeatureType
 from .eodata import EOPatch
 from .exceptions import EODeprecationWarning
-from .types import EllipsisType, FeatureSpec, FeaturesSpecification, SingleFeatureSpec
+from .types import EllipsisType, FeaturesSpecification, SingleFeatureSpec
 from .utils.parsing import FeatureParser, parse_feature, parse_features, parse_renamed_feature, parse_renamed_features
 
 LOGGER = logging.getLogger(__name__)
@@ -93,7 +93,7 @@ class EOTask(metaclass=ABCMeta):
         features: FeaturesSpecification,
         eopatch: EOPatch | None = None,
         allowed_feature_types: EllipsisType | Iterable[FeatureType] | Callable[[FeatureType], bool] = ...,
-    ) -> list[FeatureSpec]:
+    ) -> list[tuple[FeatureType, str]]:
         """See `eolearn.core.utils.parse_features`."""
         return parse_features(features, eopatch, allowed_feature_types)
 

--- a/core/eolearn/core/eotask.py
+++ b/core/eolearn/core/eotask.py
@@ -84,7 +84,7 @@ class EOTask(metaclass=ABCMeta):
         feature: SingleFeatureSpec,
         eopatch: EOPatch | None = None,
         allowed_feature_types: EllipsisType | Iterable[FeatureType] | Callable[[FeatureType], bool] = ...,
-    ) -> tuple[FeatureType, str | None]:
+    ) -> tuple[FeatureType, str]:
         """See `eolearn.core.utils.parse_feature`."""
         return parse_feature(feature, eopatch, allowed_feature_types)
 

--- a/core/eolearn/core/eoworkflow.py
+++ b/core/eolearn/core/eoworkflow.py
@@ -231,10 +231,7 @@ class EOWorkflow:
         :return: The result and statistics of the task in the node.
         """
         # EOPatches are copied beforehand
-        task_args = [
-            (arg.copy(copy_timestamps=arg.timestamps is not None) if isinstance(arg, EOPatch) else arg)
-            for arg in node_input_values
-        ]
+        task_args = [(arg.copy(copy_timestamps=True) if isinstance(arg, EOPatch) else arg) for arg in node_input_values]
 
         LOGGER.debug("Computing %s(*%s, **%s)", node.task.__class__.__name__, str(task_args), str(node_input_kwargs))
         start_time = dt.datetime.now()

--- a/core/eolearn/core/eoworkflow.py
+++ b/core/eolearn/core/eoworkflow.py
@@ -231,7 +231,10 @@ class EOWorkflow:
         :return: The result and statistics of the task in the node.
         """
         # EOPatches are copied beforehand
-        task_args = [(arg.copy() if isinstance(arg, EOPatch) else arg) for arg in node_input_values]
+        task_args = [
+            (arg.copy(copy_timestamps=arg.timestamps is not None) if isinstance(arg, EOPatch) else arg)
+            for arg in node_input_values
+        ]
 
         LOGGER.debug("Computing %s(*%s, **%s)", node.task.__class__.__name__, str(task_args), str(node_input_kwargs))
         start_time = dt.datetime.now()

--- a/core/eolearn/core/types.py
+++ b/core/eolearn/core/types.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import sys
 
 # pylint: disable=unused-import
-from typing import Dict, Iterable, Optional, Sequence, Tuple, Union
+from typing import Dict, Iterable, Sequence, Tuple, Union
 
 from .constants import FeatureType
 
@@ -28,17 +28,10 @@ else:
 
 # DEVELOPER NOTE: the #: comments are applied as docstrings
 
-#: Specification describing a single feature
-FeatureSpec: TypeAlias = Tuple[FeatureType, str]
-#: Specification describing a feature with its current and desired new name
-FeatureRenameSpec: TypeAlias = Tuple[FeatureType, str, str]
+SingleFeatureSpec: TypeAlias = Union[Tuple[FeatureType, str], Tuple[FeatureType, str, str]]
 
-SingleFeatureSpec: TypeAlias = Union[FeatureSpec, FeatureRenameSpec]
-
-SequenceFeatureSpec: TypeAlias = Sequence[
-    Union[SingleFeatureSpec, FeatureType, Tuple[FeatureType, Optional[EllipsisType]]]
-]
-DictFeatureSpec: TypeAlias = Dict[FeatureType, Union[None, EllipsisType, Iterable[Union[str, Tuple[str, str]]]]]
+SequenceFeatureSpec: TypeAlias = Sequence[Union[SingleFeatureSpec, FeatureType, Tuple[FeatureType, EllipsisType]]]
+DictFeatureSpec: TypeAlias = Dict[FeatureType, Union[EllipsisType, Iterable[Union[str, Tuple[str, str]]]]]
 MultiFeatureSpec: TypeAlias = Union[
     EllipsisType, FeatureType, Tuple[FeatureType, EllipsisType], SequenceFeatureSpec, DictFeatureSpec
 ]

--- a/core/eolearn/core/types.py
+++ b/core/eolearn/core/types.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import sys
 
 # pylint: disable=unused-import
-from typing import Dict, Iterable, Literal, Optional, Sequence, Tuple, Union
+from typing import Dict, Iterable, Optional, Sequence, Tuple, Union
 
 from .constants import FeatureType
 
@@ -29,11 +29,10 @@ else:
 # DEVELOPER NOTE: the #: comments are applied as docstrings
 
 #: Specification describing a single feature
-FeatureSpec: TypeAlias = Union[Tuple[Literal[FeatureType.BBOX, FeatureType.TIMESTAMPS], None], Tuple[FeatureType, str]]
+FeatureSpec: TypeAlias = Tuple[FeatureType, str]
 #: Specification describing a feature with its current and desired new name
-FeatureRenameSpec: TypeAlias = Union[
-    Tuple[Literal[FeatureType.BBOX, FeatureType.TIMESTAMPS], None, None], Tuple[FeatureType, str, str]
-]
+FeatureRenameSpec: TypeAlias = Tuple[FeatureType, str, str]
+
 SingleFeatureSpec: TypeAlias = Union[FeatureSpec, FeatureRenameSpec]
 
 SequenceFeatureSpec: TypeAlias = Sequence[

--- a/core/eolearn/core/utils/parsing.py
+++ b/core/eolearn/core/utils/parsing.py
@@ -15,7 +15,6 @@ from ..constants import FeatureType
 from ..types import (
     DictFeatureSpec,
     EllipsisType,
-    FeatureRenameSpec,
     FeaturesSpecification,
     SequenceFeatureSpec,
     SingleFeatureSpec,
@@ -303,7 +302,7 @@ def parse_feature(
     feature: SingleFeatureSpec,
     eopatch: EOPatch | None = None,
     allowed_feature_types: EllipsisType | Iterable[FeatureType] | Callable[[FeatureType], bool] = ...,
-) -> tuple[FeatureType, str | None]:
+) -> tuple[FeatureType, str]:
     """Parses input describing a single feature into a `(feature_type, feature_name)` pair.
 
     See :class:`FeatureParser<eolearn.core.utilities.FeatureParser>` for viable inputs.
@@ -319,7 +318,7 @@ def parse_renamed_feature(
     feature: SingleFeatureSpec,
     eopatch: EOPatch | None = None,
     allowed_feature_types: EllipsisType | Iterable[FeatureType] | Callable[[FeatureType], bool] = ...,
-) -> FeatureRenameSpec:
+) -> tuple[FeatureType, str, str]:
     """Parses input describing a single feature into a `(feature_type, old_name, new_name)` triple.
 
     See :class:`FeatureParser<eolearn.core.utilities.FeatureParser>` for viable inputs.

--- a/core/eolearn/core/utils/parsing.py
+++ b/core/eolearn/core/utils/parsing.py
@@ -47,12 +47,11 @@ class FeatureParser:
 
     1. Ellipsis `...` signify that all features of all types should be parsed.
 
-    2. Input representing a single feature, either `FeatureType.BBOX`, `FeatureType.TIMESTAMPS` or a tuple where the
-       first element is a `FeatureType` element and the other (or two for renaming) is a string.
+    2. Input representing a single feature, where the first element is a `FeatureType` element and the other
+       (or two for renaming) is a string.
 
     3. Dictionary mapping `feature_type` keys to sequences of feature names. Feature names are either a sequence of
-       strings, pairs of shape `(old_name, new_name)` or `...`. For feature types with no names (BBox and timestamps)
-       one should use `None` in place of the sequence. Example:
+       strings, pairs of shape `(old_name, new_name)` or `...`. Example:
 
         .. code-block:: python
 
@@ -64,7 +63,6 @@ class FeatureParser:
                     'NDWI',
                 },
                 FeatureType.MASK: ...
-                FeatureType.BBOX: None
             }
 
     4. Sequences of elements, each describing a feature. When describing all features of a given feature type use
@@ -76,7 +74,6 @@ class FeatureParser:
             [
                 (FeatureType.DATA, 'BANDS'),
                 (FeatureType.MASK, 'CLOUD_MASK', 'NEW_CLOUD_MASK'),
-                FeatureType.BBOX
             ]
 
     Outputs of the FeatureParser are:

--- a/core/eolearn/tests/test_core_tasks.py
+++ b/core/eolearn/tests/test_core_tasks.py
@@ -43,7 +43,7 @@ from eolearn.core import (
     ZipFeatureTask,
 )
 from eolearn.core.core_tasks import ExplodeBandsTask
-from eolearn.core.types import FeatureRenameSpec, FeatureSpec, FeaturesSpecification
+from eolearn.core.types import FeaturesSpecification
 from eolearn.core.utils.parsing import parse_features
 from eolearn.core.utils.testing import PatchGeneratorConfig, assert_feature_data_equal, generate_eopatch
 
@@ -91,7 +91,7 @@ def test_copy(patch: EOPatch, deep: bool) -> None:
     ],
 )
 @pytest.mark.parametrize("deep", [True, False])
-def test_partial_copy(features: list[FeatureSpec], deep: bool, patch: EOPatch) -> None:
+def test_partial_copy(features: list[tuple[FeatureType, str]], deep: bool, patch: EOPatch) -> None:
     patch_copy = CopyTask(features=features, deep=deep)(patch)
 
     assert set(patch_copy.get_features()) == {*features}
@@ -132,7 +132,7 @@ def test_io_task_pickling(filesystem: FS, task_class: type[EOTask]) -> None:
         ((FeatureType.META_INFO, "something_else"), np.random.rand(10, 1)),
     ],
 )
-def test_add_feature(feature: FeatureSpec, feature_data: Any) -> None:
+def test_add_feature(feature: tuple[FeatureType, str], feature_data: Any) -> None:
     patch = EOPatch(bbox=DUMMY_BBOX)
     assert feature not in patch
     patch = AddFeatureTask(feature)(patch, feature_data)
@@ -170,7 +170,9 @@ def test_remove_feature(features: FeaturesSpecification, patch: EOPatch) -> None
     ],
 )
 @pytest.mark.parametrize("deep", [True, False])
-def test_duplicate_feature(feature_specification: list[FeatureRenameSpec], deep: bool, patch: EOPatch) -> None:
+def test_duplicate_feature(
+    feature_specification: list[tuple[FeatureType, str, str]], deep: bool, patch: EOPatch
+) -> None:
     patch = DuplicateFeatureTask(feature_specification, deep)(patch)
 
     for f_type, f_name, f_dup_name in feature_specification:
@@ -215,7 +217,7 @@ def test_initialize_feature(
     ],
 )
 def test_initialize_feature_with_spec(
-    init_val: float, shape: FeatureSpec, feature_spec: FeaturesSpecification, patch: EOPatch
+    init_val: float, shape: tuple[FeatureType, str], feature_spec: FeaturesSpecification, patch: EOPatch
 ) -> None:
     expected_data = init_val * np.ones(patch[shape].shape)
 
@@ -237,7 +239,7 @@ def test_initialize_feature_fails(patch: EOPatch) -> None:
         [(FeatureType.DATA, "bands"), (FeatureType.MASK_TIMELESS, "mask")],
     ],
 )
-def test_move_feature(features: FeatureSpec, deep: bool, patch: EOPatch) -> None:
+def test_move_feature(features: tuple[FeatureType, str], deep: bool, patch: EOPatch) -> None:
     patch_dst = MoveFeatureTask(features, deep_copy=deep)(patch, EOPatch(bbox=DUMMY_BBOX, timestamps=patch.timestamps))
 
     for feat in features:
@@ -268,7 +270,9 @@ def test_move_feature(features: FeatureSpec, deep: bool, patch: EOPatch) -> None
     ],
 )
 @pytest.mark.filterwarnings("ignore::eolearn.core.exceptions.TemporalDimensionWarning")
-def test_merge_features(axis: int, features_to_merge: list[FeatureSpec], feature: FeatureSpec, patch: EOPatch) -> None:
+def test_merge_features(
+    axis: int, features_to_merge: list[tuple[FeatureType, str]], feature: tuple[FeatureType, str], patch: EOPatch
+) -> None:
     patch = MergeFeatureTask(features_to_merge, feature, axis=axis)(patch)
     expected = np.concatenate([patch[f] for f in features_to_merge], axis=axis)
 
@@ -297,7 +301,7 @@ def test_merge_features(axis: int, features_to_merge: list[FeatureSpec], feature
 )
 def test_zip_features(
     input_features: FeaturesSpecification,
-    output_feature: FeatureSpec,
+    output_feature: tuple[FeatureType, str],
     zip_function: Callable,
     kwargs: dict[str, Any],
     patch: EOPatch,
@@ -380,7 +384,7 @@ def test_map_features_fails(patch: EOPatch) -> None:
         ((FeatureType.DATA, "bands"), {"axis": -1, "name": "fun_name", "bands": [4, 3, 2]}),
     ],
 )
-def test_map_kwargs_passing(input_feature: FeatureSpec, kwargs: dict[str, Any], patch: EOPatch) -> None:
+def test_map_kwargs_passing(input_feature: tuple[FeatureType, str], kwargs: dict[str, Any], patch: EOPatch) -> None:
     def kwargs_map(_, *, some=3, **kwargs) -> tuple:
         return some, kwargs
 

--- a/core/eolearn/tests/test_eodata.py
+++ b/core/eolearn/tests/test_eodata.py
@@ -286,7 +286,6 @@ def test_copy_features(test_eopatch: EOPatch) -> None:
         ("auto", ..., True),
         ("auto", [(FeatureType.MASK_TIMELESS, ...)], False),
         ("auto", [(FeatureType.DATA, ...)], True),
-        ("auto", [(FeatureType.TIMESTAMPS, ...)], True),  # provides backwards compatibility
         (False, [(FeatureType.DATA, ...)], False),
         (True, [(FeatureType.DATA, ...)], True),
         (True, [], True),
@@ -391,11 +390,9 @@ def test_get_spatial_dimension(
                 (FeatureType.MASK, "D"),
                 (FeatureType.MASK_TIMELESS, "E"),
                 (FeatureType.META_INFO, "beep"),
-                (FeatureType.BBOX, None),
-                (FeatureType.TIMESTAMPS, None),
             ],
         ),
-        (EOPatch(bbox=DUMMY_BBOX), [(FeatureType.BBOX, None)]),
+        (EOPatch(bbox=DUMMY_BBOX), []),
     ],
 )
 def test_get_features(patch: EOPatch, expected_features: list[FeatureSpec]) -> None:

--- a/core/eolearn/tests/test_eodata.py
+++ b/core/eolearn/tests/test_eodata.py
@@ -19,7 +19,7 @@ from sentinelhub import CRS, BBox
 from eolearn.core import EOPatch, FeatureType
 from eolearn.core.eodata_io import FeatureIO
 from eolearn.core.exceptions import EODeprecationWarning, TemporalDimensionWarning
-from eolearn.core.types import FeatureSpec, FeaturesSpecification
+from eolearn.core.types import FeaturesSpecification
 from eolearn.core.utils.testing import assert_feature_data_equal, generate_eopatch
 
 DUMMY_BBOX = BBox((0, 0, 1, 1), CRS(3857))
@@ -182,7 +182,7 @@ def test_simplified_feature_operations() -> None:
         (FeatureType.META_INFO, "beep"),
     ],
 )
-def test_delete_existing_feature(feature_to_delete: FeatureSpec, mini_eopatch: EOPatch) -> None:
+def test_delete_existing_feature(feature_to_delete: tuple[FeatureType, str], mini_eopatch: EOPatch) -> None:
     old = mini_eopatch.copy(deep=True)
 
     del mini_eopatch[feature_to_delete]
@@ -206,7 +206,7 @@ def test_delete_existing_feature_type(feature_type: FeatureType, mini_eopatch: E
 
 
 @pytest.mark.parametrize("bbox_feature", [FeatureType.BBOX, (FeatureType.BBOX, None)])
-def test_cannot_delete_bbox(bbox_feature: FeatureType | FeatureSpec, mini_eopatch: EOPatch) -> None:
+def test_cannot_delete_bbox(bbox_feature: FeatureType | tuple[FeatureType, str], mini_eopatch: EOPatch) -> None:
     with pytest.raises(ValueError):
         del mini_eopatch[bbox_feature]
 
@@ -395,7 +395,7 @@ def test_get_spatial_dimension(
         (EOPatch(bbox=DUMMY_BBOX), []),
     ],
 )
-def test_get_features(patch: EOPatch, expected_features: list[FeatureSpec]) -> None:
+def test_get_features(patch: EOPatch, expected_features: list[tuple[FeatureType, str]]) -> None:
     assert patch.get_features() == expected_features
 
 

--- a/core/eolearn/tests/test_eodata_io.py
+++ b/core/eolearn/tests/test_eodata_io.py
@@ -239,7 +239,6 @@ def test_bbox_always_saved(eopatch, fs_loader, use_zarr: bool):
         ("auto", ..., True),
         ("auto", [(FeatureType.MASK_TIMELESS, ...)], False),
         ("auto", [(FeatureType.DATA, ...)], True),
-        ("auto", [(FeatureType.TIMESTAMPS, ...)], True),  # provides backwards compatibility
         (False, [(FeatureType.DATA, ...)], False),
         (True, [(FeatureType.DATA, ...)], True),
         (True, [], True),

--- a/core/eolearn/tests/test_eoworkflow_tasks.py
+++ b/core/eolearn/tests/test_eoworkflow_tasks.py
@@ -37,7 +37,7 @@ def test_output_task(test_eopatch):
     new_eopatch = task.execute(test_eopatch)
     assert id(new_eopatch) != id(test_eopatch)
 
-    assert len(new_eopatch.get_features()) == 3
+    assert len(new_eopatch.get_features()) == 1
     assert new_eopatch.bbox == test_eopatch.bbox
 
 

--- a/core/eolearn/tests/test_utils/test_parsing.py
+++ b/core/eolearn/tests/test_utils/test_parsing.py
@@ -6,15 +6,15 @@ from typing import Callable, Iterable
 import pytest
 
 from eolearn.core import EOPatch, FeatureParser, FeatureType
-from eolearn.core.types import EllipsisType, FeatureRenameSpec, FeatureSpec, FeaturesSpecification
+from eolearn.core.types import EllipsisType, FeaturesSpecification
 from eolearn.core.utils.testing import generate_eopatch
 
 
 @dataclass
 class ParserTestCase:
     parser_input: FeaturesSpecification
-    features: list[FeatureSpec]
-    renaming: list[FeatureRenameSpec]
+    features: list[tuple[FeatureType, str]]
+    renaming: list[tuple[FeatureType, str, str]]
     specifications: list[tuple[FeatureType, str | EllipsisType]] | None = None
     description: str = ""
 

--- a/core/eolearn/tests/test_utils/test_parsing.py
+++ b/core/eolearn/tests/test_utils/test_parsing.py
@@ -35,13 +35,6 @@ def get_test_case_description(test_case: ParserTestCase) -> str:
             description="Singleton feature",
         ),
         ParserTestCase(
-            parser_input=FeatureType.BBOX,
-            features=[(FeatureType.BBOX, None)],
-            renaming=[(FeatureType.BBOX, None, None)],
-            specifications=[(FeatureType.BBOX, ...)],
-            description="BBox feature",
-        ),
-        ParserTestCase(
             parser_input=(FeatureType.MASK, "CLM", "new_CLM"),
             features=[(FeatureType.MASK, "CLM")],
             renaming=[(FeatureType.MASK, "CLM", "new_CLM")],
@@ -49,55 +42,44 @@ def get_test_case_description(test_case: ParserTestCase) -> str:
             description="Renamed feature",
         ),
         ParserTestCase(
-            parser_input=[FeatureType.BBOX, (FeatureType.DATA, "bands"), (FeatureType.VECTOR_TIMELESS, "geoms")],
-            features=[(FeatureType.BBOX, None), (FeatureType.DATA, "bands"), (FeatureType.VECTOR_TIMELESS, "geoms")],
+            parser_input=[(FeatureType.DATA, "bands"), (FeatureType.VECTOR_TIMELESS, "geoms")],
+            features=[(FeatureType.DATA, "bands"), (FeatureType.VECTOR_TIMELESS, "geoms")],
             renaming=[
-                (FeatureType.BBOX, None, None),
                 (FeatureType.DATA, "bands", "bands"),
                 (FeatureType.VECTOR_TIMELESS, "geoms", "geoms"),
             ],
             specifications=[
-                (FeatureType.BBOX, ...),
                 (FeatureType.DATA, "bands"),
                 (FeatureType.VECTOR_TIMELESS, "geoms"),
             ],
             description="List of inputs",
         ),
         ParserTestCase(
-            parser_input=((FeatureType.TIMESTAMPS, ...), (FeatureType.MASK, "CLM"), (FeatureType.SCALAR, "a", "b")),
-            features=[(FeatureType.TIMESTAMPS, None), (FeatureType.MASK, "CLM"), (FeatureType.SCALAR, "a")],
+            parser_input=((FeatureType.MASK, "CLM"), (FeatureType.SCALAR, "a", "b")),
+            features=[(FeatureType.MASK, "CLM"), (FeatureType.SCALAR, "a")],
             renaming=[
-                (FeatureType.TIMESTAMPS, None, None),
                 (FeatureType.MASK, "CLM", "CLM"),
                 (FeatureType.SCALAR, "a", "b"),
             ],
-            specifications=[(FeatureType.TIMESTAMPS, ...), (FeatureType.MASK, "CLM"), (FeatureType.SCALAR, "a")],
+            specifications=[(FeatureType.MASK, "CLM"), (FeatureType.SCALAR, "a")],
             description="Tuple of inputs with rename",
         ),
         ParserTestCase(
             parser_input={
                 FeatureType.DATA: ["bands_S2", ("bands_l8", "BANDS_L8")],
                 FeatureType.MASK_TIMELESS: [],
-                FeatureType.BBOX: ...,
-                FeatureType.TIMESTAMPS: None,
             },
             features=[
                 (FeatureType.DATA, "bands_S2"),
                 (FeatureType.DATA, "bands_l8"),
-                (FeatureType.BBOX, None),
-                (FeatureType.TIMESTAMPS, None),
             ],
             renaming=[
                 (FeatureType.DATA, "bands_S2", "bands_S2"),
                 (FeatureType.DATA, "bands_l8", "BANDS_L8"),
-                (FeatureType.BBOX, None, None),
-                (FeatureType.TIMESTAMPS, None, None),
             ],
             specifications=[
                 (FeatureType.DATA, "bands_S2"),
                 (FeatureType.DATA, "bands_l8"),
-                (FeatureType.BBOX, ...),
-                (FeatureType.TIMESTAMPS, ...),
             ],
             description="Dictionary",
         ),
@@ -117,12 +99,12 @@ def test_feature_parser_no_eopatch(test_case: ParserTestCase):
     [
         ((FeatureType.DATA, ...), [(FeatureType.DATA, ...)]),
         (
-            [FeatureType.BBOX, (FeatureType.MASK, "CLM"), FeatureType.DATA],
-            [(FeatureType.BBOX, ...), (FeatureType.MASK, "CLM"), (FeatureType.DATA, ...)],
+            [(FeatureType.MASK, "CLM"), FeatureType.DATA],
+            [(FeatureType.MASK, "CLM"), (FeatureType.DATA, ...)],
         ),
         (
-            {FeatureType.BBOX: None, FeatureType.MASK: ["CLM"], FeatureType.DATA: ...},
-            [(FeatureType.BBOX, ...), (FeatureType.MASK, "CLM"), (FeatureType.DATA, ...)],
+            {FeatureType.MASK: ["CLM"], FeatureType.DATA: ...},
+            [(FeatureType.MASK, "CLM"), (FeatureType.DATA, ...)],
         ),
     ],
 )
@@ -152,8 +134,8 @@ def test_feature_parser_no_eopatch_failure(
         (
             {
                 FeatureType.MASK: ["CLM", "IS_VALID"],
+                FeatureType.MASK_TIMELESS: ...,
                 FeatureType.DATA: [("bands", "new_bands")],
-                FeatureType.BBOX: None,
             },
             (
                 FeatureType.MASK,
@@ -231,24 +213,20 @@ def test_all_features_allowed_feature_types(
         ParserTestCase(
             parser_input=...,
             features=[
-                (FeatureType.BBOX, None),
                 (FeatureType.DATA, "data"),
                 (FeatureType.DATA, "CLP"),
                 (FeatureType.MASK, "data"),
                 (FeatureType.MASK, "IS_VALID"),
                 (FeatureType.MASK_TIMELESS, "LULC"),
                 (FeatureType.META_INFO, "something"),
-                (FeatureType.TIMESTAMPS, None),
             ],
             renaming=[
-                (FeatureType.BBOX, None, None),
                 (FeatureType.DATA, "data", "data"),
                 (FeatureType.DATA, "CLP", "CLP"),
                 (FeatureType.MASK, "data", "data"),
                 (FeatureType.MASK, "IS_VALID", "IS_VALID"),
                 (FeatureType.MASK_TIMELESS, "LULC", "LULC"),
                 (FeatureType.META_INFO, "something", "something"),
-                (FeatureType.TIMESTAMPS, None, None),
             ],
             description="Get-all",
         ),
@@ -260,20 +238,17 @@ def test_all_features_allowed_feature_types(
         ),
         ParserTestCase(
             parser_input=[
-                FeatureType.BBOX,
                 FeatureType.MASK,
                 (FeatureType.META_INFO, ...),
                 (FeatureType.MASK_TIMELESS, "LULC", "new_LULC"),
             ],
             features=[
-                (FeatureType.BBOX, None),
                 (FeatureType.MASK, "data"),
                 (FeatureType.MASK, "IS_VALID"),
                 (FeatureType.META_INFO, "something"),
                 (FeatureType.MASK_TIMELESS, "LULC"),
             ],
             renaming=[
-                (FeatureType.BBOX, None, None),
                 (FeatureType.MASK, "data", "data"),
                 (FeatureType.MASK, "IS_VALID", "IS_VALID"),
                 (FeatureType.META_INFO, "something", "something"),

--- a/core/eolearn/tests/test_utils/test_testing.py
+++ b/core/eolearn/tests/test_utils/test_testing.py
@@ -11,7 +11,7 @@ from sentinelhub import CRS, BBox
 from sentinelhub.testing_utils import assert_statistics_match
 
 from eolearn.core.constants import FeatureType
-from eolearn.core.types import FeatureSpec, FeaturesSpecification
+from eolearn.core.types import FeaturesSpecification
 from eolearn.core.utils.parsing import parse_features
 from eolearn.core.utils.testing import PatchGeneratorConfig, generate_eopatch
 
@@ -77,7 +77,7 @@ def test_generate_eopatch_seed(seed: int, features: FeaturesSpecification) -> No
 class GenerateTestCase:
     data_features: FeaturesSpecification
     seed: int
-    expected_statistics: dict[FeatureSpec, dict[str, Any]]
+    expected_statistics: dict[tuple[FeatureType, str], dict[str, Any]]
 
 
 @pytest.mark.parametrize(

--- a/features/eolearn/features/bands_extraction.py
+++ b/features/eolearn/features/bands_extraction.py
@@ -10,8 +10,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from eolearn.core import MapFeatureTask
-from eolearn.core.types import SingleFeatureSpec
+from eolearn.core import FeatureType, MapFeatureTask
 
 
 class EuclideanNormTask(MapFeatureTask):
@@ -23,7 +22,10 @@ class EuclideanNormTask(MapFeatureTask):
     """
 
     def __init__(
-        self, input_feature: SingleFeatureSpec, output_feature: SingleFeatureSpec, bands: list[int] | None = None
+        self,
+        input_feature: tuple[FeatureType, str],
+        output_feature: tuple[FeatureType, str],
+        bands: list[int] | None = None,
     ):
         """
         :param input_feature: A source feature from which to take the subset of bands.
@@ -53,8 +55,8 @@ class NormalizedDifferenceIndexTask(MapFeatureTask):
 
     def __init__(
         self,
-        input_feature: SingleFeatureSpec,
-        output_feature: SingleFeatureSpec,
+        input_feature: tuple[FeatureType, str],
+        output_feature: tuple[FeatureType, str],
         bands: tuple[int, int],
         acorvi_constant: float = 0,
         undefined_value: float = np.nan,

--- a/features/eolearn/features/clustering.py
+++ b/features/eolearn/features/clustering.py
@@ -15,7 +15,6 @@ from sklearn.cluster import AgglomerativeClustering
 from sklearn.feature_extraction.image import grid_to_graph
 
 from eolearn.core import EOPatch, EOTask, FeatureType
-from eolearn.core.types import FeatureSpec
 
 
 class ClusteringTask(EOTask):
@@ -29,7 +28,7 @@ class ClusteringTask(EOTask):
 
     def __init__(
         self,
-        features: FeatureSpec,
+        features: tuple[FeatureType, str],
         new_feature_name: str,
         distance_threshold: float | None = None,
         n_clusters: int | None = None,

--- a/features/eolearn/features/clustering.py
+++ b/features/eolearn/features/clustering.py
@@ -97,7 +97,7 @@ class ClusteringTask(EOTask):
 
         model = AgglomerativeClustering(
             distance_threshold=self.distance_threshold,
-            affinity=self.affinity,
+            metric=self.affinity,
             linkage=self.linkage,
             connectivity=self.connectivity,
             n_clusters=self.n_clusters,

--- a/features/eolearn/features/doubly_logistic_approximation.py
+++ b/features/eolearn/features/doubly_logistic_approximation.py
@@ -14,7 +14,6 @@ import numpy as np
 from scipy.optimize import curve_fit
 
 from eolearn.core import EOPatch, EOTask, FeatureType
-from eolearn.core.types import SingleFeatureSpec
 
 
 def doubly_logistic(middle, initial_value, scale, a1, a2, a3, a4, a5) -> np.ndarray:  # type: ignore[no-untyped-def]
@@ -36,10 +35,10 @@ class DoublyLogisticApproximationTask(EOTask):
 
     def __init__(
         self,
-        feature: SingleFeatureSpec,
-        new_feature: SingleFeatureSpec = (FeatureType.DATA_TIMELESS, "DOUBLY_LOGISTIC_PARAM"),
+        feature: tuple[FeatureType, str],
+        new_feature: tuple[FeatureType, str] = (FeatureType.DATA_TIMELESS, "DOUBLY_LOGISTIC_PARAM"),
         initial_parameters: list[float] | None = None,
-        valid_mask: SingleFeatureSpec | None = None,
+        valid_mask: tuple[FeatureType, str] | None = None,
     ):
         self.initial_parameters = initial_parameters
         self.feature = self.parse_feature(feature)

--- a/features/eolearn/features/feature_manipulation.py
+++ b/features/eolearn/features/feature_manipulation.py
@@ -39,7 +39,7 @@ class SimpleFilterTask(EOTask):
 
     def __init__(
         self,
-        feature: SingleFeatureSpec,
+        feature: tuple[FeatureType, str] | Literal["timestamps"],
         filter_func: Callable[[np.ndarray], bool] | Callable[[dt.datetime], bool],
         filter_features: FeaturesSpecification = ...,
     ):
@@ -48,10 +48,12 @@ class SimpleFilterTask(EOTask):
         :param filter_func: A callable that takes a numpy evaluates to bool.
         :param filter_features: A collection of features which will be filtered into a new EOPatch
         """
-
-        self.feature = self.parse_feature(
-            feature, allowed_feature_types=lambda fty: fty.is_temporal() and not fty.is_vector()
-        )
+        if feature == "timestamps":
+            self.feature: tuple[FeatureType, str] | Literal["timestamps"] = "timestamps"
+        else:
+            self.feature = self.parse_feature(
+                feature, allowed_feature_types=lambda fty: fty.is_temporal() and fty.is_array()
+            )
         self.filter_func = filter_func
         self.filter_features_parser = self.get_feature_parser(filter_features)
 
@@ -70,13 +72,12 @@ class SimpleFilterTask(EOTask):
         :param eopatch: An input EOPatch.
         :return: A new EOPatch with filtered features.
         """
-        good_idxs = self._get_filtered_indices(eopatch[self.feature])
+        selector_data = eopatch.timestamps if self.feature == "timestamps" else eopatch[self.feature]
+        good_idxs = self._get_filtered_indices(selector_data)
         timestamps = None if eopatch.timestamps is None else [eopatch.timestamps[idx] for idx in good_idxs]
         filtered_eopatch = EOPatch(bbox=eopatch.bbox, timestamps=timestamps)
 
         for feature in self.filter_features_parser.get_features(eopatch):
-            if feature[0] is FeatureType.TIMESTAMPS:
-                continue
             feature_type, _ = feature
             data = eopatch[feature]
 
@@ -111,7 +112,7 @@ class FilterTimeSeriesTask(SimpleFilterTask):
         if not isinstance(start_date, dt.datetime) or not isinstance(end_date, dt.datetime):
             raise ValueError("Both start_date and end_date must be datetime.datetime objects.")
 
-        super().__init__((FeatureType.TIMESTAMPS, None), self._filter_func, filter_features)
+        super().__init__("timestamps", self._filter_func, filter_features)
 
 
 class ValueFilloutTask(EOTask):

--- a/features/eolearn/features/feature_manipulation.py
+++ b/features/eolearn/features/feature_manipulation.py
@@ -21,7 +21,7 @@ from sentinelhub import bbox_to_dimensions
 
 from eolearn.core import EOPatch, EOTask, FeatureType, MapFeatureTask
 from eolearn.core.constants import TIMESTAMP_COLUMN
-from eolearn.core.types import FeaturesSpecification, SingleFeatureSpec
+from eolearn.core.types import FeaturesSpecification
 from eolearn.core.utils.parsing import parse_renamed_features
 
 from .utils import ResizeLib, ResizeMethod, ResizeParam, spatially_resize_image
@@ -132,7 +132,7 @@ class ValueFilloutTask(EOTask):
 
     def __init__(
         self,
-        feature: SingleFeatureSpec,
+        feature: tuple[FeatureType, str],
         operations: Literal["f", "b", "fb", "bf"] = "fb",
         value: float = np.nan,
         axis: int = 0,

--- a/features/eolearn/features/radiometric_normalization.py
+++ b/features/eolearn/features/radiometric_normalization.py
@@ -12,7 +12,7 @@ from abc import ABCMeta, abstractmethod
 
 import numpy as np
 
-from eolearn.core import EOPatch, EOTask
+from eolearn.core import EOPatch, EOTask, FeatureType
 from eolearn.core.types import SingleFeatureSpec
 from eolearn.core.utils.parsing import parse_renamed_feature
 
@@ -35,7 +35,7 @@ class ReferenceScenesTask(EOTask):
     def __init__(
         self,
         feature: SingleFeatureSpec,
-        valid_fraction_feature: SingleFeatureSpec,
+        valid_fraction_feature: tuple[FeatureType, str],
         max_scene_number: int | None = None,
     ):
         self.renamed_feature = parse_renamed_feature(feature)
@@ -63,8 +63,8 @@ class BaseCompositingTask(EOTask, metaclass=ABCMeta):
 
     Contributor: Johannes Schmid, GeoVille Information Systems GmbH, 2018
 
-    :param feature: Feature holding the input time-series. Default type is FeatureType.DATA
-    :param feature_composite: Type and name of output composite image. Default type is FeatureType.DATA_TIMELESS
+    :param feature: Feature holding the input time-series.
+    :param feature_composite: Type and name of output composite image.
     :param percentile: Percentile along the time dimension used for compositing. Methods use different percentiles
     :param max_index: Value used to flag indices with NaNs. Could be integer or NaN. Default is 255
     :param interpolation: Method used to compute percentile. Allowed values are {'geoville', 'linear', 'lower',
@@ -75,8 +75,8 @@ class BaseCompositingTask(EOTask, metaclass=ABCMeta):
 
     def __init__(
         self,
-        feature: SingleFeatureSpec,
-        feature_composite: SingleFeatureSpec,
+        feature: tuple[FeatureType, str],
+        feature_composite: tuple[FeatureType, str],
         percentile: int,
         max_index: int = 255,
         interpolation: str = "lower",
@@ -185,8 +185,8 @@ class BlueCompositingTask(BaseCompositingTask):
 
     def __init__(
         self,
-        feature: SingleFeatureSpec,
-        feature_composite: SingleFeatureSpec,
+        feature: tuple[FeatureType, str],
+        feature_composite: tuple[FeatureType, str],
         blue_idx: int,
         interpolation: str = "lower",
     ):
@@ -219,8 +219,8 @@ class HOTCompositingTask(BaseCompositingTask):
 
     def __init__(
         self,
-        feature: SingleFeatureSpec,
-        feature_composite: SingleFeatureSpec,
+        feature: tuple[FeatureType, str],
+        feature_composite: tuple[FeatureType, str],
         blue_idx: int,
         red_idx: int,
         interpolation: str = "lower",
@@ -251,8 +251,8 @@ class MaxNDVICompositingTask(BaseCompositingTask):
 
     def __init__(
         self,
-        feature: SingleFeatureSpec,
-        feature_composite: SingleFeatureSpec,
+        feature: tuple[FeatureType, str],
+        feature_composite: tuple[FeatureType, str],
         red_idx: int,
         nir_idx: int,
         interpolation: str = "lower",
@@ -294,8 +294,8 @@ class MaxNDWICompositingTask(BaseCompositingTask):
 
     def __init__(
         self,
-        feature: SingleFeatureSpec,
-        feature_composite: SingleFeatureSpec,
+        feature: tuple[FeatureType, str],
+        feature_composite: tuple[FeatureType, str],
         nir_idx: int,
         swir1_idx: int,
         interpolation: str = "lower",
@@ -329,8 +329,8 @@ class MaxRatioCompositingTask(BaseCompositingTask):
 
     def __init__(
         self,
-        feature: SingleFeatureSpec,
-        feature_composite: SingleFeatureSpec,
+        feature: tuple[FeatureType, str],
+        feature_composite: tuple[FeatureType, str],
         blue_idx: int,
         nir_idx: int,
         swir1_idx: int,
@@ -369,7 +369,7 @@ class HistogramMatchingTask(EOTask):
         Should be of the FeatureType "DATA_TIMELESS".
     """
 
-    def __init__(self, feature: SingleFeatureSpec, reference: SingleFeatureSpec):
+    def __init__(self, feature: SingleFeatureSpec, reference: tuple[FeatureType, str]):
         self.renamed_feature = parse_renamed_feature(feature)
         self.reference = self.parse_feature(reference)
 

--- a/features/eolearn/tests/test_feature_manipulation.py
+++ b/features/eolearn/tests/test_feature_manipulation.py
@@ -24,9 +24,7 @@ DUMMY_BBOX = BBox((0, 0, 1, 1), CRS(3857))
 # ruff: noqa: NPY002
 
 
-@pytest.mark.parametrize(
-    "feature", [(FeatureType.DATA, "BANDS-S2-L1C"), FeatureType.TIMESTAMPS, (FeatureType.LABEL, "IS_CLOUDLESS")]
-)
+@pytest.mark.parametrize("feature", [(FeatureType.DATA, "BANDS-S2-L1C"), (FeatureType.LABEL, "IS_CLOUDLESS")])
 def test_simple_filter_task_filter_all(example_eopatch: EOPatch, feature):
     filter_all_task = SimpleFilterTask(feature, filter_func=lambda _: False)
     filtered_eopatch = filter_all_task.execute(example_eopatch)
@@ -39,9 +37,7 @@ def test_simple_filter_task_filter_all(example_eopatch: EOPatch, feature):
     assert filtered_eopatch.timestamps == []
 
 
-@pytest.mark.parametrize(
-    "feature", [(FeatureType.MASK, "CLM"), FeatureType.TIMESTAMPS, (FeatureType.SCALAR, "CLOUD_COVERAGE")]
-)
+@pytest.mark.parametrize("feature", [(FeatureType.MASK, "CLM"), (FeatureType.SCALAR, "CLOUD_COVERAGE")])
 def test_simple_filter_task_filter_nothing(example_eopatch: EOPatch, feature):
     filter_all_task = SimpleFilterTask(feature, filter_func=lambda _: True)
     filtered_eopatch = filter_all_task.execute(example_eopatch)

--- a/geometry/eolearn/geometry/morphology.py
+++ b/geometry/eolearn/geometry/morphology.py
@@ -10,13 +10,13 @@ from __future__ import annotations
 
 import itertools as it
 from enum import Enum
-from typing import Callable, Tuple, cast
+from typing import Callable
 
 import numpy as np
 import skimage.filters.rank
 import skimage.morphology
 
-from eolearn.core import EOPatch, EOTask, FeatureType, MapFeatureTask
+from eolearn.core import EOPatch, EOTask, MapFeatureTask
 from eolearn.core.types import FeaturesSpecification, SingleFeatureSpec
 from eolearn.core.utils.parsing import parse_renamed_feature
 
@@ -41,10 +41,8 @@ class ErosionTask(EOTask):
         if not isinstance(disk_radius, int) or disk_radius is None or disk_radius < 1:
             raise ValueError("Disk radius should be an integer larger than 0!")
 
-        parsed_mask_feature = cast(
-            Tuple[FeatureType, str, str],
-            parse_renamed_feature(mask_feature, allowed_feature_types=lambda fty: fty.is_array()),
-        )
+        parsed_mask_feature = parse_renamed_feature(mask_feature, allowed_feature_types=lambda fty: fty.is_array())
+
         self.mask_type, self.mask_name, self.new_mask_name = parsed_mask_feature
         self.disk = skimage.morphology.disk(disk_radius)
         self.erode_labels = erode_labels

--- a/geometry/eolearn/geometry/superpixel.py
+++ b/geometry/eolearn/geometry/superpixel.py
@@ -19,7 +19,6 @@ from sentinelhub.exceptions import deprecated_class
 
 from eolearn.core import EOPatch, EOTask, FeatureType
 from eolearn.core.exceptions import EODeprecationWarning, EORuntimeWarning
-from eolearn.core.types import SingleFeatureSpec
 
 LOGGER = logging.getLogger(__name__)
 
@@ -37,8 +36,8 @@ class SuperpixelSegmentationTask(EOTask):
 
     def __init__(
         self,
-        feature: SingleFeatureSpec,
-        superpixel_feature: SingleFeatureSpec,
+        feature: tuple[FeatureType, str],
+        superpixel_feature: tuple[FeatureType, str],
         *,
         segmentation_object: Callable = skimage.segmentation.felzenszwalb,
         **segmentation_params: Any,
@@ -95,7 +94,7 @@ class FelzenszwalbSegmentationTask(SuperpixelSegmentationTask):
     https://scikit-image.org/docs/dev/api/skimage.segmentation.html#skimage.segmentation.felzenszwalb
     """
 
-    def __init__(self, feature: SingleFeatureSpec, superpixel_feature: SingleFeatureSpec, **kwargs: Any):
+    def __init__(self, feature: tuple[FeatureType, str], superpixel_feature: tuple[FeatureType, str], **kwargs: Any):
         """Arguments are passed to `SuperpixelSegmentationTask` task"""
         super().__init__(feature, superpixel_feature, segmentation_object=skimage.segmentation.felzenszwalb, **kwargs)
 
@@ -111,7 +110,7 @@ class SlicSegmentationTask(SuperpixelSegmentationTask):
     https://scikit-image.org/docs/dev/api/skimage.segmentation.html#skimage.segmentation.slic
     """
 
-    def __init__(self, feature: SingleFeatureSpec, superpixel_feature: SingleFeatureSpec, **kwargs: Any):
+    def __init__(self, feature: tuple[FeatureType, str], superpixel_feature: tuple[FeatureType, str], **kwargs: Any):
         """Arguments are passed to `SuperpixelSegmentationTask` task"""
         super().__init__(
             feature, superpixel_feature, segmentation_object=skimage.segmentation.slic, start_label=0, **kwargs
@@ -133,7 +132,7 @@ class MarkSegmentationBoundariesTask(EOTask):
     https://scikit-image.org/docs/dev/api/skimage.segmentation.html#skimage.segmentation.mark_boundaries
     """
 
-    def __init__(self, feature: SingleFeatureSpec, new_feature: SingleFeatureSpec, **params: Any):
+    def __init__(self, feature: tuple[FeatureType, str], new_feature: tuple[FeatureType, str], **params: Any):
         """
         :param feature: Input feature - super-pixel mask
         :param new_feature: Output feature - a new feature where new mask with boundaries will be put

--- a/geometry/eolearn/geometry/transformations.py
+++ b/geometry/eolearn/geometry/transformations.py
@@ -221,7 +221,7 @@ class VectorToRasterTask(EOTask):
                 return self.raster_shape
 
             ftype, fname = self.parse_feature(self.raster_shape, allowed_feature_types=lambda fty: fty.is_array())
-            return eopatch.get_spatial_dimension(ftype, fname)  # cast verified in parser
+            return eopatch.get_spatial_dimension(ftype, fname)
 
         if self.raster_resolution:
             # parsing from strings is not denoted in types, so an explicit upcast is required

--- a/geometry/eolearn/geometry/transformations.py
+++ b/geometry/eolearn/geometry/transformations.py
@@ -60,12 +60,12 @@ class VectorToRasterTask(EOTask):
 
     def __init__(
         self,
-        vector_input: GeoDataFrame | SingleFeatureSpec,
-        raster_feature: SingleFeatureSpec,
+        vector_input: GeoDataFrame | tuple[FeatureType, str],
+        raster_feature: tuple[FeatureType, str],
         *,
         values: None | float | list[float] = None,
         values_column: str | None = None,
-        raster_shape: None | tuple[int, int] | SingleFeatureSpec = None,
+        raster_shape: None | tuple[int, int] | tuple[FeatureType, str] = None,
         raster_resolution: None | float | tuple[float, float] = None,
         raster_dtype: np.dtype | type = np.uint8,
         no_data_value: float = 0,

--- a/geometry/eolearn/geometry/transformations.py
+++ b/geometry/eolearn/geometry/transformations.py
@@ -131,7 +131,7 @@ class VectorToRasterTask(EOTask):
             vector_input = self.parse_feature(vector_input, allowed_feature_types=lambda fty: fty.is_vector())
 
         parsed_raster_feature = self.parse_feature(raster_feature, allowed_feature_types=lambda fty: fty.is_image())
-        return vector_input, parsed_raster_feature  # type: ignore[return-value]
+        return vector_input, parsed_raster_feature
 
     def _get_vector_data_iterator(
         self, eopatch: EOPatch, join_per_value: bool
@@ -221,7 +221,7 @@ class VectorToRasterTask(EOTask):
                 return self.raster_shape
 
             ftype, fname = self.parse_feature(self.raster_shape, allowed_feature_types=lambda fty: fty.is_array())
-            return eopatch.get_spatial_dimension(ftype, cast(str, fname))  # cast verified in parser
+            return eopatch.get_spatial_dimension(ftype, fname)  # cast verified in parser
 
         if self.raster_resolution:
             # parsing from strings is not denoted in types, so an explicit upcast is required

--- a/io/eolearn/io/extra/geodb.py
+++ b/io/eolearn/io/extra/geodb.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from sentinelhub import CRS, BBox
 
-from eolearn.core.types import FeatureSpec
+from eolearn.core import FeatureType
 
 from ..geometry_io import _BaseVectorImportTask
 
@@ -26,7 +26,7 @@ class GeoDBVectorImportTask(_BaseVectorImportTask):
 
     def __init__(
         self,
-        feature: FeatureSpec,
+        feature: tuple[FeatureType, str],
         geodb_client: Any,
         geodb_collection: str,
         geodb_db: str,

--- a/io/eolearn/io/geometry_io.py
+++ b/io/eolearn/io/geometry_io.py
@@ -23,8 +23,7 @@ from fs_s3fs import S3FS
 
 from sentinelhub import CRS, BBox, GeopediaFeatureIterator, SHConfig
 
-from eolearn.core import EOPatch, EOTask, pickle_fs, unpickle_fs
-from eolearn.core.types import FeatureSpec
+from eolearn.core import EOPatch, EOTask, FeatureType, pickle_fs, unpickle_fs
 from eolearn.core.utils.fs import get_base_filesystem_and_path, get_full_path
 
 LOGGER = logging.getLogger(__name__)
@@ -34,7 +33,11 @@ class _BaseVectorImportTask(EOTask, metaclass=abc.ABCMeta):
     """Base Vector Import Task, implementing common methods"""
 
     def __init__(
-        self, feature: FeatureSpec, reproject: bool = True, clip: bool = False, config: SHConfig | None = None
+        self,
+        feature: tuple[FeatureType, str],
+        reproject: bool = True,
+        clip: bool = False,
+        config: SHConfig | None = None,
     ):
         """
         :param feature: A vector feature into which to import data
@@ -101,7 +104,7 @@ class VectorImportTask(_BaseVectorImportTask):
 
     def __init__(
         self,
-        feature: FeatureSpec,
+        feature: tuple[FeatureType, str],
         path: str,
         reproject: bool = True,
         clip: bool = False,
@@ -187,7 +190,7 @@ class GeopediaVectorImportTask(_BaseVectorImportTask):
 
     def __init__(
         self,
-        feature: FeatureSpec,
+        feature: tuple[FeatureType, str],
         geopedia_table: str | int,
         reproject: bool = True,
         clip: bool = False,

--- a/io/eolearn/io/geopedia.py
+++ b/io/eolearn/io/geopedia.py
@@ -18,7 +18,6 @@ import rasterio.warp
 from sentinelhub import CRS, BBox, GeopediaWmsRequest, MimeType
 
 from eolearn.core import EOPatch, EOTask, FeatureType
-from eolearn.core.types import FeatureSpec
 
 LOGGER = logging.getLogger(__name__)
 
@@ -38,7 +37,7 @@ class AddGeopediaFeatureTask(EOTask):
 
     def __init__(
         self,
-        feature: FeatureSpec,
+        feature: tuple[FeatureType, str],
         layer: str | int,
         theme: str,
         raster_value: dict[str, tuple[float, list[float]]] | float,

--- a/io/eolearn/io/raster_io.py
+++ b/io/eolearn/io/raster_io.py
@@ -33,7 +33,6 @@ from sentinelhub import CRS, BBox, SHConfig, parse_time_interval
 from eolearn.core import EOPatch, FeatureType
 from eolearn.core.core_tasks import IOTask
 from eolearn.core.exceptions import EORuntimeWarning
-from eolearn.core.types import SingleFeatureSpec
 from eolearn.core.utils.fs import get_base_filesystem_and_path, get_full_path
 
 LOGGER = logging.getLogger(__name__)
@@ -44,7 +43,7 @@ class BaseRasterIoTask(IOTask, metaclass=ABCMeta):
 
     def __init__(
         self,
-        feature: SingleFeatureSpec,
+        feature: tuple[FeatureType, str],
         folder: str,
         *,
         filesystem: FS | None = None,
@@ -147,7 +146,7 @@ class ExportToTiffTask(BaseRasterIoTask):
 
     def __init__(
         self,
-        feature: SingleFeatureSpec,
+        feature: tuple[FeatureType, str],
         folder: str,
         *,
         date_indices: list[int] | tuple[int, int] | tuple[dt.datetime, dt.datetime] | tuple[str, str] | None = None,
@@ -393,7 +392,7 @@ class ImportFromTiffTask(BaseRasterIoTask):
 
     def __init__(
         self,
-        feature: SingleFeatureSpec,
+        feature: tuple[FeatureType, str],
         folder: str,
         *,
         use_vsi: bool = False,

--- a/io/eolearn/io/sentinelhub_process.py
+++ b/io/eolearn/io/sentinelhub_process.py
@@ -258,7 +258,6 @@ class SentinelHubEvalscriptTask(SentinelHubInputBaseTask):
         responses = []
         for feat_type, feat_name, _ in self.features:
             if feat_type.is_array():
-                feat_name = cast(str, feat_name)  # can only be string since it's an array type
                 responses.append(SentinelHubRequest.output_response(feat_name, MimeType.TIFF))
             elif feat_type.is_meta():
                 responses.append(SentinelHubRequest.output_response("userdata", MimeType.JSON))

--- a/mask/eolearn/mask/masking.py
+++ b/mask/eolearn/mask/masking.py
@@ -23,7 +23,7 @@ class JoinMasksTask(ZipFeatureTask):
     def __init__(
         self,
         input_features: FeaturesSpecification,
-        output_feature: SingleFeatureSpec,
+        output_feature: tuple[FeatureType, str],
         join_operation: Literal["and", "or", "xor"] | Callable = "and",
     ):
         """
@@ -69,7 +69,7 @@ class MaskFeatureTask(EOTask):
     def __init__(
         self,
         feature: SingleFeatureSpec,
-        mask_feature: SingleFeatureSpec,
+        mask_feature: tuple[FeatureType, str],
         mask_values: Iterable[int],
         no_data_value: float = np.nan,
     ):

--- a/mask/eolearn/mask/snow_mask.py
+++ b/mask/eolearn/mask/snow_mask.py
@@ -17,7 +17,6 @@ import numpy as np
 from skimage.morphology import binary_dilation, disk
 
 from eolearn.core import EOPatch, EOTask, FeatureType
-from eolearn.core.types import FeatureSpec
 
 from .utils import resize_images
 
@@ -29,7 +28,7 @@ class BaseSnowMaskTask(EOTask, metaclass=ABCMeta):
 
     def __init__(
         self,
-        data_feature: FeatureSpec,
+        data_feature: tuple[FeatureType, str],
         band_indices: list[int],
         dilation_size: int = 0,
         undefined_value: int = 0,
@@ -65,7 +64,7 @@ class SnowMaskTask(BaseSnowMaskTask):
 
     def __init__(
         self,
-        data_feature: FeatureSpec,
+        data_feature: tuple[FeatureType, str],
         band_indices: list[int],
         ndsi_threshold: float = 0.4,
         brightness_threshold: float = 0.3,
@@ -127,10 +126,10 @@ class TheiaSnowMaskTask(BaseSnowMaskTask):
 
     def __init__(
         self,
-        data_feature: FeatureSpec,
+        data_feature: tuple[FeatureType, str],
         band_indices: list[int],
-        cloud_mask_feature: FeatureSpec,
-        dem_feature: FeatureSpec,
+        cloud_mask_feature: tuple[FeatureType, str],
+        dem_feature: tuple[FeatureType, str],
         dem_params: tuple[float, float] = (100, 0.1),
         red_params: tuple[float, float, float, float, float] = (12, 0.3, 0.1, 0.2, 0.040),
         ndsi_params: tuple[float, float, float] = (0.4, 0.15, 0.001),

--- a/ml_tools/eolearn/ml_tools/sampling.py
+++ b/ml_tools/eolearn/ml_tools/sampling.py
@@ -16,7 +16,7 @@ import numpy as np
 from shapely.geometry import Point, Polygon
 
 from eolearn.core import EOPatch, EOTask, FeatureType
-from eolearn.core.types import FeaturesSpecification, SingleFeatureSpec
+from eolearn.core.types import FeaturesSpecification
 
 _FractionType = Union[float, Dict[int, float]]
 
@@ -178,7 +178,7 @@ class FractionSamplingTask(BaseSamplingTask):
     def __init__(
         self,
         features_to_sample: FeaturesSpecification,
-        sampling_feature: SingleFeatureSpec,
+        sampling_feature: tuple[FeatureType, str],
         fraction: _FractionType,
         exclude_values: list[int] | None = None,
         replace: bool = False,

--- a/ml_tools/eolearn/ml_tools/sampling.py
+++ b/ml_tools/eolearn/ml_tools/sampling.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from abc import ABCMeta
 from math import sqrt
-from typing import Any, Dict, Union, cast
+from typing import Any, Dict, Union
 
 import numpy as np
 from shapely.geometry import Point, Polygon
@@ -145,7 +145,7 @@ class BaseSamplingTask(EOTask, metaclass=ABCMeta):
 
         self.mask_of_samples = mask_of_samples
         if mask_of_samples is not None:
-            self.mask_of_samples = self.parse_feature(  # type: ignore[assignment]
+            self.mask_of_samples = self.parse_feature(
                 mask_of_samples, allowed_feature_types={FeatureType.MASK_TIMELESS}
             )
 
@@ -288,7 +288,7 @@ class BlockSamplingTask(BaseSamplingTask):
         """Generate a mask consisting entirely of `values` entries, used for sampling on whole raster"""
 
         feature_type, feature_name = self.features_parser.get_features(eopatch)[0]
-        height, width = eopatch.get_spatial_dimension(feature_type, cast(str, feature_name))
+        height, width = eopatch.get_spatial_dimension(feature_type, feature_name)
         height -= self.sample_size[0] - 1
         width -= self.sample_size[1] - 1
 
@@ -367,7 +367,7 @@ class GridSamplingTask(BaseSamplingTask):
         """
         feature_type, feature_name = self.features_parser.get_features(eopatch)[0]
 
-        image_shape = eopatch.get_spatial_dimension(feature_type, cast(str, feature_name))
+        image_shape = eopatch.get_spatial_dimension(feature_type, feature_name)
         rows, columns = self._sample_regular_grid(image_shape)
         size_x, size_y = self.sample_size  # this way it also works for lists
         row_grid, column_grid = expand_to_grids(rows, columns, sample_size=(size_x, size_y))

--- a/ml_tools/eolearn/ml_tools/tdigest.py
+++ b/ml_tools/eolearn/ml_tools/tdigest.py
@@ -17,7 +17,7 @@ import numpy as np
 import tdigest as td
 
 from eolearn.core import EOPatch, EOTask, FeatureType
-from eolearn.core.types import FeatureSpec, FeaturesSpecification
+from eolearn.core.types import FeaturesSpecification
 
 ModeTypes = Union[Literal["standard", "timewise", "monthly", "total"], Callable]
 
@@ -121,8 +121,8 @@ def _is_output_ftype(feature_type: FeatureType, mode: ModeTypes, pixelwise: bool
 
 
 def _looper(
-    in_feature: list[FeatureSpec], out_feature: list[FeatureSpec], eopatch: EOPatch
-) -> Generator[tuple[FeatureSpec, FeatureSpec, np.ndarray], None, None]:
+    in_feature: list[tuple[FeatureType, str]], out_feature: list[tuple[FeatureType, str]], eopatch: EOPatch
+) -> Generator[tuple[tuple[FeatureType, str], tuple[FeatureType, str], np.ndarray], None, None]:
     for in_feature_, out_feature_ in zip(in_feature, out_feature):
         shape = np.array(eopatch[in_feature_].shape)
         yield in_feature_, out_feature_, shape

--- a/ml_tools/eolearn/ml_tools/train_test_split.py
+++ b/ml_tools/eolearn/ml_tools/train_test_split.py
@@ -14,7 +14,6 @@ from typing import Any
 import numpy as np
 
 from eolearn.core import EOPatch, EOTask, FeatureType
-from eolearn.core.types import SingleFeatureSpec
 
 # switching to np.random.Generator would change results
 # ruff: noqa: NPY002
@@ -66,8 +65,8 @@ class TrainTestSplitTask(EOTask):
 
     def __init__(
         self,
-        input_feature: SingleFeatureSpec,
-        output_feature: SingleFeatureSpec,
+        input_feature: tuple[FeatureType, str],
+        output_feature: tuple[FeatureType, str],
         bins: float | list[Any],
         split_type: TrainTestSplitType = TrainTestSplitType.PER_PIXEL,
         ignore_values: list[int] | None = None,

--- a/visualization/eolearn/tests/test_eopatch.py
+++ b/visualization/eolearn/tests/test_eopatch.py
@@ -44,11 +44,10 @@ def eopatch_fixture():
         ((FeatureType.LABEL_TIMELESS, "LULC_COUNTS"), {}),
         ((FeatureType.LABEL_TIMELESS, "LULC_COUNTS"), {"channels": [0]}),
         ((FeatureType.VECTOR_TIMELESS, "LULC"), {}),
-        (FeatureType.BBOX, {}),
     ],
 )
 @pytest.mark.sh_integration()
-def test_eopatch_plot(eopatch, feature, params):
+def test_eopatch_plot(eopatch: EOPatch, feature, params):
     """A simple test of EOPatch plotting for different features."""
     # We reduce width and height otherwise running matplotlib.pyplot.subplots in combination with pytest would
     # kill the Python kernel.

--- a/visualization/eolearn/visualization/eopatch.py
+++ b/visualization/eolearn/visualization/eopatch.py
@@ -19,9 +19,8 @@ import numpy as np
 from geopandas import GeoDataFrame
 from pyproj import CRS
 
-from eolearn.core import EOPatch
+from eolearn.core import EOPatch, FeatureType
 from eolearn.core.constants import TIMESTAMP_COLUMN
-from eolearn.core.types import SingleFeatureSpec
 from eolearn.core.utils.common import is_discrete_type
 from eolearn.core.utils.parsing import parse_feature
 
@@ -85,7 +84,7 @@ class MatplotlibVisualization:
     def __init__(
         self,
         eopatch: EOPatch,
-        feature: SingleFeatureSpec,
+        feature: tuple[FeatureType, str],
         *,
         axes: np.ndarray | None = None,
         config: PlotConfig | None = None,

--- a/visualization/eolearn/visualization/eopatch.py
+++ b/visualization/eolearn/visualization/eopatch.py
@@ -19,7 +19,7 @@ import numpy as np
 from geopandas import GeoDataFrame
 from pyproj import CRS
 
-from eolearn.core import EOPatch, FeatureType
+from eolearn.core import EOPatch
 from eolearn.core.constants import TIMESTAMP_COLUMN
 from eolearn.core.types import SingleFeatureSpec
 from eolearn.core.utils.common import is_discrete_type
@@ -134,9 +134,6 @@ class MatplotlibVisualization:
         """Plots the given feature"""
         feature_type, feature_name = self.feature
         data, timestamps = self.collect_and_prepare_feature(self.eopatch)
-
-        if feature_type is FeatureType.BBOX:
-            return self._plot_bbox()
 
         if feature_type.is_vector():
             return self._plot_vector_feature(


### PR DESCRIPTION
1. fixes `CopyTask` to correctly copy timestamps
2. `EOPatch.get_features` no longer returns bbox & timestamps
3. feature parsers no longer return bbox & timestamp features
4. `SimpleFilterTask` can still be used on timestamps by providing `feature="timestamps"`, looking for better ideas
5. Replaced types. I also noticed that a lot of tasks had `SingleFeatureSpecification` but they did not use feature renaming inputs, so i corrected those to `tuple[FeatureType, str]`. The whole renaming thing should be removed at one point...

Some test cases had to be removed as they are no longer valid (such as deleting timestamps via `RemoveFeatureTask`)