### PR TITLE
Tiff tasks parameter `folder` renamed to `path`

### DIFF
--- a/eolearn/io/raster_io.py
+++ b/eolearn/io/raster_io.py
@@ -121,8 +121,7 @@ class BaseRasterIoTask(IOTask, metaclass=ABCMeta):
     @classmethod
     def _generate_paths(cls, path_template: str, timestamps: list[dt.datetime] | None) -> list[str]:
         """Uses a filename path template to create a list of actual filename paths."""
-        has_tiff_file_extensions = path_template.lower().endswith(".tif") or path_template.lower().endswith(".tiff")
-        if not has_tiff_file_extensions:
+        if not path_template.lower().endswith((".tif", ".tiff")):
             path_template = f"{path_template}.tif"
 
         if not timestamps:

--- a/eolearn/io/raster_io.py
+++ b/eolearn/io/raster_io.py
@@ -53,7 +53,8 @@ class BaseRasterIoTask(IOTask, metaclass=ABCMeta):
     ):
         """
         :param feature: Feature which will be exported or imported
-        :param path: Path pointing to an image file or to a directory of image files. If `filesystem` is not defined, absolute paths should be provided.
+        :param path: Path pointing to an image file or to a directory of image files. If `filesystem` is not defined,
+            absolute paths should be provided.
         :param filesystem: A filesystem object. If not given it will be initialized according to `folder` parameter.
         :param image_dtype: A data type of data in exported images or data imported from images.
         :param no_data_value: When exporting this is the `NoData` value of pixels in exported images. When importing
@@ -162,7 +163,8 @@ class ExportToTiffTask(BaseRasterIoTask):
     ):
         """
         :param feature: A feature to be exported.
-        :param path: Path pointing to an image file or to a directory of image files to be exported. If `filesystem` is not defined, absolute paths should be provided.
+        :param path: Path pointing to an image file or to a directory of image files to be exported. If `filesystem` is
+            not defined, absolute paths should be provided.
         :param date_indices: Indices of those time frames from the give feature that will be exported to a tiff image.
             It can be either a list of indices or a tuple of `2` indices defining an interval of indices or a tuple of
             `2` datetime object also defining a time interval. By default, all time frames will be exported.
@@ -419,7 +421,8 @@ class ImportFromTiffTask(BaseRasterIoTask):
     ):
         """
         :param feature: EOPatch feature into which data will be imported
-        :param path: Path pointing to an image file or to a directory of image files to be imported. If `filesystem` is not defined, absolute paths should be provided.
+        :param path: Path pointing to an image file or to a directory of image files to be imported. If `filesystem` is
+            not defined, absolute paths should be provided.
         :param use_vsi: Deprecated.
         :param timestamp_size: In case data will be imported into a time-dependant feature this parameter can be used to
             specify time dimension. If not specified, time dimension will be the same as size of the timestamps

--- a/eolearn/io/raster_io.py
+++ b/eolearn/io/raster_io.py
@@ -53,8 +53,7 @@ class BaseRasterIoTask(IOTask, metaclass=ABCMeta):
     ):
         """
         :param feature: Feature which will be exported or imported
-        :param path: A path to the image(s). If `filesystem` is defined, then `folder` should be given relative to the
-            filesystem object. Otherwise, it should be an absolute path.
+        :param path: Path pointing to an image file or to a directory of image files. If `filesystem` is not defined, absolute paths should be provided.
         :param filesystem: A filesystem object. If not given it will be initialized according to `folder` parameter.
         :param image_dtype: A data type of data in exported images or data imported from images.
         :param no_data_value: When exporting this is the `NoData` value of pixels in exported images. When importing
@@ -163,8 +162,7 @@ class ExportToTiffTask(BaseRasterIoTask):
     ):
         """
         :param feature: A feature to be exported.
-        :param path: A path to the image(s). If `filesystem` is defined, then `folder` should be given relative to the
-            filesystem object. Otherwise, it should be an absolute path.
+        :param path: Path pointing to an image file or to a directory of image files to be exported. If `filesystem` is not defined, absolute paths should be provided.
         :param date_indices: Indices of those time frames from the give feature that will be exported to a tiff image.
             It can be either a list of indices or a tuple of `2` indices defining an interval of indices or a tuple of
             `2` datetime object also defining a time interval. By default, all time frames will be exported.
@@ -421,7 +419,7 @@ class ImportFromTiffTask(BaseRasterIoTask):
     ):
         """
         :param feature: EOPatch feature into which data will be imported
