### PR TITLE
Compression changes to eo-learn

### DIFF
--- a/eolearn/core/core_tasks.py
+++ b/eolearn/core/core_tasks.py
@@ -102,7 +102,6 @@ class SaveTask(IOTask):
         config: SHConfig | None = None,
         features: FeaturesSpecification = ...,
         overwrite_permission: OverwritePermission = OverwritePermission.ADD_ONLY,
-        compress_level: int = 1,
         *,
         save_timestamps: bool | Literal["auto"] = "auto",
         use_zarr: bool = False,
@@ -116,7 +115,6 @@ class SaveTask(IOTask):
         :param features: A collection of features types specifying features of which type will be saved. By default,
             all features will be saved.
         :param overwrite_permission: A level of permission for overwriting an existing EOPatch
-        :param compress_level: A level of data compression and can be specified with an integer from 0 (no compression)
             to 9 (highest compression).
         :save_timestamps: Whether to save the timestamps of the EOPatch. With the `"auto"` setting timestamps are saved
             if `features=...` or if other temporal features are being saved.
@@ -127,7 +125,6 @@ class SaveTask(IOTask):
         """
         self.features = features
         self.overwrite_permission = overwrite_permission
-        self.compress_level = compress_level
         self.use_zarr = use_zarr
         self.temporal_selection = temporal_selection
         self.save_timestamps = save_timestamps
@@ -155,7 +152,6 @@ class SaveTask(IOTask):
             filesystem=self.filesystem,
             features=self.features,
             overwrite_permission=self.overwrite_permission,
-            compress_level=self.compress_level,
             save_timestamps=self.save_timestamps,
             use_zarr=self.use_zarr,
             temporal_selection=temporal_selection,

--- a/eolearn/core/core_tasks.py
+++ b/eolearn/core/core_tasks.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import copy
 import datetime as dt
+import warnings
 from abc import ABCMeta
 from typing import Any, Callable, Iterable, Literal, Tuple, Union, cast
 
@@ -106,6 +107,7 @@ class SaveTask(IOTask):
         save_timestamps: bool | Literal["auto"] = "auto",
         use_zarr: bool = False,
         temporal_selection: None | slice | list[int] | Literal["infer"] = None,
+        compress_level: int | None = None,
     ):
         """
         :param path: root path where all EOPatches are saved
@@ -129,6 +131,13 @@ class SaveTask(IOTask):
         self.temporal_selection = temporal_selection
         self.save_timestamps = save_timestamps
         super().__init__(path, filesystem=filesystem, create=True, config=config)
