### PR TITLE
Switch morphology tasks to use cv2 instead of skimage

### DIFF
--- a/eolearn/core/utils/testing.py
+++ b/eolearn/core/utils/testing.py
@@ -23,7 +23,7 @@ from sentinelhub import CRS, BBox
 
 from ..constants import FeatureType
 from ..eodata import EOPatch
-from ..types import Feature
+from ..types import FeaturesSpecification
 from ..utils.parsing import FeatureParser
 
 DEFAULT_BBOX = BBox((0, 0, 100, 100), crs=CRS("EPSG:32633"))
@@ -46,7 +46,7 @@ class PatchGeneratorConfig:
 
 
 def generate_eopatch(
-    features: list[Feature] | None = None,
+    features: FeaturesSpecification | None = None,
     bbox: BBox = DEFAULT_BBOX,
     timestamps: list[dt.datetime] | None = None,
     seed: int = 42,

--- a/tests/geometry/test_morphology.py
+++ b/tests/geometry/test_morphology.py
@@ -23,7 +23,10 @@ MASK_TIMELESS_FEATURE = FeatureType.MASK_TIMELESS, "timeless_mask"
 @pytest.fixture(name="patch")
 def patch_fixture() -> EOPatch:
     config = PatchGeneratorConfig(max_integer_value=10, raster_shape=(50, 100), depth_range=(3, 4))
-    return generate_eopatch([MASK_FEATURE, MASK_TIMELESS_FEATURE], config=config)
+    patch = generate_eopatch([MASK_FEATURE, MASK_TIMELESS_FEATURE], config=config)
+    for feat in [MASK_FEATURE, MASK_TIMELESS_FEATURE]:
+        patch[feat] = patch[feat].astype(np.uint8)
+    return patch
 
 
 @pytest.mark.parametrize("invalid_input", [None, 0, "a"])
@@ -33,7 +36,7 @@ def test_erosion_value_error(invalid_input):
 
 
 def test_erosion_full(test_eopatch):
-    erosion_task = ErosionTask((FeatureType.MASK_TIMELESS, "LULC", "LULC_ERODED"), 1)
+    erosion_task = ErosionTask((FeatureType.MASK_TIMELESS, "LULC", "LULC_ERODED"), disk_radius=3)
     eopatch = erosion_task.execute(test_eopatch)
 
     mask_after = eopatch.mask_timeless["LULC_ERODED"]
@@ -45,7 +48,7 @@ def test_erosion_partial(test_eopatch):
     # skip forest and artificial surface
     specific_labels = [0, 1, 3, 4]
     erosion_task = ErosionTask(
-        mask_feature=(FeatureType.MASK_TIMELESS, "LULC", "LULC_ERODED"), disk_radius=1, erode_labels=specific_labels
+        mask_feature=(FeatureType.MASK_TIMELESS, "LULC", "LULC_ERODED"), disk_radius=3, erode_labels=specific_labels
     )
     eopatch = erosion_task.execute(test_eopatch)
 
@@ -60,29 +63,23 @@ def test_erosion_partial(test_eopatch):
         (
             MorphologicalOperations.DILATION,
             None,
-            [1, 30, 161, 669, 1690, 3557, 6973, 12247, 19462, 30210],
-            [7, 29, 112, 304, 639, 1336, 2465, 4012, 6096],
+            [6, 34, 172, 768, 2491, 7405, 19212, 44912],
+            [1, 2, 16, 104, 466, 1490, 3870, 9051],
         ),
-        (MorphologicalOperations.EROSION, MorphologicalStructFactory.get_disk(5), [74925, 72, 3], [14989, 11]),
-        (MorphologicalOperations.OPENING, MorphologicalStructFactory.get_disk(5), [73137, 1800, 63], [14720, 280]),
-        (MorphologicalOperations.CLOSING, MorphologicalStructFactory.get_disk(5), [1157, 73843], [501, 14499]),
-        (
-            MorphologicalOperations.MEDIAN,
-            MorphologicalStructFactory.get_rectangle(5, 6),
-            [16, 562, 6907, 24516, 28864, 12690, 1403, 42],
-            [71, 1280, 4733, 5924, 2592, 382, 18],
-        ),
+        (MorphologicalOperations.EROSION, MorphologicalStructFactory.get_disk(11), [74957, 42, 1], [14994, 6]),
+        (MorphologicalOperations.OPENING, MorphologicalStructFactory.get_disk(11), [73899, 1051, 50], [14837, 163]),
+        (MorphologicalOperations.CLOSING, MorphologicalStructFactory.get_disk(11), [770, 74230], [425, 14575]),
         (
             MorphologicalOperations.OPENING,
             MorphologicalStructFactory.get_rectangle(5, 6),
-            [47486, 24132, 2565, 497, 169, 96, 35, 20],
-            [9929, 4446, 494, 53, 54, 16, 8],
+            [48468, 24223, 2125, 169, 15],
+            [10146, 4425, 417, 3, 9],
         ),
         (
             MorphologicalOperations.DILATION,
             MorphologicalStructFactory.get_rectangle(5, 6),
-            [2, 20, 184, 3888, 70906],
-            [3, 32, 748, 14217],
+            [2, 19, 198, 3929, 70852],
+            [32, 743, 14225],
         ),
     ],
 )