-        :param path: A directory containing image files or a path of an image file
+        :param path: Path pointing to an image file or to a directory of image files to be imported. If `filesystem` is not defined, absolute paths should be provided.
         :param use_vsi: Deprecated.
         :param timestamp_size: In case data will be imported into a time-dependant feature this parameter can be used to
             specify time dimension. If not specified, time dimension will be the same as size of the timestamps

--- a/tests/io/test_raster_io.py
+++ b/tests/io/test_raster_io.py
@@ -146,13 +146,13 @@ def test_export_import(test_case, test_eopatch):
         feature = test_case.feature_type, test_case.name
 
         export_task = ExportToTiffTask(
-            feature, folder=tmp_dir_name, band_indices=test_case.bands, date_indices=test_case.times
+            feature, path=tmp_dir_name, band_indices=test_case.bands, date_indices=test_case.times
         )
         _execute_with_warning_control(export_task, test_case.warning, test_eopatch, filename=tmp_file_name)
 
         export_task = ExportToTiffTask(
             feature,
-            folder=tmp_dir_name,
+            path=tmp_dir_name,
             band_indices=test_case.bands,
             date_indices=test_case.times,
             crs="EPSG:4326",
@@ -161,7 +161,7 @@ def test_export_import(test_case, test_eopatch):
         _execute_with_warning_control(export_task, test_case.warning, test_eopatch, filename=tmp_file_name_reproject)
 
         import_task = ImportFromTiffTask(
-            feature, folder=tmp_dir_name, timestamp_size=test_case.get_expected_timestamp_size()
+            feature, path=tmp_dir_name, timestamp_size=test_case.get_expected_timestamp_size()
         )
 
         expected_raster = test_case.get_expected()
@@ -209,7 +209,7 @@ def test_export2tiff_wrong_format(bands, times, test_eopatch):
     with tempfile.TemporaryDirectory() as tmp_dir_name:
         tmp_file_name = "temp_file.tiff"
         task = ExportToTiffTask(
-            (FeatureType.DATA, "data"), folder=tmp_dir_name, band_indices=bands, date_indices=times, image_dtype=float
+            (FeatureType.DATA, "data"), path=tmp_dir_name, band_indices=bands, date_indices=times, image_dtype=float
         )
         with pytest.raises(ValueError):
             task.execute(test_eopatch, filename=tmp_file_name)
@@ -222,7 +222,7 @@ def test_export2tiff_wrong_feature(mocker, test_eopatch):
         tmp_file_name = "temp_file.tiff"
         feature = FeatureType.MASK_TIMELESS, "feature-not-present"
 
-        export_task = ExportToTiffTask(feature, folder=tmp_dir_name, fail_on_missing=False)
+        export_task = ExportToTiffTask(feature, path=tmp_dir_name, fail_on_missing=False)
         export_task(test_eopatch, filename=tmp_file_name)
 
         assert logging.Logger.warning.call_count == 1
@@ -233,7 +233,7 @@ def test_export2tiff_wrong_feature(mocker, test_eopatch):
             == "Feature (<FeatureType.MASK_TIMELESS: 'mask_timeless'>, 'feature-not-present') was not found in EOPatch"
         )
 
-        failing_export_task = ExportToTiffTask(feature, folder=tmp_dir_name, fail_on_missing=True)
+        failing_export_task = ExportToTiffTask(feature, path=tmp_dir_name, fail_on_missing=True)
         with pytest.raises(ValueError):
             failing_export_task(test_eopatch, filename=tmp_file_name)
 
