### PR TITLE
Use trigger API to build internal docker

### DIFF
--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -110,3 +110,20 @@ jobs:
           files: coverage.xml
           fail_ci_if_error: true
           verbose: false
+
+  mirror-and-integration-test-on-gitlab:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Mirror + trigger CI
+        uses: SvanBoxel/gitlab-mirror-and-ci-action@master
+        with:
+          args: "https://git.sinergise.com/eo/code/eo-learn/"
+        env:
+          FOLLOW_TAGS: "true"
+          GITLAB_HOSTNAME: "git.sinergise.com"
+          GITLAB_USERNAME: "github-action"
+          GITLAB_PASSWORD: ${{ secrets.GITLAB_PASSWORD }}
+          GITLAB_PROJECT_ID: "164"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_trigger.yml
+++ b/.github/workflows/ci_trigger.yml
@@ -7,13 +7,13 @@ on:
 
 jobs:
   trigger:
-    image: alpine
-    script:
-      - apk add --no-cache curl
-      - >
-        curl -X POST --fail \
-          -F token=${{ secrets.GITLAB_PIPELINE_TRIGGER_TOKEN }} \
-          -F ref=main \
-          -F variables[CUSTOM_RUN_TAG]=auto \
-          -F variables[LAYER_NAME]=dotai-eo \
-          https://git.sinergise.com/api/v4/projects/1031/trigger/pipeline
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger API
+        run: >
+          curl -X POST --fail \
+            -F token=${{ secrets.GITLAB_PIPELINE_TRIGGER_TOKEN }} \
+            -F ref=main \
+            -F variables[CUSTOM_RUN_TAG]=auto \
+            -F variables[LAYER_NAME]=dotai-eo \
+            https://git.sinergise.com/api/v4/projects/1031/trigger/pipeline

--- a/.github/workflows/ci_trigger.yml
+++ b/.github/workflows/ci_trigger.yml
@@ -1,30 +1,19 @@
-name: mirror_and_trigger
+name: trigger
 
 on:
-  pull_request:
-  push:
-    branches:
-      - "master"
-      - "develop"
-  workflow_call:
   release:
     types:
       - published
 
 jobs:
-  mirror-and-integration-test-on-gitlab:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Mirror + trigger CI
-        uses: SvanBoxel/gitlab-mirror-and-ci-action@master
-        with:
-          args: "https://git.sinergise.com/eo/code/eo-learn/"
-        env:
-          FOLLOW_TAGS: "true"
-          GITLAB_HOSTNAME: "git.sinergise.com"
-          GITLAB_USERNAME: "github-action"
-          GITLAB_PASSWORD: ${{ secrets.GITLAB_PASSWORD }}
-          GITLAB_PROJECT_ID: "164"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  trigger:
+    image: alpine
+    script:
+      - apk add --no-cache curl
+      - >
+        curl -X POST --fail \
+          -F token=${{ secrets.GITLAB_PIPELINE_TRIGGER_TOKEN }} \
+          -F ref=main \
+          -F variables[CUSTOM_RUN_TAG]=auto \
+          -F variables[LAYER_NAME]=dotai-eo \
+          https://git.sinergise.com/api/v4/projects/1031/trigger/pipeline

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,6 @@ image: python:3.9
 
 stages:
   - test
-  - build
 
 run_sh_integration_tests:
   stage: test
@@ -14,17 +13,3 @@ run_sh_integration_tests:
     - pip install .[DEV]
     - sentinelhub.config --sh_client_id "$SH_CLIENT_ID" --sh_client_secret "$SH_CLIENT_SECRET" > /dev/null # Gitlab can't mask SH_CLIENT_SECRET in logs
     - pytest -m sh_integration
-
-build_docker_image:
-  stage: build
-  needs: []
-  rules:
-    - if: $CI_COMMIT_TAG # run only on releases
-      when: always
-      variables:
-        CUSTOM_RUN_TAG: auto # this will create images with the latest tag and the version tag
-        LAYER_NAME: dotai-eo
-    - when: manual
-  trigger:
-    project: eo/infra/docker
-  allow_failure: true


### PR DESCRIPTION
Instead of triggering gitlab CI/CD for docker builds via the mirroring action