### PR TITLE
Adjust EOPatch repr method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - `MorphologicalFilterTask` adapted to work on boolean values.
 - Added `temporal_subset` method to `EOPatch`, which can be used to extract a subset of an `EOPatch` by filtering out temporal slices. Also added a corresponding `TemporalSubsetTask`.
 - `EOExecutor` now has an option to treat `TemporalDimensionWarning` as an exception.
+- String representation of `EOPatch` objects was revisited to avoid edge cases where the output would print enormous objects.
 
 ## [Version 1.5.0] - 2023-09-06
 

--- a/eolearn/core/eodata.py
+++ b/eolearn/core/eodata.py
@@ -467,16 +467,14 @@ class EOPatch:
             crs = CRS(value.crs).ogc_string() if value.crs else value.crs
             return f"{EOPatch._repr_value_class(value)}(columns={list(value)}, length={len(value)}, crs={crs})"
 
-        if isinstance(value, (list, tuple, dict)) and value:
-            repr_str = str(value)
-            if len(repr_str) <= MAX_DATA_REPR_LEN:
-                return repr_str
+        repr_str = str(value)
+        if len(repr_str) <= MAX_DATA_REPR_LEN:
+            return repr_str
 
+        if isinstance(value, (list, tuple)) and value:
             l_bracket, r_bracket = ("[", "]") if isinstance(value, list) else ("(", ")")
-            if isinstance(value, (list, tuple)) and len(value) > 2:
-                repr_str = f"{l_bracket}{value[0]!r}, ..., {value[-1]!r}{r_bracket}"
 
-            if len(repr_str) > MAX_DATA_REPR_LEN and isinstance(value, (list, tuple)) and len(value) > 1:
+            if len(repr_str) > MAX_DATA_REPR_LEN and len(value) > 1:
                 repr_str = f"{l_bracket}{value[0]!r}, ...{r_bracket}"
 
             if len(repr_str) > MAX_DATA_REPR_LEN:
@@ -484,7 +482,17 @@ class EOPatch:
 
             return f"{repr_str}, length={len(value)}"
 
-        return repr(value)
+        if isinstance(value, dict) and value:
+            if len(value) > 1:
+                some_key = next(iter(value))
+                repr_str = f"{{{some_key!r}: {value[some_key]!r}, ...}}"
+
+            if len(repr_str) > MAX_DATA_REPR_LEN:
+                repr_str = str(type(value))
+
+            return f"{repr_str}, length={len(value)}"
+
+        return str(type(value))
 
     @staticmethod
     def _repr_value_class(value: object) -> str:

--- a/eolearn/core/eodata.py
+++ b/eolearn/core/eodata.py
@@ -474,23 +474,25 @@ class EOPatch:
         if isinstance(value, (list, tuple)) and value:
             l_bracket, r_bracket = ("[", "]") if isinstance(value, list) else ("(", ")")
 
-            if len(repr_str) > MAX_DATA_REPR_LEN and len(value) > 1:
-                repr_str = f"{l_bracket}{value[0]!r}, ...{r_bracket}"
+            repr_of_some_element = EOPatch._repr_value(value[0])
+            many_elements_visual = ", ..." if len(value) > 1 else ""
+            repr_str = f"{l_bracket}{repr_of_some_element}{many_elements_visual}{r_bracket}"
 
             if len(repr_str) > MAX_DATA_REPR_LEN:
                 repr_str = str(type(value))
 
-            return f"{repr_str}, length={len(value)}"
+            return f"{repr_str}<length={len(value)}>"
 
         if isinstance(value, dict) and value:
-            if len(value) > 1:
-                some_key = next(iter(value))
-                repr_str = f"{{{some_key!r}: {value[some_key]!r}, ...}}"
+            some_key = next(iter(value))
+            key_repr, value_repr = EOPatch._repr_value(some_key), EOPatch._repr_value(value[some_key])
+            many_elements_visual = ", ..." if len(value) > 1 else ""
+            repr_str = f"{{{key_repr}: {value_repr}{many_elements_visual}}}"
 
             if len(repr_str) > MAX_DATA_REPR_LEN:
                 repr_str = str(type(value))
 
