### PR TITLE
Explicit loading timestamps fails if none are found

### DIFF
--- a/eolearn/core/eodata_io.py
+++ b/eolearn/core/eodata_io.py
@@ -306,15 +306,16 @@ def load_eopatch_content(
     if file_information.bbox is not None:
         bbox = FeatureIOBBox(file_information.bbox, filesystem).load()
 
-    if load_timestamps == "auto":
-        load_timestamps = any(ftype.is_temporal() for ftype, _ in features_dict)
+    auto_load = load_timestamps == "auto" and any(ftype.is_temporal() for ftype, _ in features_dict)
 
     timestamps = None
-    if load_timestamps:
+    if load_timestamps is True or auto_load:
         if maybe_timestamps is not None:
             timestamps = maybe_timestamps
         elif file_information.timestamps is not None:
             timestamps = FeatureIOTimestamps(file_information.timestamps, filesystem, simple_temporal_selection).load()
+        elif load_timestamps is True:  # this means that timestamps were requested but dont exist
+            raise OSError(f"No timestamps found when loading EOPatch at {patch_location} with `load_timestamps=True`.")
 
     return bbox, timestamps, features_dict
 

--- a/tests/core/test_eodata_io.py
+++ b/tests/core/test_eodata_io.py
@@ -264,6 +264,17 @@ def test_load_timestamps(eopatch, fs_loader, load_timestamps, features, should_l
         assert (loaded_patch.timestamps is not None) == should_load
 
 
+@pytest.mark.parametrize("features", [..., [FeatureType.DATA_TIMELESS]])
+@pytest.mark.filterwarnings("ignore::eolearn.core.exceptions.TemporalDimensionWarning")
+def test_load_timestamps_when_nonexistant(eopatch, features):
+    with TempFS() as temp_fs:
+        eopatch.save("/", filesystem=temp_fs, save_timestamps=False)
+        loaded_patch = EOPatch.load("/", filesystem=temp_fs, features=features, load_timestamps="auto")
+        assert loaded_patch.timestamps is None
+        with pytest.raises(OSError):
+            loaded_patch = EOPatch.load("/", filesystem=temp_fs, features=features, load_timestamps=True)
+
+
 @mock_s3
 @pytest.mark.parametrize("fs_loader", FS_LOADERS)
 @pytest.mark.parametrize("use_zarr", [True, False])


### PR DESCRIPTION
When `load_timestamps=True` is set, the loading fails if there are no timestamps available.