### PR TITLE
Remove partial loading for numpy arrays

### DIFF
--- a/eolearn/core/eodata_io.py
+++ b/eolearn/core/eodata_io.py
@@ -239,7 +239,7 @@ def _get_feature_io_constructor(ftype: FeatureType, use_zarr: bool) -> type[Feat
         return FeatureIOJson
     if ftype.is_vector():
         return FeatureIOGeoDf
-    return FeatureIOZarr if use_zarr else FeatureIONumpy
+    return FeatureIOZarr if use_zarr else FeatureIONumpy  # type: ignore[return-value] # not sure why
 
 
 def _remove_redundant_files(

--- a/tests/core/test_eodata_io.py
+++ b/tests/core/test_eodata_io.py
@@ -10,7 +10,6 @@ import datetime
 import json
 import os
 import sys
-import tempfile
 import warnings
 from typing import Any
 
@@ -89,11 +88,6 @@ def eopatch_fixture():
     )
 
     return eopatch
-
-
-def test_saving_to_a_file(eopatch):
-    with tempfile.NamedTemporaryFile() as fp, pytest.raises(CreateFailed):
-        eopatch.save(fp.name)
 
 
 @mock_s3
@@ -221,11 +215,9 @@ def test_save_add_only_features(eopatch, fs_loader, use_zarr: bool):
 
 @mock_s3
 @pytest.mark.parametrize("fs_loader", FS_LOADERS)
-@pytest.mark.parametrize("use_zarr", [True, False])
-def test_bbox_always_saved(eopatch, fs_loader, use_zarr: bool):
-    _skip_when_appropriate(fs_loader, use_zarr)
+def test_bbox_always_saved(eopatch, fs_loader):
     with fs_loader() as temp_fs:
-        eopatch.save("/", filesystem=temp_fs, features=[FeatureType.DATA], use_zarr=use_zarr)
+        eopatch.save("/", filesystem=temp_fs, features=[FeatureType.DATA])
         assert temp_fs.exists("/bbox.geojson")
 
 
@@ -340,12 +332,10 @@ def test_save_and_load_tasks(eopatch, fs_loader, use_zarr: bool):
 
 @mock_s3
 @pytest.mark.parametrize("fs_loader", FS_LOADERS)
-@pytest.mark.parametrize("use_zarr", [True, False])
-def test_fail_saving_nonexistent_feature(eopatch, fs_loader, use_zarr: bool):
-    _skip_when_appropriate(fs_loader, use_zarr)
+def test_fail_saving_nonexistent_feature(eopatch, fs_loader):
     features = [(FeatureType.DATA, "nonexistent")]
     with fs_loader() as temp_fs, pytest.raises(ValueError):
-        eopatch.save("/", filesystem=temp_fs, features=features, use_zarr=use_zarr)
+        eopatch.save("/", filesystem=temp_fs, features=features)
 
 
 @mock_s3
@@ -610,7 +600,7 @@ def test_partial_temporal_loading_fails_for_numpy(fs_loader: type[FS], eopatch: 
 @mock_s3
 @pytest.mark.parametrize("fs_loader", FS_LOADERS)
 @pytest.mark.parametrize("temporal_selection", [[3, 4, 10]])
-def test_partial_temporal_loading_fails(fs_loader: type[FS], eopatch: EOPatch, temporal_selection):
+def test_partial_temporal_loading_fails_bad_selection(fs_loader: type[FS], eopatch: EOPatch, temporal_selection):
     _skip_when_appropriate(fs_loader, True)
     with fs_loader() as temp_fs:
         eopatch.save(path="patch-folder", filesystem=temp_fs, use_zarr=True)

--- a/tests/core/test_eodata_merge.py
+++ b/tests/core/test_eodata_merge.py
@@ -206,7 +206,8 @@ def test_lazy_loading(test_eopatch_path):
 
 def test_temporally_independent_merge(test_eopatch_path):
     full_patch = EOPatch.load(test_eopatch_path)
-    part1 = EOPatch.load(test_eopatch_path, temporal_selection=slice(None, 10))
-    part2 = EOPatch.load(test_eopatch_path, temporal_selection=slice(10, None))
+    part1, part2 = full_patch.copy(deep=True), full_patch.copy(deep=True)
+    part1.consolidate_timestamps(full_patch.get_timestamps()[:10])
+    part2.consolidate_timestamps(full_patch.get_timestamps()[10:])
 
     assert full_patch == merge_eopatches(part1, part2, time_dependent_op="concatenate")


### PR DESCRIPTION
We decided that since we do not support partial numpy saving, we shouldn't support partial numpy loading either.