### PR TITLE
Explicit arguments in tasks instead of **kwargs

### DIFF
--- a/eolearn/io/raster_io.py
+++ b/eolearn/io/raster_io.py
@@ -13,7 +13,7 @@ import functools
 import logging
 import warnings
 from abc import ABCMeta
-from typing import Any, BinaryIO
+from typing import BinaryIO
 
 import fs
 import numpy as np
@@ -155,7 +155,10 @@ class ExportToTiffTask(BaseRasterIoTask):
         crs: CRS | int | str | None = None,
         fail_on_missing: bool = True,
         compress: str | None = None,
-        **kwargs: Any,
+        filesystem: FS | None = None,
+        image_dtype: np.dtype | type | None = None,
+        no_data_value: float | None = None,
+        config: SHConfig | None = None,
     ):
         """
         :param feature: A feature to be exported.
@@ -173,9 +176,22 @@ class ExportToTiffTask(BaseRasterIoTask):
         :param fail_on_missing: A flag to specify if the task should fail if a feature is missing or if it should
             just show a warning.
         :param compress: A type of compression that rasterio should apply to an exported image.
-        :param kwargs: Keyword arguments to be propagated to `BaseRasterIoTask`.
+        :param filesystem: A filesystem object. If not given it will be initialized according to `folder` parameter.
+        :param image_dtype: A data type of data in exported images or data imported from images.
+        :param no_data_value: When exporting this is the NoData value of pixels in exported images.
+            When importing this value is assigned to the pixels with NoData.
+        :param config: A configuration object with AWS credentials. By default, is set to None and in this case the
+            default configuration will be taken.
         """
-        super().__init__(feature, folder=folder, create=True, **kwargs)
+        super().__init__(
+            feature,
+            folder=folder,
+            create=True,
+            filesystem=filesystem,
+            image_dtype=image_dtype,
+            no_data_value=no_data_value,
+            config=config,
+        )
 
         self.date_indices = date_indices
         self.band_indices = band_indices
@@ -397,7 +413,10 @@ class ImportFromTiffTask(BaseRasterIoTask):
         *,
         use_vsi: bool = False,
         timestamp_size: int | None = None,
-        **kwargs: Any,
+        filesystem: FS | None = None,
+        image_dtype: np.dtype | type | None = None,
+        no_data_value: float | None = None,
+        config: SHConfig | None = None,
     ):
         """
         :param feature: EOPatch feature into which data will be imported
@@ -413,9 +432,21 @@ class ImportFromTiffTask(BaseRasterIoTask):
             channels of given tiff image should be in order
             T(1)B(1), T(1)B(2), ..., T(1)B(N), T(2)B(1), T(2)B(2), ..., T(2)B(N), ..., ..., T(M)B(N)
             where T and B are the time and band indices.
-        :param kwargs: Keyword arguments to be propagated to `BaseRasterIoTask`.
+        :param filesystem: A filesystem object. If not given it will be initialized according to `folder` parameter.
+        :param image_dtype: A data type of data in exported images or data imported from images.
+        :param no_data_value: When exporting this is the NoData value of pixels in exported images.
+            When importing this value is assigned to the pixels with NoData.
+        :param config: A configuration object with AWS credentials. By default, is set to None and in this case the
+            default configuration will be taken.
         """
-        super().__init__(feature, folder=folder, **kwargs)
+        super().__init__(
+            feature,
+            folder=folder,
+            filesystem=filesystem,
+            image_dtype=image_dtype,
+            no_data_value=no_data_value,
+            config=config,
+        )
 
         self.use_vsi = use_vsi
         self.timestamp_size = timestamp_size

--- a/eolearn/ml_tools/sampling.py
+++ b/eolearn/ml_tools/sampling.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from abc import ABCMeta
 from math import sqrt
-from typing import Any, Dict, Union
+from typing import Dict, Union
 
 import numpy as np
 from shapely.geometry import Point, Polygon
@@ -182,7 +182,7 @@ class FractionSamplingTask(BaseSamplingTask):
         fraction: _FractionType,
         exclude_values: list[int] | None = None,
         replace: bool = False,
-        **kwargs: Any,
+        mask_of_samples: Feature | None = None,
     ):
         """
         :param features_to_sample: Features that will be spatially sampled according to given sampling parameters.
@@ -190,9 +190,9 @@ class FractionSamplingTask(BaseSamplingTask):
         :param fraction: Fraction of points to sample. Can be dictionary mapping values of mask to fractions.
         :param exclude_values: Skips points that have these values in `sampling_mask`
         :param replace: Whether to sample with replacement. False means each value can only be chosen once.
-        :param kwargs: Arguments for :class:`BaseSamplingTask<eolearn.geometry.sampling.BaseSamplingTask>`
+        :param mask_of_samples: An output mask timeless feature of counts how many times each pixel has been sampled.
         """
-        super().__init__(features_to_sample, **kwargs)
+        super().__init__(features_to_sample, mask_of_samples=mask_of_samples)
 
         self.sampling_feature = self.parse_feature(sampling_feature, allowed_feature_types={FeatureType.MASK_TIMELESS})
 
@@ -267,7 +267,7 @@ class BlockSamplingTask(BaseSamplingTask):
         amount: float,
         sample_size: tuple[int, int] = (1, 1),
         replace: bool = False,
-        **kwargs: Any,
+        mask_of_samples: Feature | None = None,
     ):
         """
         :param features_to_sample: Features that will be spatially sampled according to given sampling parameters.
@@ -275,9 +275,9 @@ class BlockSamplingTask(BaseSamplingTask):
         :param sample_size: A tuple describing a size of sampled blocks. The size is defined as a tuple of number of
             rows and number of columns.
         :param replace: Whether to sample with replacement. False means each value can only be chosen once.
-        :param kwargs: Arguments for :class:`BaseSamplingTask<eolearn.geometry.sampling.BaseSamplingTask>`
+        :param mask_of_samples: An output mask timeless feature of counts how many times each pixel has been sampled.
         """
-        super().__init__(features_to_sample, **kwargs)
+        super().__init__(features_to_sample, mask_of_samples=mask_of_samples)
 
         self.amount = amount
         self.sample_size = tuple(sample_size)
@@ -330,7 +330,7 @@ class GridSamplingTask(BaseSamplingTask):
         features_to_sample: FeaturesSpecification,
         sample_size: tuple[int, int] = (1, 1),
         stride: tuple[int, int] = (1, 1),
-        **kwargs: Any,
+        mask_of_samples: Feature | None = None,
     ):
         """
         :param features_to_sample: Features that will be spatially sampled according to given sampling parameters.
@@ -339,9 +339,9 @@ class GridSamplingTask(BaseSamplingTask):
         :param stride: A tuple describing a distance between upper left corners of two consecutive sampled blocks.
             The first number is the vertical distance and the second number the horizontal distance. If stride in
             smaller than sample_size in any dimensions then sampled blocks will overlap.
-        :param kwargs: Arguments for :class:`BaseSamplingTask<eolearn.geometry.sampling.BaseSamplingTask>`
+        :param mask_of_samples: An output mask timeless feature of counts how many times each pixel has been sampled.
         """
-        super().__init__(features_to_sample, **kwargs)
+        super().__init__(features_to_sample, mask_of_samples=mask_of_samples)
 
         self.sample_size = tuple(sample_size)
         self.stride = tuple(stride)


### PR DESCRIPTION
Sometimes **kwargs do a lot of heavy lifting, sometimes they prevent the IDE and typecheckers from doing their work.
We are starting to favor reliability, so these need to go, even if it bloats the code a bit.