### PR TITLE
Cloud mask task should use s2cloudless

### DIFF
--- a/mask/requirements.txt
+++ b/mask/requirements.txt
@@ -3,6 +3,7 @@ eo-learn-core
 lightgbm>=2.0.11, <4
 numpy
 opencv-python-headless
+s2cloudless
 scikit-image>=0.13.0
 sentinelhub
 typing-extensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ geodb = [
     "xcube-geodb @ git+git://github.com/dcs4cop/xcube-geodb.git",
 ]
 meteoblue = ["meteoblue_dataset_sdk>=1,<2"]
-mask = ["lightgbm>=2.0.11, <4", "opencv-python-headless", "scikit-image>=0.13.0"]
+mask = ["lightgbm>=2.0.11, <4", "opencv-python-headless", "s2cloudless", "scikit-image>=0.13.0"]
 mltools = ["shapely"]
 tdigest = ["tdigest==0.5.2.2"]
 mltoolsplotting = ["matplotlib"]


### PR DESCRIPTION
Changes:
- new requirement for `eo-learn-mask` (s2cloudless)
- simplified `CloudMaskTask` after using `S2PixelCloudDetector` from `s2cloudless`

I expected the test data to change and the tests to fail, since the eo-learn version was using a different version of the s2cloudless model (or seemed to be). Doesn't seem to be any change in the tests, so this one is a freebie.