### PR TITLE
Enable github to trigger internal gitlab docker image build

### DIFF
--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -111,19 +111,3 @@ jobs:
           files: coverage.xml
           fail_ci_if_error: true
           verbose: false
-
-  mirror-and-integration-test-on-gitlab:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Mirror + trigger CI
-        uses: SvanBoxel/gitlab-mirror-and-ci-action@master
-        with:
-          args: "https://git.sinergise.com/eo/code/eo-learn/"
-        env:
-          GITLAB_HOSTNAME: "git.sinergise.com"
-          GITLAB_USERNAME: "github-action"
-          GITLAB_PASSWORD: ${{ secrets.GITLAB_PASSWORD }}
-          GITLAB_PROJECT_ID: "164"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_trigger.yml
+++ b/.github/workflows/ci_trigger.yml
@@ -12,6 +12,7 @@ on:
       - created # draft release
     # - published
 
+jobs:
   mirror-and-integration-test-on-gitlab:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_trigger.yml
+++ b/.github/workflows/ci_trigger.yml
@@ -1,0 +1,30 @@
+name: build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "master"
+      - "develop"
+  workflow_call:
+  release:
+    types:
+      - created # draft release
+    # - published
+
+  mirror-and-integration-test-on-gitlab:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Mirror + trigger CI
+        uses: SvanBoxel/gitlab-mirror-and-ci-action@master
+        with:
+          args: "https://git.sinergise.com/eo/code/eo-learn/"
+        env:
+          GITLAB_HOSTNAME: "git.sinergise.com"
+          GITLAB_USERNAME: "github-action"
+          GITLAB_PASSWORD: ${{ secrets.GITLAB_PASSWORD }}
+          GITLAB_PROJECT_ID: "164"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REF: $GITHUB_REF

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ build_docker_image:
       variables:
         - CUSTOM_RUN_TAG: auto # this will create images with the latest tag and the version tag
         - LAYER_NAME: dotai-eoo
-    when: manual
+    - when: manual
   trigger:
     project: teams/eor/dotai/infra
   allow_failure: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,7 @@ build_docker_image:
       when: always
       variables:
         - CUSTOM_RUN_TAG: auto # this will create images with the latest tag and the version tag
-        - LAYER_NAME: dotai-eoo
+        - LAYER_NAME: dotai-eo
     - when: manual
   trigger:
     project: teams/eor/dotai/infra

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@ image: python:3.9
 
 stages:
   - test
+  - build
 
 run_sh_integration_tests:
   stage: test
@@ -13,3 +14,17 @@ run_sh_integration_tests:
     - pip install .[DEV]
     - sentinelhub.config --sh_client_id "$SH_CLIENT_ID" --sh_client_secret "$SH_CLIENT_SECRET" > /dev/null # Gitlab can't mask SH_CLIENT_SECRET in logs
     - pytest -m sh_integration
+
+build_docker_image:
+  stage: build
+  needs: []
+  rules:
+    - if: $GITHUB_REF =~ /^refs\/tags\/ # run only on releases
+      when: always
+      variables:
+        - CUSTOM_RUN_TAG: auto # this will create images with the latest tag and the version tag
+        - LAYER_NAME: dotai-eoo
+    when: manual
+  trigger:
+    project: teams/eor/dotai/infra
+  allow_failure: true


### PR DESCRIPTION
Some context:

- removed gitlab mirror + CI job from the old actions file
- created a new actions file which is triggered in all old cases + on releases
  - there are multiple release types, more info [here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release)
- `$GITHUB_REF` env variable is sent to gitlab as well, which starts with `refs/tags/` for releases. this info is used so that docker build is not triggered on push/PR/scheduled events

We can test this by creating a draft release, and then we can also delete it if need be. When everything is tested, only the published release type should trigger the docker build in gitlab