### PR TITLE
Copying an EOPatch copies timestamps if `features=...`

### DIFF
--- a/eolearn/core/eodata.py
+++ b/eolearn/core/eodata.py
@@ -505,7 +505,7 @@ class EOPatch:
             features = ...
         patch_features = parse_features(features, eopatch=self)
         if copy_timestamps == "auto":
-            copy_timestamps = any(ftype.is_temporal() for ftype, _ in patch_features)
+            copy_timestamps = features is ... or any(ftype.is_temporal() for ftype, _ in patch_features)
 
         new_eopatch = EOPatch(bbox=copy.copy(self.bbox))
         if copy_timestamps:
@@ -532,7 +532,7 @@ class EOPatch:
             features = ...
         patch_features = parse_features(features, eopatch=self)
         if copy_timestamps == "auto":
-            copy_timestamps = any(ftype.is_temporal() for ftype, _ in patch_features)
+            copy_timestamps = features is ... or any(ftype.is_temporal() for ftype, _ in patch_features)
 
         new_eopatch = EOPatch(bbox=copy.deepcopy(self.bbox))
         if copy_timestamps:

--- a/eolearn/core/eodata.py
+++ b/eolearn/core/eodata.py
@@ -498,8 +498,8 @@ class EOPatch:
         """Returns a new EOPatch with shallow copies of given features.
 
         :param features: A collection of features or feature types that will be copied into new EOPatch.
-        :param copy_timestamps: Whether to copy timestamps to the new EOPatch. By default copies them over if any
-            temporal features are getting copied.
+        :param copy_timestamps: Whether to copy timestamps to the new EOPatch. By default copies them over if all
+            features are copied or if any temporal features are getting copied.
         """
         if not features:  # For some reason deepcopy and copy pass {} by default
             features = ...
@@ -525,8 +525,8 @@ class EOPatch:
 
         :param memo: built-in parameter for memoization
         :param features: A collection of features or feature types that will be copied into new EOPatch.
-        :param copy_timestamps: Whether to copy timestamps to the new EOPatch. By default copies them over if any
-            temporal features are getting copied.
+        :param copy_timestamps: Whether to copy timestamps to the new EOPatch. By default copies them over if all
+            features are copied or if any temporal features are getting copied.
         """
         if not features:  # For some reason deepcopy and copy pass {} by default
             features = ...
@@ -560,12 +560,11 @@ class EOPatch:
     ) -> EOPatch:
         """Get a copy of the current `EOPatch`.
 
-        :param features: Features to be copied into a new `EOPatch`. By default, all features will be copied. Note that
-            `BBOX` is always copied.
+        :param features: Features to be copied into a new `EOPatch`. By default, all features will be copied.
         :param deep: If `True` it will make a deep copy of all data inside the `EOPatch`. Otherwise, only a shallow copy
             of `EOPatch` will be made. Note that `BBOX` and `TIMESTAMPS` will be copied even with a shallow copy.
-        :param copy_timestamps: Whether to copy timestamps to the new EOPatch. By default copies them over if any
-            temporal features are getting copied.
+        :param copy_timestamps: Whether to copy timestamps to the new EOPatch. By default copies them over if all
+            features are copied or if any temporal features are getting copied.
         :return: An EOPatch copy.
         """
         # pylint: disable=unnecessary-dunder-call

--- a/tests/core/test_eodata.py
+++ b/tests/core/test_eodata.py
@@ -232,6 +232,20 @@ def test_deep_copy(test_eopatch: EOPatch) -> None:
     assert test_eopatch != eopatch_copy
 
 
+@pytest.mark.parametrize("deep", [True, False])
+def test_copy_full_when_no_featuers_specified(test_eopatch: EOPatch, deep: bool) -> None:
+    """In case no features are specified timestamps should be automatically copied."""
+    micro_patch = test_eopatch.copy(features=[FeatureType.MASK_TIMELESS], copy_timestamps=True)
+
+    assert (
+        micro_patch.copy(
+            deep=deep,
+        ).timestamps
+        is not None
+    )
+    assert micro_patch.copy(deep=deep, features=[FeatureType.MASK_TIMELESS]).timestamps is None
+
+
 @pytest.mark.parametrize("features", [..., [(FeatureType.MASK, "CLM")]])
 def test_copy_lazy_loaded_patch(test_eopatch_path: str, features: FeaturesSpecification) -> None:
     # shallow copy


### PR DESCRIPTION
Previously "auto" only copied timestamps if there were any temporal features, but if you do `eopatch.copy()` you want an identical patch. So now when all features are being copied (i.e. `...`) the timestamps are also copied.