### PR TITLE
Better exception grouping in reports

### DIFF
--- a/eolearn/core/eonode.py
+++ b/eolearn/core/eonode.py
@@ -100,5 +100,13 @@ class NodeStats:
     node_name: str
     start_time: dt.datetime
     end_time: dt.datetime
-    exception: BaseException | None = None
-    exception_traceback: str | None = None
+    exception_info: ExceptionInfo | None = None
+
+
+@dataclass(frozen=True)
+class ExceptionInfo:
+    """Contains information on exceptions that occur when executing a node."""
+
+    exception: BaseException
+    traceback: str
+    origin: str

--- a/eolearn/core/eoworkflow.py
+++ b/eolearn/core/eoworkflow.py
@@ -271,9 +271,9 @@ class EOWorkflow:
         except KeyboardInterrupt as exception:
             raise KeyboardInterrupt from exception
         except BaseException as exception:
-            exception_traceback = traceback.format_exc()
-            origin = "TODO"
-            return ExceptionInfo(exception, traceback=exception_traceback, origin=origin)
+            trace = traceback.extract_tb(exception.__traceback__)
+            origin = f"line {trace[-1].lineno} in {trace[-1].filename}." if trace else "unknown origin."
+            return ExceptionInfo(exception, traceback=traceback.format_exc(), origin=origin)
 
     @staticmethod
     def _relax_dependencies(

--- a/eolearn/visualization/eoexecutor.py
+++ b/eolearn/visualization/eoexecutor.py
@@ -12,7 +12,6 @@ import base64
 import datetime as dt
 import importlib
 import inspect
-import itertools as it
 import os
 import warnings
 from collections import defaultdict
@@ -108,8 +107,8 @@ class EOExecutorVisualization:
 
         exception_stats: defaultdict[str, dict[str, _ErrorSummary]] = defaultdict(dict)
 
-        for execution, results, execution_idx in zip(
-            self.eoexecutor.execution_names, self.eoexecutor.execution_results, it.count()
+        for execution_idx, (execution, results) in enumerate(
+            zip(self.eoexecutor.execution_names, self.eoexecutor.execution_results)
         ):
             if not results.error_node_uid:
                 continue

--- a/eolearn/visualization/eoexecutor.py
+++ b/eolearn/visualization/eoexecutor.py
@@ -98,10 +98,10 @@ class EOExecutorVisualization:
         dot = self.eoexecutor.workflow.dependency_graph()
         return base64.b64encode(dot.pipe()).decode()
 
-    def _get_exception_stats(self) -> list[tuple[str, str, list[tuple[str, int]]]]:
+    def _get_exception_stats(self) -> list[tuple[str, str, list[tuple[str, str, int]]]]:
         """Creates aggregated stats about exceptions
 
-        Returns {node_uid: {exception_origin: (example_message, num_occurences)}}.
+        Returns tuples of form (name, uid, [exception_origin, example_message, num_occurences])
         """
         formatter = HtmlFormatter()
         lexer = pygments.lexers.get_lexer_by_name("python", stripall=True)
@@ -114,7 +114,7 @@ class EOExecutorVisualization:
 
             error_node = workflow_results.stats[workflow_results.error_node_uid]
             exception_info: ExceptionInfo = error_node.exception_info  # type: ignore[union-attr]
-            origin_str = f"{exception_info.exception.__class__.__name__} raised from {exception_info.origin}"
+            origin_str = f"<b>{exception_info.exception.__class__.__name__}</b> raised from {exception_info.origin}"
 
             example_message, num_occurences = exception_stats[error_node.node_uid].get(origin_str, (None, 0))
             if example_message is None:

--- a/eolearn/visualization/eoexecutor.py
+++ b/eolearn/visualization/eoexecutor.py
@@ -132,7 +132,7 @@ class EOExecutorVisualization:
         """Exception stats get ordered by nodes in their execution order in workflows. Exception stats that happen
         for the same node get ordered by number of occurrences in a decreasing order.
 
-        Returns tuples of form (name, uid, [exception_origin, example_message, num_occurences])
+        Returns tuples of form (name, uid, [_error_summary])
         """
         ordered_exception_stats = []
         for node in self.eoexecutor.workflow.get_nodes():

--- a/eolearn/visualization/eoexecutor.py
+++ b/eolearn/visualization/eoexecutor.py
@@ -109,9 +109,8 @@ class EOExecutorVisualization:
                 continue
 
             error_node = workflow_results.stats[workflow_results.error_node_uid]
-            exception_str = pygments.highlight(
-                f"{error_node.exception.__class__.__name__}: {error_node.exception}", lexer, formatter
-            )
+            exception = error_node.exception_info.exception  # type: ignore[union-attr]
+            exception_str = pygments.highlight(f"{exception.__class__.__name__}: {exception}", lexer, formatter)
             exception_stats[error_node.node_uid][exception_str] += 1
 
         return self._to_ordered_stats(exception_stats)
@@ -197,7 +196,8 @@ class EOExecutorVisualization:
             if results.workflow_failed() and results.error_node_uid is not None:
                 # second part of above check needed only for typechecking purposes
                 failed_node_stats = results.stats[results.error_node_uid]
-                traceback = pygments.highlight(failed_node_stats.exception_traceback, tb_lexer, formatter)
+                traceback_str = failed_node_stats.exception_info.traceback  # type: ignore[union-attr]
+                traceback = pygments.highlight(traceback_str, tb_lexer, formatter)
             else:
                 traceback = None
 

--- a/eolearn/visualization/report_templates/report.html
+++ b/eolearn/visualization/report_templates/report.html
@@ -112,13 +112,13 @@
 
         <div class="indent">
             <ul>
-            {% for node_name, node_uid, exception_list in exception_stats %}
+            {% for node_name, node_uid, error_summary_list in exception_stats %}
                 <li>
                     <b>{{ node_name }} ({{ node_uid }}):</b>
                     <ul>
-                    {% for exception_origin, example_message, count in exception_list %}
+                    {% for error_summary in error_summary_list %}
                         <li>
-                            {{ count }} times: {{ exception_origin }} <br> Example message: {{example_message}}
+                            {{ error_summary.num_failed }} times: {{ error_summary.origin }} <br> Example message: {{error_summary.example_message}}
                         </li>
                     {% endfor %}
                     </ul>

--- a/eolearn/visualization/report_templates/report.html
+++ b/eolearn/visualization/report_templates/report.html
@@ -118,7 +118,18 @@
                     <ul>
                     {% for error_summary in error_summary_list %}
                         <li>
-                            {{ error_summary.num_failed }} times: {{ error_summary.origin }} <br> Example message: {{error_summary.example_message}}
+                            {{ error_summary.num_failed }} times: {{ error_summary.origin }}
+                            <br>
+                            Example message: <pre>{{ error_summary.example_message }}</pre>
+                            <br>
+                            <button class="collapsible">Failed executions</button>
+                            <div class="collapsible-content">
+                                <ul>
+                                    {% for idx, execution in error_summary.failed_indexed_executions %}
+                                    <li><a href="#execution{{ idx }}">{{ execution }}</a></li>
+                                    {% endfor %}
+                                </ul>
+                            </div>
                         </li>
                     {% endfor %}
                     </ul>

--- a/eolearn/visualization/report_templates/report.html
+++ b/eolearn/visualization/report_templates/report.html
@@ -118,7 +118,7 @@
                     <ul>
                     {% for exception_origin, example_message, count in exception_list %}
                         <li>
-                            {{ count }} times: {{ exception_origin }} similar to {{example_message}}
+                            {{ count }} times: {{ exception_origin }} <br> Example message: {{example_message}}
                         </li>
                     {% endfor %}
                     </ul>

--- a/eolearn/visualization/report_templates/report.html
+++ b/eolearn/visualization/report_templates/report.html
@@ -116,9 +116,9 @@
                 <li>
                     <b>{{ node_name }} ({{ node_uid }}):</b>
                     <ul>
-                    {% for exception_string, count in exception_list %}
+                    {% for exception_origin, example_message, count in exception_list %}
                         <li>
-                            {{ count }} times: {{ exception_string }}
+                            {{ count }} times: {{ exception_origin }} similar to {{example_message}}
                         </li>
                     {% endfor %}
                     </ul>

--- a/tests/core/test_eoworkflow.py
+++ b/tests/core/test_eoworkflow.py
@@ -291,8 +291,7 @@ def test_exception_handling():
         assert node_stats.node_name == node.name
 
         if node is exception_node:
-            assert isinstance(node_stats.exception, CustomExceptionError)
-            assert node_stats.exception_traceback.startswith("Traceback")
+            assert isinstance(node_stats.exception_info.exception, CustomExceptionError)
+            assert node_stats.exception_info.traceback.startswith("Traceback")
         else:
-            assert node_stats.exception is None
-            assert node_stats.exception_traceback is None
+            assert node_stats.exception_info is None

--- a/tests/visualization/test_eoexecutor.py
+++ b/tests/visualization/test_eoexecutor.py
@@ -25,12 +25,18 @@ class ExampleTask(EOTask):
         my_logger.debug("Debug statement of Example task with kwargs: %s", kwargs)
 
         if "arg1" in kwargs and kwargs["arg1"] is None:
-            raise Exception
+            raise RuntimeError(f"Oh no, i spilled my kwargs all over the floor! {kwargs}!")
 
 
 NODE = EONode(ExampleTask())
 WORKFLOW = EOWorkflow([NODE, EONode(task=ExampleTask(), inputs=[NODE, NODE])])
-EXECUTION_KWARGS = [{NODE: {"arg1": 1}}, {}, {NODE: {"arg1": 3, "arg3": 10}}, {NODE: {"arg1": None}}]
+EXECUTION_KWARGS = [
+    {NODE: {"arg1": 1}},
+    {},
+    {NODE: {"arg1": 3, "arg3": 10}},
+    {NODE: {"arg1": None}},
+    {NODE: {"arg1": None, "arg3": 10}},
+]
 
 
 @pytest.mark.parametrize("save_logs", [True, False])
@@ -42,7 +48,7 @@ def test_report_creation(save_logs, include_logs):
             EXECUTION_KWARGS,
             logs_folder=tmp_dir_name,
             save_logs=save_logs,
-            execution_names=["ex 1", 2, 0.4, None],
+            execution_names=["ex 1", 2, 0.4, None, "beep"],
         )
         executor.run(workers=10)
         executor.make_report(include_logs=include_logs)


### PR DESCRIPTION
Exceptions are now grouped by exception origin instead of error message (which often contains unique information and is thus unsuitable for grouping).

the summary also contains a list of all failed executions (per error)

(added screenshot of test case, the button toggles visibility)
![image](https://github.com/sentinel-hub/eo-learn/assets/31988337/cec62a1b-380d-4832-bc7e-b772a6fde64d)
