### PR TITLE
Fix mistake of logs paths being absolute

### DIFF
--- a/eolearn/visualization/eoexecutor.py
+++ b/eolearn/visualization/eoexecutor.py
@@ -68,7 +68,7 @@ class EOExecutorVisualization:
 
             template = self._get_template()
 
-            log_paths = self.eoexecutor.get_log_paths()
+            log_paths = self.eoexecutor.get_log_paths(full_path=False)
             if not include_logs:
                 execution_logs = None
             elif self.eoexecutor.save_logs:


### PR DESCRIPTION
I had a hunch that i screwed something up with logs.
Ran some eo-grow pipelines and found out that i forgot to make paths relative