@@ -261,7 +261,7 @@ def test_export2tiff_separate_timestamps(test_eopatch):
         full_path = os.path.join(tmp_dir_name, tmp_file_name_reproject)
         export_task = ExportToTiffTask(
             feature,
-            folder=full_path,
+            path=full_path,
             band_indices=test_case.bands,
             date_indices=test_case.times,
             crs="EPSG:4326",
@@ -281,7 +281,7 @@ def test_import_tiff_subset(test_eopatch, example_data_path, use_vsi):
     path = os.path.join(example_data_path, "import-tiff-test1.tiff")
     mask_feature = FeatureType.MASK_TIMELESS, "TEST_TIF"
 
-    task = ImportFromTiffTask(mask_feature, path, use_vsi=use_vsi)
+    task = ImportFromTiffTask(mask_feature, path=path, use_vsi=use_vsi)
     task(test_eopatch)
 
     tiff_img = read_data(path)
@@ -326,8 +326,8 @@ def test_timeless_feature(test_eopatch):
     feature = FeatureType.DATA_TIMELESS, "DEM"
     filename = "relative-path/my-filename.tiff"
 
-    export_task = ExportToTiffTask(feature, folder=PATH_ON_BUCKET)
-    import_task = ImportFromTiffTask(feature, folder=PATH_ON_BUCKET)
+    export_task = ExportToTiffTask(feature, path=PATH_ON_BUCKET)
+    import_task = ImportFromTiffTask(feature, path=PATH_ON_BUCKET)
 
     export_task.execute(test_eopatch, filename=filename)
     new_eopatch = import_task.execute(test_eopatch, filename=filename)
@@ -343,8 +343,8 @@ def test_time_dependent_feature(test_eopatch):
     ]
 
     with tempfile.TemporaryDirectory() as tmp_dir_name:
-        export_task = ExportToTiffTask(feature, folder=tmp_dir_name)
-        import_task = ImportFromTiffTask(feature, folder=tmp_dir_name, timestamp_size=68)
+        export_task = ExportToTiffTask(feature, path=tmp_dir_name)
+        import_task = ImportFromTiffTask(feature, path=tmp_dir_name, timestamp_size=68)
 
         export_task(test_eopatch, filename=filename_export)
         new_eopatch = import_task(filename=filename_import)
@@ -365,8 +365,8 @@ def test_time_dependent_feature_with_timestamps(test_eopatch):
     filename = "relative-path/%Y%m%dT%H%M%S.tiff"
 
     with tempfile.TemporaryDirectory() as tmp_dir_name:
-        export_task = ExportToTiffTask(feature, folder=tmp_dir_name)
-        import_task = ImportFromTiffTask(feature, folder=tmp_dir_name)
+        export_task = ExportToTiffTask(feature, path=tmp_dir_name)
+        import_task = ImportFromTiffTask(feature, path=tmp_dir_name)
 
         export_task.execute(test_eopatch, filename=filename)
         new_eopatch = import_task(test_eopatch, filename=filename)
@@ -390,7 +390,7 @@ def test_export_import_sequence(no_data_value, data_type):
         filename = "test_seq.tiff"
         file_path = os.path.join(tmp_dir_name, filename)
         export_task = ExportToTiffTask(
-            feature=feature, folder=tmp_dir_name, band_indices=[0], no_data_value=no_data_value
+            feature=feature, path=tmp_dir_name, band_indices=[0], no_data_value=no_data_value
         )
         export_task.execute(eopatch=eopatch, filename=filename)
 
@@ -405,7 +405,7 @@ def test_export_import_sequence(no_data_value, data_type):
 
             assert_array_equal(tif_array.mask, no_data_arr)
 
-        import_task = ImportFromTiffTask(feature=feature, folder=tmp_dir_name, no_data_value=no_data_value)
+        import_task = ImportFromTiffTask(feature=feature, path=tmp_dir_name, no_data_value=no_data_value)
         new_eopatch = import_task.execute(filename=filename)
 
         assert_array_equal(eopatch[feature], new_eopatch[feature])


### PR DESCRIPTION
It's often not a folder, so it's very confusing...

Ellipsis as a default seemed like the best way to signal that this might still be required (using `None` would be odd).

- `TiffTask(feature, my_path)` works as before
- `TiffTask(feature)` will raise a `TypeError` that the parameter `path` is missing (similar to what would happen before)
- `TiffTask(feature, path=my_path)` works as intended
- `TiffTask(feature, folder=my_path)` also works as previously intended, but also warns the user