+
+        if compress_level is not None:
+            warnings.warn(
+                "The `compress_level` parameter has been deprecated, data is now compressed by default.",
+                category=EODeprecationWarning,
+                stacklevel=2,
+            )
 
     def execute(
         self,

--- a/eolearn/core/eodata.py
+++ b/eolearn/core/eodata.py
@@ -609,6 +609,7 @@ class EOPatch:
         save_timestamps: bool | Literal["auto"] = "auto",
         use_zarr: bool = False,
         temporal_selection: None | slice | list[int] | Literal["infer"] = None,
+        compress_level: int | None = None,
     ) -> None:
         """Method to save an EOPatch from memory to a storage.
 
@@ -628,6 +629,13 @@ class EOPatch:
         if filesystem is None:
             filesystem = get_filesystem(path, create=True)
             path = "/"
+
+        if compress_level is not None:
+            warnings.warn(
+                "The `compress_level` parameter has been deprecated, data is now compressed by default.",
+                category=EODeprecationWarning,
+                stacklevel=2,
+            )
 
         save_eopatch(
             self,

--- a/eolearn/core/eodata.py
+++ b/eolearn/core/eodata.py
@@ -604,7 +604,6 @@ class EOPatch:
         path: str,
         features: FeaturesSpecification = ...,
         overwrite_permission: OverwritePermission = OverwritePermission.ADD_ONLY,
-        compress_level: int = 1,
         filesystem: FS | None = None,
         *,
         save_timestamps: bool | Literal["auto"] = "auto",
@@ -617,8 +616,6 @@ class EOPatch:
         :param features: A collection of features types specifying features of which type will be saved. By default,
             all features will be saved.
         :param overwrite_permission: A level of permission for overwriting an existing EOPatch
-        :param compress_level: A level of data compression and can be specified with an integer from 0 (no compression)
-            to 9 (highest compression).
         :param filesystem: An existing filesystem object. If not given it will be initialized according to the `path`
             parameter.
         :save_timestamps: Whether to save the timestamps of the EOPatch. With the `"auto"` setting timestamps are saved
@@ -637,7 +634,6 @@ class EOPatch:
             filesystem,
             path,
             features=features,
-            compress_level=compress_level,
             overwrite_permission=OverwritePermission(overwrite_permission),
             save_timestamps=save_timestamps,
             use_zarr=use_zarr,

--- a/eolearn/core/eodata_io.py
+++ b/eolearn/core/eodata_io.py
@@ -418,11 +418,9 @@ def get_filesystem_data_info(
 
         if object_name == "timestamp":
             warnings.warn(
-                (
-                    f"EOPatch at {patch_location} contains the deprecated naming `timestamp` for the `timestamps`"
-                    " feature. The old name will no longer be valid in the future. You can re-save the `EOPatch` to"
-                    " update it."
-                ),
+                f"EOPatch at {patch_location} contains the deprecated naming `timestamp` for the `timestamps`"
+                " feature. The old name will no longer be valid in the future. You can re-save the `EOPatch` to"
+                " update it.",
                 category=EODeprecationWarning,
                 stacklevel=2,
             )

--- a/eolearn/core/eodata_io.py
+++ b/eolearn/core/eodata_io.py
@@ -116,7 +116,6 @@ def save_eopatch(
     features: FeaturesSpecification,
     save_timestamps: bool | Literal["auto"],
     overwrite_permission: OverwritePermission,
-    compress_level: int,
     use_zarr: bool,
     temporal_selection: None | slice | list[int] | Literal["infer"],
 ) -> None:
@@ -144,7 +143,6 @@ def save_eopatch(
             patch_location=patch_location,
             filesystem=filesystem,
             use_zarr=use_zarr,
-            compress_level=compress_level,
             save_timestamps=save_timestamps,
             temporal_selection=_infer_temporal_selection(temporal_selection, filesystem, file_information, eopatch),
         )
@@ -409,9 +407,11 @@ def get_filesystem_data_info(
 
         if object_name == "timestamp":
             warnings.warn(
-                f"EOPatch at {patch_location} contains the deprecated naming `timestamp` for the `timestamps`"
-                " feature. The old name will no longer be valid in the future. You can re-save the `EOPatch` to"
-                " update it.",
+                (
+                    f"EOPatch at {patch_location} contains the deprecated naming `timestamp` for the `timestamps`"
+                    " feature. The old name will no longer be valid in the future. You can re-save the `EOPatch` to"
+                    " update it."
+                ),
                 category=EODeprecationWarning,
                 stacklevel=2,
             )

--- a/tests/core/test_eodata_io.py
+++ b/tests/core/test_eodata_io.py
@@ -329,6 +329,19 @@ def test_overwrite_failure(fs_loader, use_zarr: bool):
 
 @mock_s3
 @pytest.mark.parametrize("fs_loader", FS_LOADERS)
+@pytest.mark.parametrize("compress_level", [0, 1])
+def test_compression_deprecation(eopatch, fs_loader, compress_level: int | None):
+    folder = "foo-folder"
+
+    with fs_loader() as temp_fs, pytest.warns(EODeprecationWarning):
+        SaveTask(folder, filesystem=temp_fs, compress_level=compress_level)
+
+    with fs_loader() as temp_fs, pytest.warns(EODeprecationWarning):
+        eopatch.save(folder, filesystem=temp_fs, compress_level=compress_level)
+
+
+@mock_s3
+@pytest.mark.parametrize("fs_loader", FS_LOADERS)
 @pytest.mark.parametrize("use_zarr", [True, False])
 def test_save_and_load_tasks(eopatch, fs_loader, use_zarr: bool):
     _skip_when_appropriate(fs_loader, use_zarr)

--- a/tests/core/test_eodata_io.py
+++ b/tests/core/test_eodata_io.py
@@ -441,6 +441,9 @@ def test_cleanup_different_compression(fs_loader, eopatch):
         mask_timeless_path = fs.path.join(folder, patch_folder, ftype.value, f"{fname}.npy")
         FeatureIONumpy.save(eopatch[(ftype, fname)], temp_fs, mask_timeless_path, compress_level=0)
 
+        # test EOPatch load of uncompressed features
+        EOPatch.load(fs.path.join(folder, patch_folder), filesystem=temp_fs)
+
         # re-save compressed and check cleanup, bbox and timestamps are not compressed
         save_task(eopatch, eopatch_folder=patch_folder)
         assert temp_fs.exists(bbox_path)


### PR DESCRIPTION
Changes:
- `compression_level` parameter removed
- compress by default for everything except bbox and timestamps
- test updates