--- a/tests/geometry/test_morphology.py
+++ b/tests/geometry/test_morphology.py
@@ -10,15 +10,20 @@ import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
 
-from sentinelhub import CRS, BBox
-
 from eolearn.core import EOPatch, FeatureType
+from eolearn.core.utils.testing import PatchGeneratorConfig, generate_eopatch
 from eolearn.geometry import ErosionTask, MorphologicalFilterTask, MorphologicalOperations, MorphologicalStructFactory
 
 CLASSES = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 MASK_FEATURE = FeatureType.MASK, "mask"
 MASK_TIMELESS_FEATURE = FeatureType.MASK_TIMELESS, "timeless_mask"
 # ruff: noqa: NPY002
+
+
+@pytest.fixture(name="patch")
+def patch_fixture() -> EOPatch:
+    config = PatchGeneratorConfig(max_integer_value=10, raster_shape=(50, 100), depth_range=(3, 4))
+    return generate_eopatch([MASK_FEATURE, MASK_TIMELESS_FEATURE], config=config)
 
 
 @pytest.mark.parametrize("invalid_input", [None, 0, "a"])
@@ -49,19 +54,45 @@ def test_erosion_partial(test_eopatch):
     assert_array_equal(np.unique(mask_after, return_counts=True)[1], [1145, 7601, 1069, 87, 198])
 
 
-@pytest.mark.parametrize("morph_operation", MorphologicalOperations)
 @pytest.mark.parametrize(
-    "struct_element", [None, MorphologicalStructFactory.get_disk(5), MorphologicalStructFactory.get_rectangle(5, 6)]
+    ("morph_operation", "struct_element", "mask_counts", "mask_timeless_counts"),
+    [
+        (
+            MorphologicalOperations.DILATION,
+            None,
+            [1, 30, 161, 669, 1690, 3557, 6973, 12247, 19462, 30210],
+            [7, 29, 112, 304, 639, 1336, 2465, 4012, 6096],
+        ),
+        (MorphologicalOperations.EROSION, MorphologicalStructFactory.get_disk(5), [74925, 72, 3], [14989, 11]),
+        (MorphologicalOperations.OPENING, MorphologicalStructFactory.get_disk(5), [73137, 1800, 63], [14720, 280]),
+        (MorphologicalOperations.CLOSING, MorphologicalStructFactory.get_disk(5), [1157, 73843], [501, 14499]),
+        (
+            MorphologicalOperations.MEDIAN,
+            MorphologicalStructFactory.get_rectangle(5, 6),
+            [16, 562, 6907, 24516, 28864, 12690, 1403, 42],
+            [71, 1280, 4733, 5924, 2592, 382, 18],
+        ),
+        (
+            MorphologicalOperations.OPENING,
+            MorphologicalStructFactory.get_rectangle(5, 6),
+            [47486, 24132, 2565, 497, 169, 96, 35, 20],
+            [9929, 4446, 494, 53, 54, 16, 8],
+        ),
+        (
+            MorphologicalOperations.DILATION,
+            MorphologicalStructFactory.get_rectangle(5, 6),
+            [2, 20, 184, 3888, 70906],
+            [3, 32, 748, 14217],
+        ),
+    ],
 )
