### PR TITLE
Make OutputTask always output timestamps if any

### DIFF
--- a/eolearn/core/eoworkflow_tasks.py
+++ b/eolearn/core/eoworkflow_tasks.py
@@ -57,5 +57,5 @@ class OutputTask(EOTask):
             possibly BBox and timestamps (see `copy` method of `EOPatch`).
         """
         if isinstance(data, EOPatch):
-            return data.copy(features=self.features)
+            return data.copy(features=self.features, copy_timestamps=True)
         return data


### PR DESCRIPTION
In the case that the OutputTask gets an EOPatch, it should output the patch fully (with timestamps)

Currently timestamps are discarded if there are no other temporal features, but the EOPatch must match the one that the task recieved.