-            return f"{repr_str}, length={len(value)}"
+            return f"{repr_str}<length={len(value)}>"
 
         return str(type(value))
 

--- a/eolearn/core/eodata.py
+++ b/eolearn/core/eodata.py
@@ -470,7 +470,7 @@ class EOPatch:
         if isinstance(value, (list, tuple, dict)) and value:
             lb, rb = ("[", "]") if isinstance(value, list) else ("(", ")") if isinstance(value, tuple) else ("{", "}")
 
-            if isinstance(value, dict):  # generate representation of first element or key, value pair
+            if isinstance(value, dict):  # generate representation of first element or (key, value) pair
                 some_key = next(iter(value))
                 repr_of_el = f"{EOPatch._repr_value(some_key)}: {EOPatch._repr_value(value[some_key])}"
             else:

--- a/eolearn/core/eodata.py
+++ b/eolearn/core/eodata.py
@@ -455,11 +455,7 @@ class EOPatch:
 
     @staticmethod
     def _repr_value(value: object) -> str:
-        """Creates a representation string for different types of data.
-
-        :param value: data in any type
-        :return: representation string
-        """
+        """Creates a representation string for different types of data."""
         if isinstance(value, np.ndarray):
             return f"{EOPatch._repr_value_class(value)}(shape={value.shape}, dtype={value.dtype})"
 

--- a/eolearn/core/eodata.py
+++ b/eolearn/core/eodata.py
@@ -471,23 +471,17 @@ class EOPatch:
         if len(repr_str) <= MAX_DATA_REPR_LEN:
             return repr_str
 
-        if isinstance(value, (list, tuple)) and value:
-            l_bracket, r_bracket = ("[", "]") if isinstance(value, list) else ("(", ")")
+        if isinstance(value, (list, tuple, dict)) and value:
+            lb, rb = ("[", "]") if isinstance(value, list) else ("(", ")") if isinstance(value, tuple) else ("{", "}")
 
-            repr_of_some_element = EOPatch._repr_value(value[0])
-            many_elements_visual = ", ..." if len(value) > 1 else ""
-            repr_str = f"{l_bracket}{repr_of_some_element}{many_elements_visual}{r_bracket}"
+            if isinstance(value, dict):  # generate representation of first element or key, value pair
+                some_key = next(iter(value))
+                repr_of_el = f"{EOPatch._repr_value(some_key)}: {EOPatch._repr_value(value[some_key])}"
+            else:
+                repr_of_el = EOPatch._repr_value(value[0])
 
-            if len(repr_str) > MAX_DATA_REPR_LEN:
-                repr_str = str(type(value))
-
-            return f"{repr_str}<length={len(value)}>"
-
-        if isinstance(value, dict) and value:
-            some_key = next(iter(value))
-            key_repr, value_repr = EOPatch._repr_value(some_key), EOPatch._repr_value(value[some_key])
-            many_elements_visual = ", ..." if len(value) > 1 else ""
-            repr_str = f"{{{key_repr}: {value_repr}{many_elements_visual}}}"
+            many_elements_visual = ", ..." if len(value) > 1 else ""  # add ellipsis if there are multiple elements
+            repr_str = f"{lb}{repr_of_el}{many_elements_visual}{rb}"
 
             if len(repr_str) > MAX_DATA_REPR_LEN:
                 repr_str = str(type(value))


### PR DESCRIPTION
Turns out dictionaries were never covered. Also any object other than `tuple` or `list` would just be printed out in full. And if the element inside a list was huge, why not, print that fully as well...

So what i did is make sure that:
- Every element with a representation that is too large gets shortened to `str(type(x))`
- Dictionaries follow a similar set of rules as tuples and lists (print first element and show length)
- When doing the above, the first element is recursively formatted with the same function
- I switched from `[x, ...], length=100` to `[x, ...]<length=100>` otherwise recursive nesting was unreadable since you got `[[x, ...], length=100], length=100`, but `[[x, ...]<length=100>, ...]<length=100>` is a bit better.

Example of how it works now:
![image](https://github.com/sentinel-hub/eo-learn/assets/31988337/54b241dc-3e15-4ec7-8c1d-a7dbad98f51f)