-def test_morphological_filter(morph_operation, struct_element):
-    eopatch = EOPatch(bbox=BBox((0, 0, 1, 1), CRS(3857)), timestamps=["2015-7-7"] * 10)
-    eopatch[MASK_FEATURE] = np.random.randint(20, size=(10, 100, 100, 3), dtype=np.uint8)
-    eopatch[MASK_TIMELESS_FEATURE] = np.random.randint(20, 50, size=(100, 100, 5), dtype=np.uint8)
-
+def test_morphological_filter(patch, morph_operation, struct_element, mask_counts, mask_timeless_counts):
     task = MorphologicalFilterTask(
         [MASK_FEATURE, MASK_TIMELESS_FEATURE], morph_operation=morph_operation, struct_elem=struct_element
     )
-    task.execute(eopatch)
+    task.execute(patch)
 
-    assert eopatch[MASK_FEATURE].shape == (10, 100, 100, 3)
-    assert eopatch[MASK_TIMELESS_FEATURE].shape == (100, 100, 5)
+    assert patch[MASK_FEATURE].shape == (5, 50, 100, 3)
+    assert patch[MASK_TIMELESS_FEATURE].shape == (50, 100, 3)
+    assert_array_equal(np.unique(patch[MASK_FEATURE], return_counts=True)[1], mask_counts)
+    assert_array_equal(np.unique(patch[MASK_TIMELESS_FEATURE], return_counts=True)[1], mask_timeless_counts)

--- a/tests/geometry/test_morphology.py
+++ b/tests/geometry/test_morphology.py
@@ -28,25 +28,15 @@ def test_erosion_value_error(invalid_input):
 
 
 def test_erosion_full(test_eopatch):
-    mask_before = test_eopatch.mask_timeless["LULC"].copy()
-
     erosion_task = ErosionTask((FeatureType.MASK_TIMELESS, "LULC", "LULC_ERODED"), 1)
     eopatch = erosion_task.execute(test_eopatch)
 
-    mask_after = eopatch.mask_timeless["LULC_ERODED"].copy()
+    mask_after = eopatch.mask_timeless["LULC_ERODED"]
 
-    assert not np.all(mask_before == mask_after)
-
-    for label in CLASSES:
-        if label == 0:
-            assert np.sum(mask_after == label) >= np.sum(mask_before == label), "Error in the erosion process"
-        else:
-            assert np.sum(mask_after == label) <= np.sum(mask_before == label), "Error in the erosion process"
+    assert_array_equal(np.unique(mask_after, return_counts=True)[1], [1942, 6950, 1069, 87, 52])
 
 
 def test_erosion_partial(test_eopatch):
-    mask_before = test_eopatch.mask_timeless["LULC"].copy()
-
     # skip forest and artificial surface
     specific_labels = [0, 1, 3, 4]
     erosion_task = ErosionTask(
@@ -54,17 +44,9 @@ def test_erosion_partial(test_eopatch):
     )
     eopatch = erosion_task.execute(test_eopatch)
 
-    mask_after = eopatch.mask_timeless["LULC_ERODED"].copy()
+    mask_after = eopatch.mask_timeless["LULC_ERODED"]
 
-    assert not np.all(mask_before == mask_after)
-
-    for label in CLASSES:
-        if label == 0:
-            assert np.sum(mask_after == label) >= np.sum(mask_before == label), "Error in the erosion process"
-        elif label in specific_labels:
-            assert np.sum(mask_after == label) <= np.sum(mask_before == label), "Error in the erosion process"
-        else:
-            assert_array_equal(mask_after == label, mask_before == label, err_msg="Error in the erosion process")
+    assert_array_equal(np.unique(mask_after, return_counts=True)[1], [1145, 7601, 1069, 87, 198])
 
 
 @pytest.mark.parametrize("morph_operation", MorphologicalOperations)


### PR DESCRIPTION
Changes:
- remove usage of `skimage`
- introduce usage of `cv2`
- remove some things not obvious in cv2 (diamond kernel, etc.)
- update tests